### PR TITLE
Changed how the _config in AssistManager construct

### DIFF
--- a/frontend/app/player/MessageDistributor/managers/AssistManager.ts
+++ b/frontend/app/player/MessageDistributor/managers/AssistManager.ts
@@ -147,12 +147,13 @@ export default class AssistManager {
       return;
     }
     this.setStatus(ConnectionStatus.Connecting)
+    const urlObject = new URL(window.ENV.API_EDP)
     import('peerjs').then(({ default: Peer }) => {
       const _config = {
         // @ts-ignore
-        host: new URL(window.ENV.API_EDP).host,
+        host: urlObject.hostname,
         path: '/assist',
-        port:  location.protocol === 'https:' ? 443 : 80,
+        port: urlObject.port === "" ? location.protocol === 'https:' ? 443 : 80 : urlObject.port,
       }
 
       if (this.config) {


### PR DESCRIPTION
- Changed URL().host to URL().hostname so it wont attached port while the config set again another port and causing duplicate port when connect using peerjs.
- Changed the port in the config to check first if the URL() has port defined, then using the defined port first, so user can use custom port number for ws, when there is no custom port defined at the domainUrl, then it will then check https or not and append the correct port.