### PR TITLE
Feature: Upgrade script

### DIFF
--- a/scripts/helm/migration.yaml
+++ b/scripts/helm/migration.yaml
@@ -1,0 +1,47 @@
+---
+- hosts: localhost
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+  tasks:
+    - name: listing out migrtaions
+      debug:
+        var: migration_versions
+    - block:
+      - name: generating migration db paths
+        set_fact:
+          db_path: "{{dst_list | default([])}} + [ '{{ item[0] }}/*.sql' ]" 
+        with_items: "{{ migration_versions.split(',') }}"
+      - name: Migrate postgresql
+        shell: |
+          file="{{ item|basename }}"
+          kubectl exec -n db postgresql-postgresql-0 -- /bin/bash -c "rm -rf /tmp/$file"
+          kubectl cp -n db $file postgresql-postgresql-0:/tmp/
+          kubectl exec -n db postgresql-postgresql-0 -- /bin/bash -c "PGPASSWORD=asayerPostgres psql -U postgres -f /tmp/$file" &> "{{ playbook_dir }}"/postgresql_init.log
+        args:
+          chdir: db/init_dbs/postgresql
+        with_fileglob:
+          - "{{ db_path }}"
+      tags:
+        - postgresql
+    - block:
+      - name: generating migration db paths
+        set_fact:
+          db_path: "{{dst_list | default([])}} + [ '{{ item[0] }}/*.sql' ]" 
+        with_items: "{{ migration_versions.split(',') }}"
+      - name: Restoring clickhouse data
+        shell: |
+          file="{{ item|basename }}"
+          kubectl exec -n db clickhouse-0 -- /bin/bash -c "rm -rf /tmp/$file"
+          kubectl cp -n db $file clickhouse-0:/tmp/
+          kubectl exec -n db clickhouse-0 -- /bin/bash -c "clickhouse-client < /tmp/$file" 2>&1 | tee -a "{{ playbook_dir }}"/clickhouse_init.log
+        args:
+          chdir: db/init_dbs/clickhouse/create
+        with_fileglob:
+          - "{{ db_path }}"
+        retries: 3
+        delay: 60
+        register: result
+        until: result.rc == 0
+      tags:
+        - clickhouse
+      when: enterprise_edition_license|length > 0

--- a/scripts/helm/migration.yaml
+++ b/scripts/helm/migration.yaml
@@ -3,8 +3,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
   tasks:
-    - name: listing out migrtaions
-      debug:
+    - debug:
         var: migration_versions
     - block:
       - name: generating migration db paths

