### PR TITLE
change(tracker): Ensure that the remote control session is ended in the case that the tracker instance is cleaned

### DIFF
--- a/tracker/tracker-assist/src/Assist.ts
+++ b/tracker/tracker-assist/src/Assist.ts
@@ -1,4 +1,3 @@
-import { remoteControl } from './icons';
 /* eslint-disable @typescript-eslint/no-empty-function */
 import type { Socket, } from 'socket.io-client'
 import { connect, } from 'socket.io-client'


### PR DESCRIPTION
If the client abruptly ends the tracker instance, the Assist session is not cleaned up properly, which leaves the Assist agent's cursor on the screen.