### PR TITLE
Monitoring support for enterprise edition

### DIFF
--- a/scripts/helm/app/alerts.yaml
+++ b/scripts/helm/app/alerts.yaml
@@ -18,8 +18,8 @@ resources:
     cpu: 256m
     memory: 512Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 1m
+    memory: 1Mi
 
 env:
   ALERT_NOTIFICATION_STRING: http://chalice-openreplay.app.svc.cluster.local:8000/alerts/notifications

--- a/scripts/helm/app/assets.yaml
+++ b/scripts/helm/app/assets.yaml
@@ -18,8 +18,8 @@ resources:
     cpu: 256m
     memory: 512Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 1m
+    memory: 1Mi
 
 env:
   ASSETS_ORIGIN: /sessions-assets # TODO: full path (with the minio prefix)

--- a/scripts/helm/app/chalice.yaml
+++ b/scripts/helm/app/chalice.yaml
@@ -17,8 +17,8 @@ resources:
     cpu: 1000m
     memory: 1Gi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 1m
+    memory: 1Mi
 env:
   AWS_DEFAULT_REGION: us-east-1
   pg_host: postgresql.db.svc.cluster.local

--- a/scripts/helm/app/db.yaml
+++ b/scripts/helm/app/db.yaml
@@ -18,8 +18,8 @@ resources:
     cpu: 256m
     memory: 512Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 1m
+    memory: 1Mi
 
 env:
   POSTGRES_STRING: postgres://postgres:asayerPostgres@postgresql.db.svc.cluster.local:5432

--- a/scripts/helm/app/ender.yaml
+++ b/scripts/helm/app/ender.yaml
@@ -18,8 +18,8 @@ resources:
     cpu: 256m
     memory: 512Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 1m
+    memory: 1Mi
 
 env:
   REDIS_STRING: redis-master.db.svc.cluster.local:6379

--- a/scripts/helm/app/http.yaml
+++ b/scripts/helm/app/http.yaml
@@ -18,8 +18,8 @@ resources:
     cpu: 256m
     memory: 512Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 1m
+    memory: 1Mi
 
 env:
   ASSETS_ORIGIN: /sessions-assets # TODO: full path (with the minio prefix)

--- a/scripts/helm/app/integrations.yaml
+++ b/scripts/helm/app/integrations.yaml
@@ -18,8 +18,8 @@ resources:
     cpu: 512m
     memory: 1Gi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 1m
+    memory: 1Mi
 
 env:
   POSTGRES_STRING: postgres://postgres:asayerPostgres@postgresql.db.svc.cluster.local:5432

--- a/scripts/helm/app/sink.yaml
+++ b/scripts/helm/app/sink.yaml
@@ -18,8 +18,8 @@ resources:
     cpu: 512m
     memory: 512Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 1m
+    memory: 1Mi
 
 pvc:
   create: true

--- a/scripts/helm/app/storage.yaml
+++ b/scripts/helm/app/storage.yaml
@@ -18,8 +18,8 @@ resources:
     cpu: 512m
     memory: 512Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 1m
+    memory: 1Mi
 
 pvc:
   # PVC Created from filesink.yaml

