### PR TITLE
Add suppport for Redis credentials and TLS connections

### DIFF
--- a/scripts/helmcharts/openreplay/charts/assets/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/assets/templates/deployment.yaml
@@ -54,8 +54,22 @@ spec:
               value: '{{ .Values.global.s3.endpoint }}'
             - name: AWS_REGION
               value: '{{ .Values.global.s3.region }}'
+            {{- if .Values.global.redis.existingSecret }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.existingSecret }}
+                  key: redis-password
+            {{- else if .Values.global.redis.redisPassword }}
+            - name: REDIS_PASSWORD
+              value: {{ .Values.global.redis.redisPassword }}
+            {{- end}}
             - name: REDIS_STRING
-              value: '{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- else }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL

--- a/scripts/helmcharts/openreplay/charts/assets/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/assets/templates/deployment.yaml
@@ -54,22 +54,6 @@ spec:
               value: '{{ .Values.global.s3.endpoint }}'
             - name: AWS_REGION
               value: '{{ .Values.global.s3.region }}'
-            {{- if .Values.global.redis.existingSecret }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.redis.existingSecret }}
-                  key: redis-password
-            {{- else if .Values.global.redis.redisPassword }}
-            - name: REDIS_PASSWORD
-              value: {{ .Values.global.redis.redisPassword }}
-            {{- end}}
-            - name: REDIS_STRING
-              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- else }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL
@@ -94,6 +78,7 @@ spec:
               # S3 compatible storage
               value: '{{ .Values.global.s3.endpoint }}/{{.Values.global.s3.assetsBucket}}'
             {{- end }}
+            {{- include "openreplay.env.redis_string" .Values.global.redis | nindent 12 }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: '{{ $val }}'

--- a/scripts/helmcharts/openreplay/charts/assets/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/assets/templates/deployment.yaml
@@ -89,14 +89,16 @@ spec:
               containerPort: {{ $val }}
               protocol: TCP
             {{- end }}
-          {{- with .Values.persistence.mounts  }}
           volumeMounts:
+          {{- include "openreplay.volume.redis_ca_certificate.mount" .Values.global.redis | nindent 12 }}
+          {{- with .Values.persistence.mounts  }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.persistence.volumes  }}
       volumes:
+      {{- include "openreplay.volume.redis_ca_certificate" .Values.global.redis | nindent 8 }}
+      {{- with .Values.persistence.volumes  }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/scripts/helmcharts/openreplay/charts/db/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/db/templates/deployment.yaml
@@ -44,8 +44,22 @@ spec:
           env:
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
+            {{- if .Values.global.redis.existingSecret }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.existingSecret }}
+                  key: redis-password
+            {{- else if .Values.global.redis.redisPassword }}
+            - name: REDIS_PASSWORD
+              value: {{ .Values.global.redis.redisPassword }}
+            {{- end}}
             - name: REDIS_STRING
-              value: '{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- else }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL

--- a/scripts/helmcharts/openreplay/charts/db/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/db/templates/deployment.yaml
@@ -61,16 +61,18 @@ spec:
               containerPort: {{ $val }}
               protocol: TCP
             {{- end }}
-          {{- with .Values.persistence.mounts  }}
           volumeMounts:
+          {{- include "openreplay.volume.redis_ca_certificate.mount" .Values.global.redis | nindent 12 }}
+          {{- with .Values.persistence.mounts  }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.persistence.volumes  }}
       volumes:
