### PR TITLE
chore(helm): S3 endpoint validation

### DIFF
--- a/scripts/helmcharts/openreplay/charts/assets/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/assets/templates/deployment.yaml
@@ -56,13 +56,25 @@ spec:
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL
               value: '{{ .Values.global.kafka.kafkaUseSsl }}'
-            # Ref: https://stackoverflow.com/questions/53634583/go-template-split-string-by-delimiter
-            # We need https://bucketname.s3endpoint
+            # We need to check what is the object store endpoint.
+            # There can be 4 options
+            # 1. Using minio inside kube clster
+            # 2. Using minio managed external cluster, like aws minio offering
+            # 3. Using GCP or other object stores compatible with s3 apis
+            # 4. Using AWS itself.
+            # AWS uses bucketname.endpoint/object while others use endpoint/bucketname/object
             - name: ASSETS_ORIGIN
             {{- if eq .Values.global.s3.endpoint "http://minio.db.svc.cluster.local:9000" }}
+              # Local minio Installation
               value: 'https://{{ .Values.global.domainName }}/{{.Values.global.s3.assetsBucket}}'
-            {{- else }}
+            {{- else if contains "amazonaws.com" .Values.global.s3.endpoint }}
+              # AWS S3
+              # Ref: https://stackoverflow.com/questions/53634583/go-template-split-string-by-delimiter
+              # We need https://bucketname.s3endpoint
               value: {{ (split "://" .Values.global.s3.endpoint)._0 }}://{{.Values.global.s3.assetsBucket}}.{{ (split "://" .Values.global.s3.endpoint)._1 }}
+            {{- else }}
+              # S3 compatible storage
+              value: '{{ .Values.global.s3.endpoint }}/{{.Values.global.s3.assetsBucket}}'
             {{- end }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}

--- a/scripts/helmcharts/openreplay/charts/http/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/http/templates/deployment.yaml
@@ -54,11 +54,25 @@ spec:
               value: '{{ .Values.global.kafka.kafkaUseSsl }}'
             - name: POSTGRES_STRING
               value: 'postgres://{{ .Values.global.postgresql.postgresqlUser }}:{{ .Values.global.postgresql.postgresqlPassword }}@{{ .Values.global.postgresql.postgresqlHost }}:{{ .Values.global.postgresql.postgresqlPort }}/{{ .Values.global.postgresql.postgresqlDatabase }}'
+            # We need to check what is the object store endpoint.
+            # There can be 4 options
+            # 1. Using minio inside kube clster
+            # 2. Using minio managed external cluster, like aws minio offering
+            # 3. Using GCP or other object stores compatible with s3 apis
+            # 4. Using AWS itself.
+            # AWS uses bucketname.endpoint/object while others use endpoint/bucketname/object
             - name: ASSETS_ORIGIN
             {{- if eq .Values.global.s3.endpoint "http://minio.db.svc.cluster.local:9000" }}
+              # Local minio Installation
               value: 'https://{{ .Values.global.domainName }}/{{.Values.global.s3.assetsBucket}}'
-            {{- else }}
+            {{- else if contains "amazonaws.com" .Values.global.s3.endpoint }}
+              # AWS S3
+              # Ref: https://stackoverflow.com/questions/53634583/go-template-split-string-by-delimiter
+              # We need https://bucketname.s3endpoint
               value: {{ (split "://" .Values.global.s3.endpoint)._0 }}://{{.Values.global.s3.assetsBucket}}.{{ (split "://" .Values.global.s3.endpoint)._1 }}
+            {{- else }}
+              # S3 compatible storage
+              value: '{{ .Values.global.s3.endpoint }}/{{.Values.global.s3.assetsBucket}}'
             {{- end }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}


### PR DESCRIPTION
We need to check what is the object store endpoint.
There can be 4 options
1. Using minio inside kube clster
2. Using minio managed external cluster, like aws minio offering
3. Using GCP or other object stores compatible with s3 apis
4. Using AWS itself.
AWS uses bucketname.endpoint/object while others use endpoint/bucketname/object