### PR TITLE
Added optional chaining for deprecated navigationStart

### DIFF
--- a/tracker/tracker-axios/src/index.ts
+++ b/tracker/tracker-axios/src/index.ts
@@ -156,7 +156,7 @@ export default function(opts: Partial<Options> = {}) {
           getStj(reqResData.request),
           getStj(reqResData.response),
           status,
-          startTime + performance.timing.navigationStart,
+          startTime + performance?.timing?.navigationStart,
           duration,
         ),
       );

--- a/tracker/tracker-fetch/src/index.ts
+++ b/tracker/tracker-fetch/src/index.ts
@@ -159,7 +159,7 @@ export default function(opts: Partial<Options> = {}): (app: App | null) => Windo
               getStj(reqResInfo.request),
               getStj(reqResInfo.response),
               r.status,
-              startTime + performance.timing.navigationStart,
+              startTime + performance?.timing?.navigationStart,
               duration,
             ),
           ) 

--- a/tracker/tracker/src/main/modules/timing.ts
+++ b/tracker/tracker/src/main/modules/timing.ts
@@ -110,7 +110,7 @@ export default function (app: App, opts: Partial<Options>): void {
     }
     app.send(
       ResourceTiming(
-        entry.startTime + performance.timing.navigationStart,
+        entry.startTime + performance?.timing?.navigationStart,
         entry.duration,
         entry.responseStart && entry.startTime ? entry.responseStart - entry.startTime : 0,
         entry.transferSize > entry.encodedBodySize ? entry.transferSize - entry.encodedBodySize : 0,
@@ -231,8 +231,8 @@ export default function (app: App, opts: Partial<Options>): void {
             ? Math.max(
                 interactiveWindowStartTime,
                 firstContentfulPaint,
-                performance.timing.domContentLoadedEventEnd - performance.timing.navigationStart ||
-                  0,
+                performance?.timing?.domContentLoadedEventEnd -
+                  performance?.timing?.navigationStart || 0,
               )
             : 0
         app.send(

--- a/tracker/tracker/src/main/modules/viewport.ts
+++ b/tracker/tracker/src/main/modules/viewport.ts
@@ -3,7 +3,7 @@ import { SetPageLocation, SetViewportSize, SetPageVisibility } from '../app/mess
 
 export default function (app: App): void {
   let url: string, width: number, height: number
-  let navigationStart = performance.timing.navigationStart
+  let navigationStart = performance?.timing?.navigationStart
 
   const sendSetPageLocation = app.safe(() => {
     const { URL } = document

--- a/tracker/tracker/src/main/utils.ts
+++ b/tracker/tracker/src/main/utils.ts
@@ -7,7 +7,7 @@ export const IS_FIREFOX = IN_BROWSER && navigator.userAgent.match(/firefox|fxios
 export const MAX_STR_LEN = 1e5
 
 const navigationStart: number | false =
-  IN_BROWSER && (performance.timing.navigationStart || performance.timeOrigin)
+  IN_BROWSER && (performance?.timing?.navigationStart || performance.timeOrigin)
 // performance.now() is buggy in some browsers
 export const now: () => number =
   IN_BROWSER && performance.now() && navigationStart


### PR DESCRIPTION
I had a problem with Jest. Tests failed with this error. Fixed the problem with an optional operator. @sylenien can you check this? :)
![image](https://user-images.githubusercontent.com/48125109/203547629-f577347d-1749-4cf0-97b8-e07d7518108d.png)