+      {{- with .Values.persistence.volumes  }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "openreplay.volume.redis_ca_certificate" .Values.global.redis | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/scripts/helmcharts/openreplay/charts/db/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/db/templates/deployment.yaml
@@ -44,28 +44,13 @@ spec:
           env:
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
-            {{- if .Values.global.redis.existingSecret }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.redis.existingSecret }}
-                  key: redis-password
-            {{- else if .Values.global.redis.redisPassword }}
-            - name: REDIS_PASSWORD
-              value: {{ .Values.global.redis.redisPassword }}
-            {{- end}}
-            - name: REDIS_STRING
-              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- else }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL
               value: '{{ .Values.global.kafka.kafkaUseSsl }}'
             - name: POSTGRES_STRING
               value: 'postgres://{{ .Values.global.postgresql.postgresqlUser }}:{{ .Values.global.postgresql.postgresqlPassword }}@{{ .Values.global.postgresql.postgresqlHost }}:{{ .Values.global.postgresql.postgresqlPort }}/{{ .Values.global.postgresql.postgresqlDatabase }}'
+            {{- include "openreplay.env.redis_string" .Values.global.redis | nindent 12 }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: '{{ $val }}'

--- a/scripts/helmcharts/openreplay/charts/ender/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/ender/templates/deployment.yaml
@@ -44,8 +44,22 @@ spec:
           env:
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
+            {{- if .Values.global.redis.existingSecret }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.existingSecret }}
+                  key: redis-password
+            {{- else if .Values.global.redis.redisPassword }}
+            - name: REDIS_PASSWORD
+              value: {{ .Values.global.redis.redisPassword }}
+            {{- end}}
             - name: REDIS_STRING
-              value: '{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- else }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL

--- a/scripts/helmcharts/openreplay/charts/ender/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/ender/templates/deployment.yaml
@@ -61,16 +61,18 @@ spec:
               containerPort: {{ $val }}
               protocol: TCP
             {{- end }}
-          {{- with .Values.persistence.mounts  }}
           volumeMounts:
+          {{- include "openreplay.volume.redis_ca_certificate.mount" .Values.global.redis | nindent 12 }}
+          {{- with .Values.persistence.mounts  }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.persistence.volumes  }}
       volumes:
+      {{- with .Values.persistence.volumes  }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "openreplay.volume.redis_ca_certificate" .Values.global.redis | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/scripts/helmcharts/openreplay/charts/ender/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/ender/templates/deployment.yaml
@@ -44,28 +44,13 @@ spec:
           env:
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
-            {{- if .Values.global.redis.existingSecret }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.redis.existingSecret }}
-                  key: redis-password
-            {{- else if .Values.global.redis.redisPassword }}
-            - name: REDIS_PASSWORD
-              value: {{ .Values.global.redis.redisPassword }}
-            {{- end}}
-            - name: REDIS_STRING
-              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- else }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL
               value: '{{ .Values.global.kafka.kafkaUseSsl }}'
             - name: POSTGRES_STRING
               value: 'postgres://{{ .Values.global.postgresql.postgresqlUser }}:{{ .Values.global.postgresql.postgresqlPassword }}@{{ .Values.global.postgresql.postgresqlHost }}:{{ .Values.global.postgresql.postgresqlPort }}/{{ .Values.global.postgresql.postgresqlDatabase }}'
+            {{- include "openreplay.env.redis_string" .Values.global.redis | nindent 12 }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: '{{ $val }}'

--- a/scripts/helmcharts/openreplay/charts/frontend/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/templates/deployment.yaml
@@ -50,22 +50,6 @@ spec:
               value: '{{ .Values.global.s3.region }}'
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
-            {{- if .Values.global.redis.existingSecret }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.redis.existingSecret }}
-                  key: redis-password
-            {{- else if .Values.global.redis.redisPassword }}
-            - name: REDIS_PASSWORD
-              value: {{ .Values.global.redis.redisPassword }}
-            {{- end}}
-            - name: REDIS_STRING
-              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- else }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL
@@ -92,6 +76,7 @@ spec:
               # S3 compatible storage
               value: '{{ .Values.global.s3.endpoint }}/{{.Values.global.s3.assetsBucket}}'
             {{- end }}
