### PR TITLE
fix(helm): build all components of non-ee build

### DIFF
--- a/api/build.sh
+++ b/api/build.sh
@@ -49,3 +49,5 @@ IMAGE_TAG=$IMAGE_TAG PUSH_IMAGE=$PUSH_IMAGE DOCKER_REPO=$DOCKER_REPO bash build_
   cp ../ee/api/build_crons.sh .
   IMAGE_TAG=$IMAGE_TAG PUSH_IMAGE=$PUSH_IMAGE DOCKER_REPO=$DOCKER_REPO bash build_crons.sh $1
 }
+
+true


### PR DESCRIPTION
- The exit code of the `if` statement at the end of the script will be used as the exit code for the entire script because it is the last command.
- `deploy_build.sh` in `scripts/helm` has `set -e` set causing the build to halt whenever a command fails.

These two things combined cause the `deploy_build.sh` to not fully complete and only build the `chalice` and the `alerts` docker image.