### PR TITLE
Adding better helm configurability 

### DIFF
--- a/scripts/helmcharts/openreplay/Chart.yaml
+++ b/scripts/helmcharts/openreplay/Chart.yaml
@@ -33,3 +33,7 @@ dependencies:
     version: "0.3.1"
     repository: "file://charts/quickwit"
     condition: quickwit.enabled
+  - name: alerts
+    repository: "file://charts/alerts"
+    version: "0.1.0"
+    condition: alerts.enabled

--- a/scripts/helmcharts/openreplay/Chart.yaml
+++ b/scripts/helmcharts/openreplay/Chart.yaml
@@ -33,7 +33,3 @@ dependencies:
     version: "0.3.1"
     repository: "file://charts/quickwit"
     condition: quickwit.enabled
-  - name: alerts
-    repository: "file://charts/alerts"
-    version: "0.1.0"
-    condition: alerts.enabled

--- a/scripts/helmcharts/openreplay/files/clickhouse.sh
+++ b/scripts/helmcharts/openreplay/files/clickhouse.sh
@@ -11,7 +11,7 @@ function migrate() {
         echo "Migrating clickhouse version $version"
         # For now, we can ignore the clickhouse db inject errors.
         # TODO: Better error handling in script
-        clickhouse-client -h clickhouse-openreplay-clickhouse.db.svc.cluster.local --port 9000 --multiquery < ${clickhousedir}/${version}/${version}.sql || true
+        clickhouse-client -h "$CLICKHOUSE_HOST" --port "$CLICKHOUSE_PORT" --multiquery < ${clickhousedir}/${version}/${version}.sql || true
     done
 }
 
@@ -19,7 +19,7 @@ function init() {
     echo "Initializing clickhouse"
     for file in `ls ${clickhousedir}/create/*.sql`; do
         echo "Injecting $file"
-        clickhouse-client -h clickhouse-openreplay-clickhouse.db.svc.cluster.local --port 9000 --multiquery < $file || true
+        clickhouse-client -h "$CLICKHOUSE_HOST" --port "$CLICKHOUSE_PORT" --multiquery < $file || true
     done
 }
 

--- a/scripts/helmcharts/openreplay/files/minio.sh
+++ b/scripts/helmcharts/openreplay/files/minio.sh
@@ -7,7 +7,7 @@ cd /tmp
 
 buckets=("mobs" "sessions-assets" "static" "sourcemaps" "sessions-mobile-assets" "quickwit")
 
