### PR TITLE
feat(install): override default db resource allocation

### DIFF
--- a/scripts/helm/roles/openreplay/templates/clickhouse.yaml
+++ b/scripts/helm/roles/openreplay/templates/clickhouse.yaml
@@ -1,3 +1,6 @@
+{% if db_resource_override.clickhouse %}{
+{{ db_resource_override.clickhouse|to_nice_yaml(indent=2) }}
+{% else %}
 resources:
   limits:
     cpu: {{ ( 100 * scale|float ) | int }}m
@@ -5,3 +8,4 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
+{% endif %}

--- a/scripts/helm/roles/openreplay/templates/postgresql.yaml
+++ b/scripts/helm/roles/openreplay/templates/postgresql.yaml
@@ -1,8 +1,11 @@
+{% if db_resource_override.postgresql %}
+{{ db_resource_override.postgresql|to_nice_yaml(indent=2) }}
+{% else %}
 resources:
   limits:
-    cpu: {{ ( 250 * scale|float ) | int }}m
+    cpu: {{ ( 250 * scale|float ) | int }/db_resource_override/db_resource_override//db_resource_override/db_resource_override/gm
     memory: {{ ( 512 * scale|float ) | int }}Mi
   requests:
     cpu: 250m
     memory: 256Mi
-
+{% endif %}

--- a/scripts/helm/roles/openreplay/templates/redis.yaml
+++ b/scripts/helm/roles/openreplay/templates/redis.yaml
@@ -1,7 +1,11 @@
 fullnameOverride: redis
+usePassword: false
 cluster:
   enabled: false
 redis:
+{% if db_resource_override.redis %}
+  {{ db_resource_override.redis|to_nice_yaml(indent=2) }}
+{% else %}
   resources:
     limits:
       cpu: {{ ( 100 * scale|float ) | int }}m
@@ -9,4 +13,4 @@ redis:
     requests:
       cpu: 100m
       memory: 128Mi
-usePassword: false
+{% endif %}

--- a/scripts/helm/vars.yaml
+++ b/scripts/helm/vars.yaml
@@ -72,3 +72,17 @@ enable_monitoring: "false"
 #
 # Username: admin
 grafana_password: ""
+
+## Advanced
+# If you need to override the default cpu/memory allocation of databases.
+db_resource_override:
+  postgresql: {}
+    # resources:
+    #   limits:
+    #     cpu: 1000m
+    #     memory: 1024Mi
+    #   requests:
+    #     cpu: 250m
+    #     memory: 256Mi
+  redis: {}
+  clickhouse: {}


### PR DESCRIPTION
If you need to override the default resource allocation or dbs, which is
indented to be for small machines, you can override the default
allocation here.

Ref: https://github.com/openreplay/openreplay/issues/64