### PR TITLE
change(tracker): webworker crash fix due to uninitialised sender/writer

### DIFF
--- a/tracker/tracker/src/webworker/index.ts
+++ b/tracker/tracker/src/webworker/index.ts
@@ -136,13 +136,15 @@ self.onmessage = ({ data }: any): any => {
 
   if (data.type === 'auth') {
     if (!sender) {
-      throw new Error('WebWorker: sender not initialised. Received auth.')
+      console.debug('WebWorker: sender not initialised. Received auth.')
     }
     if (!writer) {
-      throw new Error('WebWorker: writer not initialised. Received auth.')
+      console.debug('WebWorker: writer not initialised. Received auth.')
     }
-    sender.authorise(data.token)
-    data.beaconSizeLimit && writer.setBeaconSizeLimit(data.beaconSizeLimit)
+    if (sender && writer) {
+      sender.authorise(data.token)
+      data.beaconSizeLimit && writer.setBeaconSizeLimit(data.beaconSizeLimit)
+    }
     return
   }
 }

--- a/tracker/tracker/src/webworker/index.ts
+++ b/tracker/tracker/src/webworker/index.ts
@@ -137,14 +137,16 @@ self.onmessage = ({ data }: any): any => {
   if (data.type === 'auth') {
     if (!sender) {
       console.debug('WebWorker: sender not initialised. Received auth.')
+      return
     }
+    
     if (!writer) {
       console.debug('WebWorker: writer not initialised. Received auth.')
+      return
     }
-    if (sender && writer) {
-      sender.authorise(data.token)
-      data.beaconSizeLimit && writer.setBeaconSizeLimit(data.beaconSizeLimit)
-    }
+
+    sender.authorise(data.token)
+    data.beaconSizeLimit && writer.setBeaconSizeLimit(data.beaconSizeLimit)
     return
   }
 }


### PR DESCRIPTION
The webworker has a bug where after being foregrounded (on mobile especially), if the writer or sender is not present, it will throw an error which will bubble up and crash the entire app. Instead, log a debug message and allow the writer / sender to reinit