-mc alias set minio "http://$MINIO_HOST:$MINIO_PORT" $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+mc alias set minio "http://$MINIO_HOST" $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
 
 function init() {
 echo "Initializing minio"

--- a/scripts/helmcharts/openreplay/files/minio.sh
+++ b/scripts/helmcharts/openreplay/files/minio.sh
@@ -7,7 +7,7 @@ cd /tmp
 
 buckets=("mobs" "sessions-assets" "static" "sourcemaps" "sessions-mobile-assets" "quickwit")
 
-mc alias set minio http://minio.db.svc.cluster.local:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+mc alias set minio "http://$MINIO_HOST:$MINIO_PORT" $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
 
 function init() {
 echo "Initializing minio"

--- a/scripts/helmcharts/openreplay/templates/job.yaml
+++ b/scripts/helmcharts/openreplay/templates/job.yaml
@@ -135,7 +135,6 @@ spec:
           mountPath: /opt/migrations/
       {{- end}}
       {{- if .Values.global.enterpriseEditionLicense }}
-      {{- if .Values.clickhouse.enabled }}
       # Enterprise migration
       - name: clickhouse
         image: yandex/clickhouse-client:21.9.4.35
@@ -147,9 +146,9 @@ spec:
           - name: CHART_APP_VERSION
             value: "{{ .Chart.AppVersion }}"
           - name: CLICKHOUSE_HOST
-            value: "{{ .Values.clickhouse.global.clickhouse.clickhouseHost }}"
+            value: "{{ .Values.clickhouse.clickhouseHost }}"
           - name: CLICKHOUSE_PORT
-            value: "{{ .Values.clickhouse.global.clickhouse.clickhousePort }}"
+            value: "{{ .Values.clickhouse.clickhousePort }}"
         command: 
         - /bin/bash
         - /opt/migrations/dbops.sh
@@ -160,8 +159,6 @@ spec:
           mountPath: /opt/openreplay
         - name: dbmigrationscript
           mountPath: /opt/migrations/
-      {{- end}}
-      {{- if .Values.kafka.enabled }}
       - name: kafka
         image: bitnami/kafka:2.6.0-debian-10-r30
         env:
@@ -189,7 +186,6 @@ spec:
           mountPath: /opt/openreplay
         - name: dbmigrationscript
           mountPath: /opt/migrations/
-        {{- end}}
         {{- end}}
       volumes:
       - name: dbmigrationscript

--- a/scripts/helmcharts/openreplay/templates/job.yaml
+++ b/scripts/helmcharts/openreplay/templates/job.yaml
@@ -119,6 +119,10 @@ spec:
             value: "{{ .Values.minio.global.minio.accessKey }}"
           - name: MINIO_SECRET_KEY
             value: "{{ .Values.minio.global.minio.secretKey }}"
+          - name: MINIO_HOST
+            value: "{{ .Values.minio.global.minio.minioHost }}"
+          - name: MINIO_POST
+            value: "{{ .Values.minio.global.minio.minioPort }}"
         command: 
         - /bin/bash
         - /opt/migrations/dbops.sh
@@ -131,6 +135,7 @@ spec:
           mountPath: /opt/migrations/
       {{- end}}
       {{- if .Values.global.enterpriseEditionLicense }}
+      {{- if .Values.clickhouse.enabled }}
       # Enterprise migration
       - name: clickhouse
         image: yandex/clickhouse-client:21.9.4.35
@@ -141,6 +146,10 @@ spec:
             value: "{{ .Values.fromVersion }}"
           - name: CHART_APP_VERSION
             value: "{{ .Chart.AppVersion }}"
+          - name: CLICKHOUSE_HOST
+            value: "{{ .Values.clickhouse.global.clickhouse.clickhouseHost }}"
+          - name: CLICKHOUSE_PORT
+            value: "{{ .Values.clickhouse.global.clickhouse.clickhousePort }}"
         command: 
         - /bin/bash
         - /opt/migrations/dbops.sh
@@ -151,6 +160,8 @@ spec:
           mountPath: /opt/openreplay
         - name: dbmigrationscript
           mountPath: /opt/migrations/
+      {{- end}}
+      {{- if .Values.kafka.enabled }}
       - name: kafka
         image: bitnami/kafka:2.6.0-debian-10-r30
         env:
@@ -178,6 +189,7 @@ spec:
           mountPath: /opt/openreplay
         - name: dbmigrationscript
           mountPath: /opt/migrations/
+        {{- end}}
         {{- end}}
       volumes:
       - name: dbmigrationscript

--- a/scripts/helmcharts/openreplay/templates/job.yaml
+++ b/scripts/helmcharts/openreplay/templates/job.yaml
@@ -103,7 +103,7 @@ spec:
           mountPath: /opt/openreplay
         - name: dbmigrationscript
           mountPath: /opt/migrations/
-      {{- if eq .Values.global.s3.endpoint "http://minio.db.svc.cluster.local:9000" }}
+      {{- if contains "svc.cluster.local" .Values.global.s3.endpoint }}
       - name: minio
         image: bitnami/minio:2020.10.9-debian-10-r6
         env:
@@ -120,9 +120,7 @@ spec:
           - name: MINIO_SECRET_KEY
             value: "{{ .Values.minio.global.minio.secretKey }}"
           - name: MINIO_HOST
-            value: "{{ .Values.minio.global.minio.minioHost }}"
-          - name: MINIO_POST
-            value: "{{ .Values.minio.global.minio.minioPort }}"
+            value: "{{ .Values.global.s3.endpoint }}"
         command: 
         - /bin/bash
         - /opt/migrations/dbops.sh

--- a/scripts/helmcharts/vars.yaml
+++ b/scripts/helmcharts/vars.yaml
@@ -25,6 +25,9 @@ clickhouse:
       clickhouseHost: clickhouse-openreplay-clickhouse.db.svc.cluster.local
       clickhousePort: 9000
 
+alerts:
+  enabled: false
+
 quickwit: &quickwit
   # For enterpriseEdition
   enabled: false

--- a/scripts/helmcharts/vars.yaml
+++ b/scripts/helmcharts/vars.yaml
@@ -20,16 +20,14 @@ postgresql: &postgres
 clickhouse:
   # For enterpriseEdition
   enabled: false
-  global:
-    clickhouse:
-      clickhouseHost: clickhouse-openreplay-clickhouse.db.svc.cluster.local
-      clickhousePort: 9000
+  clickhouseHost: clickhouse-openreplay-clickhouse.db.svc.cluster.local
+  clickhousePort: 9000
 
 alerts:
   enabled: false
 
-quickwit: &quickwit
-  # For enterpriseEdition
+# For enterpriseEdition
+quickwit: &quickwit 
   enabled: false
 
 kafka: &kafka
@@ -51,8 +49,7 @@ kafka: &kafka
     # - name: KAFKA_CFG_MESSAGE_MAX_BYTES
     #   value: "3000000"
 
-
-redis: &redis
+redis: &redis 
   # enabled: false
   redisHost: "redis-master.db.svc.cluster.local"
   redisPort: "6379"
@@ -67,16 +64,14 @@ minio:
       # `openssl rand -hex 20`
       accessKey: "changeMeMinioAccessKey"
       secretKey: "changeMeMinioPassword"
-      minioHost: minio.db.svc.cluster.local
-      minioPort: 9000
 
 ingress-nginx: &ingress-nginx
   controller:
     ingressClassResource:
       # -- Name of the ingressClass
       name: openreplay
-  # -- For backwards compatibility with ingress.class annotation, use ingressClass.
-  # Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation
+    # -- For backwards compatibility with ingress.class annotation, use ingressClass.
+    # Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation
     ingressClass: openreplay
     service:
       externalTrafficPolicy: "Local"
@@ -124,15 +119,15 @@ global:
     accessKey: "changeMeMinioAccessKey"
     secretKey: "changeMeMinioPassword"
   email:
-    emailHost: ''
-    emailPort: '587'
-    emailUser: ''
-    emailPassword: ''
-    emailUseTls: 'true'
-    emailUseSsl: 'false'
-    emailSslKey: ''
-    emailSslCert: ''
-    emailFrom: 'OpenReplay<do-not-reply@openreplay.com>'
+    emailHost: ""
+    emailPort: "587"
+    emailUser: ""
+    emailPassword: ""
+    emailUseTls: "true"
+    emailUseSsl: "false"
+    emailSslKey: ""
+    emailSslCert: ""
+    emailFrom: "OpenReplay<do-not-reply@openreplay.com>"
 
   enterpriseEditionLicense: ""
   domainName: ""
@@ -160,7 +155,6 @@ chalice:
     # idp_sls_url: ''
     # idp_name: ''
     # idp_tenantKey: ''
-
 # If you want to override something
 # chartname:
 #   filedFrom chart/Values.yaml:

--- a/scripts/helmcharts/vars.yaml
+++ b/scripts/helmcharts/vars.yaml
@@ -20,6 +20,10 @@ postgresql: &postgres
 clickhouse:
   # For enterpriseEdition
   enabled: false
+  global:
+    clickhouse:
+      clickhouseHost: clickhouse-openreplay-clickhouse.db.svc.cluster.local
+      clickhousePort: 9000
 
 quickwit: &quickwit
   # For enterpriseEdition
@@ -60,6 +64,8 @@ minio:
       # `openssl rand -hex 20`
       accessKey: "changeMeMinioAccessKey"
       secretKey: "changeMeMinioPassword"
+      minioHost: minio.db.svc.cluster.local
+      minioPort: 9000
 
 ingress-nginx: &ingress-nginx
   controller:

--- a/scripts/helmcharts/vars_template.yaml
+++ b/scripts/helmcharts/vars_template.yaml
@@ -16,7 +16,11 @@ postgresql: &postgres
   #     memory: 3000Mi
   #     cpu: 2
 
-clickhouse: {}
+clickhouse:
+  global:
+    clickhouse:
+      clickhouseHost: "{{ clickhouse_host }}"
+      clickhousePort: "{{ clickhouse_port }}"
   # For enterpriseEdition
   # enabled: true
 
@@ -41,6 +45,8 @@ minio:
       # `openssl rand -hex 20`
       accessKey: "{{ minio_access_key }}"
       secretKey: "{{ minio_secret_key }}"
+      minioHost: "{{ minio_host }}"
+      minioPort: "{{ minio_port }}"
 
 # Application specific variables
 global:


### PR DESCRIPTION
This PR would address some issues regarding the configuration of the helm deployments in kubernetes.

Regarding the [clickhouse script](https://github.com/openreplay/openreplay/pull/757/files#diff-450bc4c04bf64267be4935d30f40064b74cb5d9b10115e80ae9bcddea25e2d66) it would run into the same issue as with the minio when enabled and not deployed in the "db" namespace.

The helm [templating](https://github.com/openreplay/openreplay/pull/757/files#diff-0c0dacc62a872f133f8fb332d2f432d82f4ca5bb6dbc84dd6ea4e4bbb89a5eab), the [vars](https://github.com/openreplay/openreplay/pull/757/files#diff-a19e7fafb5abe676c09245f3b29b953c29aee57b385148c6dd1a572864f77559) and the [vars_template](https://github.com/openreplay/openreplay/pull/757/files#diff-add7d662e1d7640ce976d73a3832ee9af09969c3cf7cd93254775c65f3b6edc5) make sure these values are properly set for the [minio](https://github.com/openreplay/openreplay/pull/757/files#diff-9953b1a1529ef8d4ab1b759e11395e5be7ddfb7f0ca41298578863740f33891a) and [clickhouse](https://github.com/openreplay/openreplay/pull/757/files#diff-450bc4c04bf64267be4935d30f40064b74cb5d9b10115e80ae9bcddea25e2d66) changes.

The above changes were done to look the same as how we can configure the other resources.

Additionally I believe the [alerts](https://github.com/openreplay/openreplay/pull/757/files#diff-453163620f207b0da535c6c32fbb1a2f2fc14b9d18c705340fbf15b7065425db) subchart was the only one that could be disabled/enabled like the other subcharts.