### PR TITLE
Openreplay install, without kubernetes and related tools

### DIFF
--- a/scripts/helmcharts/init.sh
+++ b/scripts/helmcharts/init.sh
@@ -19,50 +19,57 @@ version="v1.6.0"
 usr=`whoami`
 
 # Installing k3s
-curl -sL https://get.k3s.io | sudo K3S_KUBECONFIG_MODE="644" INSTALL_K3S_VERSION='v1.22.8+k3s1' INSTALL_K3S_EXEC="--no-deploy=traefik" sh -
-[[ -d ~/.kube ]] || mkdir ~/.kube
-sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-sudo chmod 0644 ~/.kube/config
-sudo chown -R $usr ~/.kube/config
-
-
-## installing kubectl
-which kubectl &> /dev/null || {
-    info "kubectl not installed. Installing it..."
-    sudo curl -SsL https://dl.k8s.io/release/v1.20.0/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl ; sudo chmod +x /usr/local/bin/kubectl
+[[ x$SKIP_K8S_INSTALL == "xtrue" ]] && {
+    info "Skipping Kuberntes installation"
+} || {
+    curl -sL https://get.k3s.io | sudo K3S_KUBECONFIG_MODE="644" INSTALL_K3S_VERSION='v1.22.8+k3s1' INSTALL_K3S_EXEC="--no-deploy=traefik" sh -
+    [[ -d ~/.kube ]] || mkdir ~/.kube
+    sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+    sudo chmod 0644 ~/.kube/config
+    sudo chown -R $usr ~/.kube/config
 }
 
-## installing stern
-which stern &> /dev/null || {
-    info "stern not installed. installing..."
-    sudo curl -SsL https://github.com/derdanne/stern/releases/download/2.1.16/stern_linux_amd64 -o /usr/local/bin/stern ; sudo chmod +x /usr/local/bin/stern
+[[ x$SKIP_K8S_TOOLS == "xtrue" ]] && {
+    info "Skipping Kuberntes installation"
+} || {
+    ## installing kubectl
+    which kubectl &> /dev/null || {
+        info "kubectl not installed. Installing it..."
+        sudo curl -SsL https://dl.k8s.io/release/v1.20.0/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl ; sudo chmod +x /usr/local/bin/kubectl
+    }
+
+    ## installing stern
+    which stern &> /dev/null || {
+        info "stern not installed. installing..."
+        sudo curl -SsL https://github.com/derdanne/stern/releases/download/2.1.16/stern_linux_amd64 -o /usr/local/bin/stern ; sudo chmod +x /usr/local/bin/stern
+    }
+
+    ## installing k9s
+    which k9s &> /dev/null || {
+        info "k9s not installed. Installing it..."
+        sudo curl -SsL https://github.com/derailed/k9s/releases/download/v0.24.2/k9s_Linux_x86_64.tar.gz -o /tmp/k9s.tar.gz
+        cd /tmp
+        tar -xf k9s.tar.gz
+        sudo mv k9s /usr/local/bin/k9s
+        sudo chmod +x /usr/local/bin/k9s
+        cd -
+    }
+
+    ## installing helm
+    which helm &> /dev/null
+    if [[ $? -ne 0 ]]; then
+        info "helm not installed. Installing it..."
+        curl -ssl https://get.helm.sh/helm-v3.4.2-linux-amd64.tar.gz -o /tmp/helm.tar.gz
+        tar -xf /tmp/helm.tar.gz
+        chmod +x linux-amd64/helm
+        sudo cp linux-amd64/helm /usr/local/bin/helm
+        rm -rf linux-amd64/helm /tmp/helm.tar.gz
+    fi
 }
 
-## installing k9s
-which k9s &> /dev/null || {
-    info "k9s not installed. Installing it..."
-    sudo curl -SsL https://github.com/derailed/k9s/releases/download/v0.24.2/k9s_Linux_x86_64.tar.gz -o /tmp/k9s.tar.gz
-    cd /tmp
-    tar -xf k9s.tar.gz
-    sudo mv k9s /usr/local/bin/k9s
-    sudo chmod +x /usr/local/bin/k9s
-    cd -
-}
-
-## installing helm
-which helm &> /dev/null
-if [[ $? -ne 0 ]]; then
-    info "helm not installed. Installing it..."
-    curl -ssl https://get.helm.sh/helm-v3.4.2-linux-amd64.tar.gz -o /tmp/helm.tar.gz
-    tar -xf /tmp/helm.tar.gz
-    chmod +x linux-amd64/helm
-    sudo cp linux-amd64/helm /usr/local/bin/helm
-    rm -rf linux-amd64/helm /tmp/helm.tar.gz
-fi
-
-## Installing openssl
-sudo apt update &> /dev/null
-sudo apt install openssl -y &> /dev/null
+# ## Installing openssl
+# sudo apt update &> /dev/null
+# sudo apt install openssl -y &> /dev/null
 
 randomPass() {
     openssl rand -hex 10


### PR DESCRIPTION
This will help to install OpenReplay against the Kubernetes cluster using

`SKIP_K8S_INSTALL=true SKIP_K8S_TOOLS=true DOMAIN_NAME=openreplay.local bash init.sh`

> You should have a proper KUBECONFIG env variable set.