--- a/scripts/helm/roles/openreplay/tasks/main.yml
+++ b/scripts/helm/roles/openreplay/tasks/main.yml
@@ -29,6 +29,7 @@
     - templates/*.yaml
   tags:
     - app
+    - template
 
 # Installing and initializing dbs
 - import_tasks: install-dbs.yaml

--- a/scripts/helm/upgrade.sh
+++ b/scripts/helm/upgrade.sh
@@ -1,4 +1,4 @@
-/home/ubuntu/openreplay/scripts/helm/vars_template.yaml#!/bin/bash
+#!/bin/bash
 
 # upgrade.sh v1.10
 
@@ -31,7 +31,7 @@ migration(){
     # Ref: https://stackoverflow.com/questions/1527049/how-can-i-join-elements-of-an-array-in-bash
     # Creating an array of versions to migrate.
     db=$1
-    migration_versions=(`ls -l db/init_dbs/$db_path | grep -E ^d | awk -v number=${old_version} '$NF > number {print $NF}'`)
+    migration_versions=(`ls -l db/init_dbs/$db | grep -E ^d | awk -v number=${old_version} '$NF > number {print $NF}'`)
     # Can't pass the space seperated array to ansible for migration. So joining them with ,
     joined_migration_versions=$(IFS=, ; echo "${migration_versions[*]}")
 

--- a/scripts/helm/upgrade.sh
+++ b/scripts/helm/upgrade.sh
@@ -43,6 +43,10 @@ migration(){
         ansible-playbook -c local migration.yaml -e vars.yaml -e migration_versions=${joined_migration_versions} --tags $db
     }
 }
-echo -e "Migrating postgresql"
-migration postgresql
-echo -e "Migrating clickhouse"
+# As of now, we don't have any migrations to do, as there is no delta files,
+# We'll have to do full installation.
+#
+# echo -e "Migrating postgresql"
+# migration postgresql
+# Re installing everything.
+./install.sh

--- a/scripts/helm/upgrade.sh
+++ b/scripts/helm/upgrade.sh
@@ -1,0 +1,48 @@
+/home/ubuntu/openreplay/scripts/helm/vars_template.yaml#!/bin/bash
+
+# upgrade.sh v1.10
+
+cwd=$PWD
+vars_file_path=$1/scripts/helm/vars.yaml
+
+[[ $# == 1 ]] || {
+    echo -e "OpenReplay previous version path not given.\nUsage: bash $0 /path/to/previous_openreplay_code_path"
+    exit 1
+}
+[[ -f $1 ]] || {
+    echo -e "$1 doesn't exist. Please check the path and run\n \`bash upgrade.sh </path/to/previous/vars.yaml> \`"
+}
+which ansible &> /dev/null || {
+    echo "ansible not found. Are you sure, this is the same machine in which openreplay installed ?"
+    exit 100;
+}
+
+echo -e"Updating vars.yaml\n"
+{
+    ansible localhost -m template -a "src=vars_template.yaml dest=vars.yaml" -e @${vars_file_path}
+    ansible localhost -m debug -a "var=openreplay_version" -e @${vars_file_path}
+} || {
+    echo -e "variable file update failed. Update the value from old $vars_file_path to ./vars.yaml by hand"
+}
+
+old_version=`grep openreplay_version ${vars_file_path} | cut -d "v" -f 3 | cut -d '"' -f 1`
+enterprise_edition=`grep enterprise_edition_license ${vars_file_path} | cut -d ":" -f 2 | xargs`
+migration(){
+    # Ref: https://stackoverflow.com/questions/1527049/how-can-i-join-elements-of-an-array-in-bash
+    # Creating an array of versions to migrate.
+    db=$1
+    migration_versions=(`ls -l db/init_dbs/$db_path | grep -E ^d | awk -v number=${old_version} '$NF > number {print $NF}'`)
+    # Can't pass the space seperated array to ansible for migration. So joining them with ,
+    joined_migration_versions=$(IFS=, ; echo "${migration_versions[*]}")
+
+    [[ $joined_migration_versions == "" ]] ||
+    {
+        echo -e "Starting db migrations"
+        echo -e "Migrating versions $migration_versions"
+
+        ansible-playbook -c local migration.yaml -e vars.yaml -e migration_versions=${joined_migration_versions} --tags $db
+    }
+}
+echo -e "Migrating postgresql"
+migration postgresql
+echo -e "Migrating clickhouse"

--- a/scripts/helm/vars_template.yaml
+++ b/scripts/helm/vars_template.yaml
@@ -7,23 +7,23 @@
 # Give absolute file path.
 # Use following command to get the full file path
 # `readlink -f <file>`
-kubeconfig_path: ""
+kubeconfig_path: "{{ kubeconfig_path }}"
 
 # Using which domain name, you'll be accessing OpenReplay
 # for example: domain_name: "openreplay.mycompany.com"
 #
 # Without domain name session replay is not possible, because we've to
 # create signed url for s3 objects.
-domain_name: ""
+domain_name: "{{ domain_name }}"
 
 ###################
 ## Optional Fields.
 ###################
 
 # If you've private registry, please update the details here.
-docker_registry_username: ""
-docker_registry_password: ""
-docker_registry_url: "rg.fr-par.scw.cloud/foss"
+docker_registry_username: "{{ docker_registry_username }}"
+docker_registry_password: "{{ docker_registry_password }}"
+docker_registry_url: "{{ docker_registry_url }}"
 image_tag: "v1.1.0"
 openreplay_version: "v1.1.0"
 
@@ -39,31 +39,31 @@ openreplay_version: "v1.1.0"
 # By Default, we'll create a self signed certificate for nginx, and populate the values here.
 # Once you've proper domain name, and ssl certificate
 # Change the following variables accordingly.
-nginx_ssl_cert_file_path: ""
-nginx_ssl_key_file_path: ""
+nginx_ssl_cert_file_path: "{{ nginx_ssl_cert_file_path }}"
+nginx_ssl_key_file_path: "{{ nginx_ssl_key_file_path }}"
 
 # This key is used to create password for chalice api requests.
 # Create a strong password.
 # By default, a default key will be generated and will update the value here.
-jwt_secret_key: ""
+jwt_secret_key: "{{ jwt_secret_key }}"
 
 # Random password for minio,
 # If not defined, will generate at runtime.
 # Use following command to generate password
 # `openssl rand -base64 30`
-minio_access_key: ""
-minio_secret_key: ""
+minio_access_key: "{{ minio_access_key }}"
+minio_secret_key: "{{ minio_secret_key }}"
 
 # If you're using enterprise edition.
 # Insert the enterprise_edition_License key which you got.
-enterprise_edition_license: ""
+enterprise_edition_license: "{{ enterprise_edition_license }}"
 
 # Enable monitoring
 # If set, monitoring stack will be installed
 # including, prometheus, grafana and other core components,
 # to scrape the metrics. But this will cost, additional resources (cpu and memory).
 # Monitoring won't be installed on base installation.
-enable_monitoring: "false"
+enable_monitoring: "{{ enable_monitoring }}"
 # Password for grafana.
 # If password is not given, it'll be generated, and updated here.
 #
@@ -71,4 +71,4 @@ enable_monitoring: "false"
 # `openssl rand -base64 30`
 #
 # Username: admin
-grafana_password: ""
+grafana_password: "{{ grafana_password }}"


### PR DESCRIPTION
We've to do upgrade release on release rather than fresh installation.
This script will migrate the data and upgrade the applications.

HowTo:
- copy the current openreplay folder to `_version-number`.
  `cp -rf openreplay openreplay-v1.1.0`
- Clone the new OpenReplay version
  `git clone https://github.com/openreplay/openreplay -b v1.2.0`
- If you've done any manual changes, like application variable updation, change it in the new version folder.
  `vim openreplay/scripts/helm/apps/<app>.yaml`
- Upgrade
  ```
  cd openreplay/scripts/helm
  # bash upgrade.sh <old openreplay path>
  bash upgrade.sh /home/ubuntu/openreplay-v1.1.0
  ```

TODO:
- Preserve custom configurations from user, like postgres cpu changes
  As of now, the manual overrides to the app configs, will be reset. So if you have any custom overrides,
  prior to run the upgrade scripts, please make the changes in the new version code.