### PR TITLE
Fix invalid yaml errors in openreplay chart

### DIFF
--- a/scripts/helmcharts/openreplay/charts/utilities/templates/efs-cron.yaml
+++ b/scripts/helmcharts/openreplay/charts/utilities/templates/efs-cron.yaml
@@ -25,7 +25,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: efs-cleaner
-            image: "{{ tpl .Values.efsCleaner.image.repository . }}:{{ .Values.efsCleaner.image.tag | default .Chart.AppVersion }}"
+            image: alpine
             command:
             - /bin/sh
             - -c

--- a/scripts/helmcharts/openreplay/charts/utilities/templates/efs-cron.yaml
+++ b/scripts/helmcharts/openreplay/charts/utilities/templates/efs-cron.yaml
@@ -25,7 +25,6 @@ spec:
           restartPolicy: Never
           containers:
           - name: efs-cleaner
-            image: alpine
             image: "{{ tpl .Values.efsCleaner.image.repository . }}:{{ .Values.efsCleaner.image.tag | default .Chart.AppVersion }}"
             command:
             - /bin/sh

--- a/scripts/helmcharts/openreplay/charts/utilities/templates/efs-cron.yaml
+++ b/scripts/helmcharts/openreplay/charts/utilities/templates/efs-cron.yaml
@@ -44,7 +44,6 @@ spec:
             volumeMounts:
             - mountPath: /mnt/efs
               name: datadir
-          restartPolicy: Never
           {{- if eq (tpl .Values.efsCleaner.pvc.name . ) "hostPath" }}
           volumes:
           - name: datadir

--- a/scripts/helmcharts/openreplay/charts/utilities/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/utilities/values.yaml
@@ -5,10 +5,6 @@
 replicaCount: 1
 
 efsCleaner:
-  image:
-    repository: "{{ .Values.global.openReplayContainerRegistry }}/alpine"
-    pullPolicy: Always
-    tag: 3.16.1
   retention: 2
   pvc:
     # This can be either persistentVolumeClaim or hostPath.


### PR DESCRIPTION
The openreplay chart is currently uninstallable due to this error:
```
  Error  error   11s (x5 over 28s)  helm-controller  Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 44: mapping key "restartPolicy" already defined at line 22
```

This fixes this issue so the chart can be installed.