+            {{- include "openreplay.env.redis_string" .Values.global.redis | nindent 12 }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: '{{ $val }}'

--- a/scripts/helmcharts/openreplay/charts/frontend/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/templates/deployment.yaml
@@ -50,8 +50,22 @@ spec:
               value: '{{ .Values.global.s3.region }}'
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
+            {{- if .Values.global.redis.existingSecret }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.existingSecret }}
+                  key: redis-password
+            {{- else if .Values.global.redis.redisPassword }}
+            - name: REDIS_PASSWORD
+              value: {{ .Values.global.redis.redisPassword }}
+            {{- end}}
             - name: REDIS_STRING
-              value: '{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- else }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL

--- a/scripts/helmcharts/openreplay/charts/frontend/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/templates/deployment.yaml
@@ -87,6 +87,11 @@ spec:
               containerPort: {{ $val }}
               protocol: TCP
             {{- end }}
+          volumeMounts:
+          {{- include "openreplay.volume.redis_ca_certificate.mount" .Values.global.redis | nindent 12 }}
+          {{- with .Values.persistence.mounts  }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -101,3 +106,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+      {{- with .Values.persistence.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "openreplay.volume.redis_ca_certificate" .Values.global.redis | nindent 8 }}

--- a/scripts/helmcharts/openreplay/charts/frontend/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/values.yaml
@@ -99,3 +99,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+persistence: {}

--- a/scripts/helmcharts/openreplay/charts/heuristics/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/heuristics/templates/deployment.yaml
@@ -44,26 +44,11 @@ spec:
           env:
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
-            {{- if .Values.global.redis.existingSecret }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.redis.existingSecret }}
-                  key: redis-password
-            {{- else if .Values.global.redis.redisPassword }}
-            - name: REDIS_PASSWORD
-              value: {{ .Values.global.redis.redisPassword }}
-            {{- end}}
-            - name: REDIS_STRING
-              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- else }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL
               value: '{{ .Values.global.kafka.kafkaUseSsl }}'
+            {{- include "openreplay.env.redis_string" .Values.global.redis | nindent 12 }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: '{{ $val }}'

--- a/scripts/helmcharts/openreplay/charts/heuristics/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/heuristics/templates/deployment.yaml
@@ -44,8 +44,22 @@ spec:
           env:
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
+            {{- if .Values.global.redis.existingSecret }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.existingSecret }}
+                  key: redis-password
+            {{- else if .Values.global.redis.redisPassword }}
+            - name: REDIS_PASSWORD
+              value: {{ .Values.global.redis.redisPassword }}
+            {{- end}}
             - name: REDIS_STRING
-              value: '{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- else }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL

--- a/scripts/helmcharts/openreplay/charts/heuristics/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/heuristics/templates/deployment.yaml
@@ -59,16 +59,18 @@ spec:
               containerPort: {{ $val }}
               protocol: TCP
             {{- end }}
-          {{- with .Values.persistence.mounts  }}
           volumeMounts:
+          {{- include "openreplay.volume.redis_ca_certificate.mount" .Values.global.redis | nindent 12 }}
+          {{- with .Values.persistence.mounts  }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.persistence.volumes  }}
       volumes:
+      {{- with .Values.persistence.volumes  }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- include "openreplay.volume.redis_ca_certificate" .Values.global.redis | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/scripts/helmcharts/openreplay/charts/http/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/http/templates/deployment.yaml
@@ -50,22 +50,6 @@ spec:
               value: '{{ .Values.global.s3.region }}'
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
-            {{- if .Values.global.redis.existingSecret }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.redis.existingSecret }}
-                  key: redis-password
-            {{- else if .Values.global.redis.redisPassword }}
-            - name: REDIS_PASSWORD
-              value: {{ .Values.global.redis.redisPassword }}
-            {{- end}}
-            - name: REDIS_STRING
-              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- else }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL
@@ -92,6 +76,7 @@ spec:
               # S3 compatible storage
               value: '{{ .Values.global.s3.endpoint }}/{{.Values.global.s3.assetsBucket}}'
             {{- end }}
