### PR TITLE
feat(tracker): add option to jump to current time in `getSessionURL`

### DIFF
--- a/tracker/tracker/src/main/app/index.ts
+++ b/tracker/tracker/src/main/app/index.ts
@@ -312,8 +312,8 @@ export default class App {
     return this.session.getInfo().sessionID || undefined
   }
 
-  getSessionURL(): string | undefined {
-    const { projectID, sessionID } = this.session.getInfo()
+  getSessionURL(options?: { withCurrentTime?: boolean }): string | undefined {
+    const { projectID, sessionID, timestamp } = this.session.getInfo()
     if (!projectID || !sessionID) {
       this.debug.error('OpenReplay error: Unable to build session URL')
       return undefined
@@ -323,7 +323,14 @@ export default class App {
 
     const projectPath = isSaas ? ingest.replace('api', 'app') : ingest
 
-    return projectPath.replace(/ingest$/, `${projectID}/session/${sessionID}`)
+    const url = projectPath.replace(/ingest$/, `${projectID}/session/${sessionID}`)
+
+    if (options?.withCurrentTime) {
+      const jumpTo = now() - timestamp
+      return `${url}?jumpto=${jumpTo}`
+    }
+
+    return url
   }
 
   getHost(): string {

--- a/tracker/tracker/src/main/index.ts
+++ b/tracker/tracker/src/main/index.ts
@@ -212,11 +212,11 @@ export default class API {
     return this.getSessionID()
   }
 
-  getSessionURL(): string | undefined {
+  getSessionURL(options?: { withCurrentTime?: boolean }): string | undefined {
     if (this.app === null) {
       return undefined
     }
-    return this.app.getSessionURL()
+    return this.app.getSessionURL(options)
   }
 
   setUserID(id: string): void {


### PR DESCRIPTION
This PR is the implementation of this Q&A https://github.com/openreplay/openreplay/discussions/862

Added optional option to `getSessionURL`:
```ts
getSessionURL(options?: { jumpToCurrentTime?: boolean })
```
Example of the result:
https://app.openreplay.com/1234/session/123456789?jumpto=4432