--- a/scripts/helm/install.sh
+++ b/scripts/helm/install.sh
@@ -17,6 +17,7 @@ domain_name=`grep domain_name vars.yaml | grep -v "example" | cut -d " " -f2 | c
     }
 }
 
+sudo apt update
 which docker &> /dev/null || {
     echo "docker is not installed. Installing it..."
     user=`whoami`
@@ -38,7 +39,6 @@ export KUBECONFIG=~/.kube/config
 sed -i "s#kubeconfig.*#kubeconfig_path: ${HOME}/.kube/config#g" vars.yaml
 
 # Installing nfs common for NFS
-sudo apt update
 sudo apt install -y nfs-common
 
 bash -x kube-install.sh $@

--- a/scripts/helm/nginx-ingress/nginx-ingress/templates/configmap.yaml
+++ b/scripts/helm/nginx-ingress/nginx-ingress/templates/configmap.yaml
@@ -43,6 +43,15 @@ data:
       proxy_set_header Host $host;
       proxy_pass http://http-openreplay.app.svc.cluster.local;
     }
+    location /grafana {
+      set $target http://monitoring-grafana.monitoring.svc.cluster.local;
+      rewrite ^/grafana/(.*) /$1 break;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+      proxy_set_header Host $host;
+      proxy_pass $target;
+    }
     location /streaming/ {
       set $target http://ios-proxy-openreplay.app.svc.cluster.local;        rewrite ^/streaming/(.*) /$1 break;
       proxy_http_version 1.1;
@@ -107,6 +116,7 @@ data:
     ;
 
   sites.conf: |-
+    resolver {{ .Values.kubeDnsIP }};
     # Need real ip address for flags in replay.
     # Some LBs will forward real ips as x-forwarded-for
     # So making that as priority

--- a/scripts/helm/nginx-ingress/nginx-ingress/values.yaml
+++ b/scripts/helm/nginx-ingress/nginx-ingress/values.yaml
@@ -10,6 +10,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# DNS address of the kubernetes resolver
+kubeDnsIP: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/scripts/helm/roles/openreplay/tasks/install-apps.yaml
+++ b/scripts/helm/roles/openreplay/tasks/install-apps.yaml
@@ -20,7 +20,17 @@
     - "app/*.yaml"
   when: app_name|length == 0
   tags: apps
+
+- name: getting kube dns ip
+  shell: kubectl get service --namespace kube-system kube-dns -o jsonpath="{.spec.clusterIP}"
+  register: kube_dns_ip
+  tags: nginx
 - name: Installing Proxy
   shell: |
-    helm upgrade --install -n nginx-ingress nginx-ingress "./nginx-ingress/nginx-ingress" --create-namespace
+    helm upgrade --install -n nginx-ingress nginx-ingress "./nginx-ingress/nginx-ingress" --create-namespace --set kubeDnsIP="{{ kube_dns_ip.stdout }}"
   tags: nginx
+- name: Installing Monitoring
+  shell: |
+    helm upgrade --install -n monitoring monitoring "./monitoring/kube-prometheus-stack" -f "/tmp/monitoring.yaml" --create-namespace
+  tags: monitoring
+  when: enable_monitoring == "true"

--- a/scripts/helm/roles/openreplay/tasks/pre-check.yaml
+++ b/scripts/helm/roles/openreplay/tasks/pre-check.yaml
@@ -126,3 +126,19 @@
   when: enterprise_edition_license|length > 0
   register: enterprise_edition_license_check
   failed_when: enterprise_edition_license_check.json.data.valid != true
+- name: Generaing grafana password
+  block:
+    - name: Generating grafana password
+      set_fact:
+        grafana_password_generated: "{{ lookup('password', '/dev/null length=30 chars=ascii_letters') }}"
+    - name: Updating vars.yaml
+      lineinfile:
+        regexp: '^grafana_password'
+        line: 'grafana_password: "{{ grafana_password_generated }}"'
+        path: vars.yaml
+    - name: Generating grafana access key
+      set_fact:
+        grafana_password: "{{ grafana_password_generated }}"
+  when: grafana_password|length == 0
+  tags: 
+    - pre-check

--- a/scripts/helm/roles/openreplay/templates/monitoring.yaml
+++ b/scripts/helm/roles/openreplay/templates/monitoring.yaml
@@ -1,0 +1,6 @@
+fullnameOverride: "openreplay"
+grafana:
+  adminPassword: "{{ grafana_password }}"
+  env:
+    GF_SERVER_ROOT_URL: http://grafana.local.com/grafana
+

--- a/scripts/helm/vars.yaml
+++ b/scripts/helm/vars.yaml
@@ -46,13 +46,6 @@ nginx_ssl_key_file_path: ""
 # By default, a default key will be generated and will update the value here.
 jwt_secret_key: ""
 
-# Enable monitoring
-# If set, monitoring stack will be installed
-# including, prometheus, grafana and other core components,
-# to scrape the metrics. But this will cost, additional resources (cpu and memory).
-# Monitoring won't be installed on base installation.
-enable_monitoring: "false"
-
 # Random password for minio,
 # If not defined, will generate at runtime.
 # Use following command to generate password
@@ -63,3 +56,18 @@ minio_secret_key: ""
 # If you're using enterprise edition.
 # Insert the enterprise_edition_License key which you got.
 enterprise_edition_license: ""
+
+# Enable monitoring
+# If set, monitoring stack will be installed
+# including, prometheus, grafana and other core components,
+# to scrape the metrics. But this will cost, additional resources (cpu and memory).
+# Monitoring won't be installed on base installation.
+enable_monitoring: "false"
+# Password for grafana.
+# If password is not given, it'll be generated, and updated here.
+#
+# Use following command to generate password 
+# `openssl rand -base64 30`
+#
+# Username: admin
+grafana_password: ""


### PR DESCRIPTION
Kubernetes cluster and workloads will be monitored for the enterprise edition.

```
./install.sh -e <enterprise_key> --monitoring
```

Dashboards should be available in `https://domain_name/grafana`
Username: admin
Password can be specified else autogenerated. In case of later, the password will be updated in `vars.yaml`.