+            {{- include "openreplay.env.redis_string" .Values.global.redis | nindent 12 }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: '{{ $val }}'

--- a/scripts/helmcharts/openreplay/charts/http/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/http/templates/deployment.yaml
@@ -50,8 +50,22 @@ spec:
               value: '{{ .Values.global.s3.region }}'
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
+            {{- if .Values.global.redis.existingSecret }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.existingSecret }}
+                  key: redis-password
+            {{- else if .Values.global.redis.redisPassword }}
+            - name: REDIS_PASSWORD
+              value: {{ .Values.global.redis.redisPassword }}
+            {{- end}}
             - name: REDIS_STRING
-              value: '{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- else }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL

--- a/scripts/helmcharts/openreplay/charts/http/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/http/templates/deployment.yaml
@@ -87,14 +87,16 @@ spec:
               containerPort: {{ $val }}
               protocol: TCP
             {{- end }}
-          {{- with .Values.persistence.mounts  }}
           volumeMounts:
+          {{- include "openreplay.volume.redis_ca_certificate.mount" .Values.global.redis | nindent 12 }}
+          {{- with .Values.persistence.mounts  }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.persistence.volumes  }}
       volumes:
+      {{- include "openreplay.volume.redis_ca_certificate" .Values.global.redis | nindent 8 }}
+      {{- with .Values.persistence.volumes  }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/scripts/helmcharts/openreplay/charts/integrations/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/integrations/templates/deployment.yaml
@@ -44,8 +44,22 @@ spec:
           env:
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
+            {{- if .Values.global.redis.existingSecret }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.existingSecret }}
+                  key: redis-password
+            {{- else if .Values.global.redis.redisPassword }}
+            - name: REDIS_PASSWORD
+              value: {{ .Values.global.redis.redisPassword }}
+            {{- end}}
             - name: REDIS_STRING
-              value: '{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- else }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL

--- a/scripts/helmcharts/openreplay/charts/integrations/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/integrations/templates/deployment.yaml
@@ -44,28 +44,13 @@ spec:
           env:
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
-            {{- if .Values.global.redis.existingSecret }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.redis.existingSecret }}
-                  key: redis-password
-            {{- else if .Values.global.redis.redisPassword }}
-            - name: REDIS_PASSWORD
-              value: {{ .Values.global.redis.redisPassword }}
-            {{- end}}
-            - name: REDIS_STRING
-              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- else }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL
               value: '{{ .Values.global.kafka.kafkaUseSsl }}'
             - name: POSTGRES_STRING
               value: 'postgres://{{ .Values.global.postgresql.postgresqlUser }}:{{ .Values.global.postgresql.postgresqlPassword }}@{{ .Values.global.postgresql.postgresqlHost }}:{{ .Values.global.postgresql.postgresqlPort }}/{{ .Values.global.postgresql.postgresqlDatabase }}'
+            {{- include "openreplay.env.redis_string" .Values.global.redis | nindent 12 }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: '{{ $val }}'

--- a/scripts/helmcharts/openreplay/charts/integrations/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/integrations/templates/deployment.yaml
@@ -61,14 +61,16 @@ spec:
               containerPort: {{ $val }}
               protocol: TCP
             {{- end }}
-          {{- with .Values.persistence.mounts  }}
           volumeMounts:
+          {{- include "openreplay.volume.redis_ca_certificate.mount" .Values.global.redis | nindent 12 }}
+          {{- with .Values.persistence.mounts  }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.persistence.volumes  }}
       volumes:
+      {{- include "openreplay.volume.redis_ca_certificate" .Values.global.redis | nindent 8 }}
+      {{- with .Values.persistence.volumes  }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/scripts/helmcharts/openreplay/charts/sink/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/sink/templates/deployment.yaml
@@ -44,22 +44,6 @@ spec:
           env:
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
-            {{- if .Values.global.redis.existingSecret }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.redis.existingSecret }}
-                  key: redis-password
-            {{- else if .Values.global.redis.redisPassword }}
-            - name: REDIS_PASSWORD
-              value: {{ .Values.global.redis.redisPassword }}
-            {{- end}}
-            - name: REDIS_STRING
-              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- else }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL
@@ -84,6 +68,7 @@ spec:
               # S3 compatible storage
               value: '{{ .Values.global.s3.endpoint }}/{{.Values.global.s3.assetsBucket}}'
             {{- end }}
+            {{- include "openreplay.env.redis_string" .Values.global.redis | nindent 12 }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: '{{ $val }}'

--- a/scripts/helmcharts/openreplay/charts/sink/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/sink/templates/deployment.yaml
@@ -44,8 +44,22 @@ spec:
           env:
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
+            {{- if .Values.global.redis.existingSecret }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.existingSecret }}
+                  key: redis-password
+            {{- else if .Values.global.redis.redisPassword }}
+            - name: REDIS_PASSWORD
+              value: {{ .Values.global.redis.redisPassword }}
+            {{- end}}
             - name: REDIS_STRING
-              value: '{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- else }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL

--- a/scripts/helmcharts/openreplay/charts/sink/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/sink/templates/deployment.yaml
@@ -84,6 +84,7 @@ spec:
           volumeMounts:
           - name: datadir
             mountPath: /mnt/efs
+          {{- include "openreplay.volume.redis_ca_certificate.mount" .Values.global.redis | nindent 10 }}
           {{- with .Values.persistence.mounts  }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -94,6 +95,7 @@ spec:
           # Ensure the file directory is created.
           path: {{ .Values.pvc.hostMountPath }}
           type: DirectoryOrCreate
+      {{- include "openreplay.volume.redis_ca_certificate" .Values.global.redis | nindent 6 }}
       {{- with .Values.persistence.volumes  }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
@@ -102,6 +104,7 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: {{ .Values.pvc.name }}
+      {{- include "openreplay.volume.redis_ca_certificate" .Values.global.redis | nindent 6 }}
       {{- with .Values.persistence.volumes  }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/scripts/helmcharts/openreplay/charts/storage/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/storage/templates/deployment.yaml
@@ -58,8 +58,22 @@ spec:
               value: {{ .Values.global.s3.recordingsBucket }}
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
+            {{- if .Values.global.redis.existingSecret }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.existingSecret }}
+                  key: redis-password
+            {{- else if .Values.global.redis.redisPassword }}
+            - name: REDIS_PASSWORD
+              value: {{ .Values.global.redis.redisPassword }}
+            {{- end}}
             - name: REDIS_STRING
-              value: '{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- else }}
+              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
+              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL

--- a/scripts/helmcharts/openreplay/charts/storage/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/storage/templates/deployment.yaml
@@ -78,6 +78,7 @@ spec:
           volumeMounts:
           - name: datadir
             mountPath: /mnt/efs
+          {{- include "openreplay.volume.redis_ca_certificate.mount" .Values.global.redis | nindent 10 }}
           {{- with .Values.persistence.mounts  }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -100,6 +101,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.pvc.name }}
       {{- end }}
+      {{- include "openreplay.volume.redis_ca_certificate" .Values.global.redis | nindent 6 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/scripts/helmcharts/openreplay/charts/storage/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/storage/templates/deployment.yaml
@@ -58,26 +58,11 @@ spec:
               value: {{ .Values.global.s3.recordingsBucket }}
             - name: LICENSE_KEY
               value: '{{ .Values.global.enterpriseEditionLicense }}'
-            {{- if .Values.global.redis.existingSecret }}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.redis.existingSecret }}
-                  key: redis-password
-            {{- else if .Values.global.redis.redisPassword }}
-            - name: REDIS_PASSWORD
-              value: {{ .Values.global.redis.redisPassword }}
-            {{- end}}
-            - name: REDIS_STRING
-              {{- if or .Values.global.redis.existingSecret .Values.global.redis.redisPassword }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisUsername }}:$(REDIS_PASSWORD)@{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- else }}
-              value: '{{ ternary "rediss" "redis" .Values.global.redis.tls.enabled }}://{{ .Values.global.redis.redisHost }}:{{ .Values.global.redis.redisPort }}'
-              {{- end}}
             - name: KAFKA_SERVERS
               value: '{{ .Values.global.kafka.kafkaHost }}:{{ .Values.global.kafka.kafkaPort }}'
             - name: KAFKA_USE_SSL
               value: '{{ .Values.global.kafka.kafkaUseSsl }}'
