### PR TITLE
Tracker pf fix

### DIFF
--- a/tracker/tracker/package.json
+++ b/tracker/tracker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openreplay/tracker",
   "description": "The OpenReplay tracker main package",
-  "version": "3.5.12",
+  "version": "3.5.13",
   "keywords": [
     "logging",
     "replay"

--- a/tracker/tracker/src/main/app/index.ts
+++ b/tracker/tracker/src/main/app/index.ts
@@ -163,7 +163,7 @@ export default class App {
       }
       // TODO: keep better tactics, discard others (look https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon)
       this.attachEventListener(window, 'beforeunload', alertWorker, false);
-      this.attachEventListener(document, 'mouseleave', alertWorker, false, false);
+      this.attachEventListener(document.body, 'mouseleave', alertWorker, false, false);
       this.attachEventListener(document, 'visibilitychange', alertWorker, false);
     } catch (e) { 
       this._debug("worker_start", e);

--- a/tracker/tracker/src/main/app/nodes.ts
+++ b/tracker/tracker/src/main/app/nodes.ts
@@ -1,4 +1,4 @@
-type NodeCallback = (node: Node) => void;
+type NodeCallback = (node: Node, isStart: boolean) => void;
 type ElementListener = [string, EventListener];
 
 export default class Nodes {
@@ -57,8 +57,8 @@ export default class Nodes {
     }
     return id;
   }
-  callNodeCallbacks(node: Node): void {
-    this.nodeCallbacks.forEach((cb) => cb(node));
+  callNodeCallbacks(node: Node, start: boolean): void {
+    this.nodeCallbacks.forEach((cb) => cb(node, start));
   }
   getID(node: Node): number | undefined {
     return (node as any)[this.node_id];

--- a/tracker/tracker/src/main/app/nodes.ts
+++ b/tracker/tracker/src/main/app/nodes.ts
@@ -57,8 +57,8 @@ export default class Nodes {
     }
     return id;
   }
-  callNodeCallbacks(node: Node, start: boolean): void {
-    this.nodeCallbacks.forEach((cb) => cb(node, start));
+  callNodeCallbacks(node: Node, isStart: boolean): void {
+    this.nodeCallbacks.forEach((cb) => cb(node, isStart));
   }
   getID(node: Node): number | undefined {
     return (node as any)[this.node_id];

--- a/tracker/tracker/src/main/app/observer/observer.ts
+++ b/tracker/tracker/src/main/app/observer/observer.ts
@@ -333,12 +333,12 @@ export default abstract class Observer {
     }
     return (this.commited[id] = this._commitNode(id, node));
   }
-  private commitNodes(): void {
+  private commitNodes(isStart: boolean = false): void {
     let node;
     this.recents.forEach((type, id) => {
       this.commitNode(id);
       if (type === RecentsType.New && (node = this.app.nodes.getNode(id))) {
-        this.app.nodes.callNodeCallbacks(node);
+        this.app.nodes.callNodeCallbacks(node, isStart)
       }
     })
     this.clear();
@@ -356,7 +356,7 @@ export default abstract class Observer {
     });
     this.bindTree(nodeToBind);
     beforeCommit(this.app.nodes.getID(node))
-    this.commitNodes();
+    this.commitNodes(true)
   }
 
   disconnect(): void {

--- a/tracker/tracker/src/main/modules/scroll.ts
+++ b/tracker/tracker/src/main/modules/scroll.ts
@@ -35,8 +35,8 @@ export default function (app: App): void {
     nodeScroll.clear();
   });
 
-  app.nodes.attachNodeCallback(node => {
-    if (isElementNode(node) && node.scrollLeft + node.scrollTop > 0) {
+  app.nodes.attachNodeCallback((node, isStart) => {
+    if (isStart && isElementNode(node) && node.scrollLeft + node.scrollTop > 0) {
       nodeScroll.set(node, [node.scrollLeft, node.scrollTop]);
     }
   })


### PR DESCRIPTION
* use of `.nodeType` property instead of `instanceof` when possible
* use of `.nodeName` property instead of `instanceof` for Elements 
* 2 previous also solve issue of non-function `instanceof` under different iframe contexts
* use map instead of array for storing recent nodes
* check node scrolls on start only
