### PR TITLE
Fix verbose CLI option

### DIFF
--- a/sourcemap-uploader/cli.js
+++ b/sourcemap-uploader/cli.js
@@ -55,10 +55,10 @@ dir.addArgument(['-u', '--js-dir-url'], {
 
 // TODO: exclude in dir
 
-const { command, api_key, project_key, server, verbose, ...args } =
+const { command, api_key, project_key, server, logs, ...args } =
   parser.parseArgs();
 
-global._VERBOSE = !!verbose;
+global._VERBOSE = !!logs;
 
 (command === 'file'
   ? uploadFile(


### PR DESCRIPTION
The arg was changed to be `--logs` instead of `--verbose`, but this change is needed to actually use the value and print verbose output with `-l`.