+            {{- include "openreplay.env.redis_string" .Values.global.redis | nindent 12 }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: '{{ $val }}'

--- a/scripts/helmcharts/openreplay/templates/_helpers.tpl
+++ b/scripts/helmcharts/openreplay/templates/_helpers.tpl
@@ -60,3 +60,26 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the environment configuration for REDIS_STRING
+*/}}
+{{- define "openreplay.env.redis_string" -}}
+{{- $scheme := (eq .tls.enabled true) | ternary "rediss" "redis" -}}
+{{- $auth := "" -}}
+{{- if or .existingSecret .redisPassword -}}
+  {{- $auth = printf "%s:$(REDIS_PASSWORD)@" (.redisUsername | default "") -}}
+{{- end -}}
+{{- if .existingSecret -}}
+- name: REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .existingSecret }}
+      key: redis-password
+{{- else if .redisPassword }}
+- name: REDIS_PASSWORD
+  value: {{ .redisPassword }}
+{{- end}}
+- name: REDIS_STRING
+  value: '{{ $scheme }}://{{ $auth }}{{ .redisHost }}:{{ .redisPort }}'
+{{- end }}

--- a/scripts/helmcharts/openreplay/templates/_helpers.tpl
+++ b/scripts/helmcharts/openreplay/templates/_helpers.tpl
@@ -83,3 +83,22 @@ Create the environment configuration for REDIS_STRING
 - name: REDIS_STRING
   value: '{{ $scheme }}://{{ $auth }}{{ .redisHost }}:{{ .redisPort }}'
 {{- end }}
+
+{{/*
+Create the volume mount config for redis TLS certificates
+*/}}
+{{- define "openreplay.volume.redis_ca_certificate" -}}
+{{- if and (.tls.enabled) (.tls.certificatesSecret) (.tls.certCAFilename) -}}
+- name: redis-ca-certificate
+  secret:
+    secretName: {{ .tls.certificatesSecret }}
+{{- end }}
+{{- end }}
+
+{{- define "openreplay.volume.redis_ca_certificate.mount" -}}
+{{- if and (.tls.enabled) (.tls.certificatesSecret) (.tls.certCAFilename) -}}
+- name: redis-ca-certificate
+  mountPath: /etc/ssl/certs/redis-ca-certificate.pem
+  subPath: {{ .tls.certCAFilename }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
By using `redis.ParseURL` in the `redisstream` package it is now possible to
- Supply login credentials for the redis instance
- Use an encrypted TLS connection by setting the scheme to `rediss://`

Support is added to the helmcharts for supplying redis password as a kubernetes secret and allowing TLS to be enabled.

- The underlying charts have support for an `existingSecret` ([1](https://github.com/openreplay/openreplay/blob/main/scripts/helmcharts/databases/charts/redis/README.md?plain=1#L79)) configuration variable which this PR re-uses for the configuration of the different openreplay components if the `existingSecret` key is set.
- Similarly the connections string scheme is set to `rediss://` when the [`tls.enabled`](https://github.com/openreplay/openreplay/blob/main/scripts/helmcharts/databases/charts/redis/README.md?plain=1#L159) flag is enabled.