### PR TITLE
feat(backend/db): send metadata directly to db (removed from batches)

### DIFF
--- a/backend/pkg/db/postgres/messages-common.go
+++ b/backend/pkg/db/postgres/messages-common.go
@@ -155,12 +155,11 @@ func (conn *Conn) InsertUserAnonymousID(sessionID uint64, userAnonymousID string
 }
 
 func (conn *Conn) InsertMetadata(sessionID uint64, keyNo uint, value string) error {
-	return conn.batchQueue(sessionID, fmt.Sprintf(`
+	return conn.exec(fmt.Sprintf(`
 		UPDATE sessions SET  metadata_%v = $1
 		WHERE session_id = $2`, keyNo),
 		value, sessionID,
 	)
-	// conn.insertAutocompleteValue(sessionID, "METADATA", value)
 }
 
 func (conn *Conn) InsertIssueEvent(sessionID uint64, projectID uint32, e *messages.IssueEvent) error {

--- a/backend/services/db/messages.go
+++ b/backend/services/db/messages.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	. "openreplay/backend/pkg/messages"
 )
 
@@ -8,7 +9,10 @@ func insertMessage(sessionID uint64, msg Message) error {
 	switch m := msg.(type) {
 	// Common
 	case *Metadata:
-		return pg.InsertMetadata(sessionID, m)
+		if err := pg.InsertMetadata(sessionID, m); err != nil {
+			return fmt.Errorf("insert metadata err: %s", err)
+		}
+		return nil
 	case *IssueEvent:
 		return pg.InsertIssueEvent(sessionID, m)
 		//TODO: message adapter (transformer) (at the level of pkg/message) for types:


### PR DESCRIPTION
Hotfix for db component to store metadata directly to db, instead of collecting in batches.