### PR TITLE
fix(ui): Serve react index file for all page urls

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -3,6 +3,9 @@ server {
   listen [::]:8080 default_server;
   root /var/www/openreplay;
   index index.html;
+  rewrite ^((?!.(js|css|png|svg|jpg|woff|woff2)).)*$ /index.html break;
+  proxy_intercept_errors on; # see frontend://nginx.org/en/docs/frontend/ngx_frontend_proxy_module.html#proxy_intercept_errors
+  error_page 404 =200 /index.html;
   location / {
     try_files $uri $uri/ =404;
   }


### PR DESCRIPTION
Currently all urls except the index are not getting served the react files in order to view them after a page reload. This breaks "back " navigations and page refreshing.

Example:
/login 
![image](https://user-images.githubusercontent.com/7943856/181015604-2bbeddb9-6fac-4f04-a75f-e983bf637bb8.png)

