### PR TITLE
CLI improvements

### DIFF
--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -195,7 +195,11 @@ function clone_repo() {
 
 function install() {
   domain_name=$1
-  # TODO: Check existing installation
+  # Check existing installation
+  [[ -f ${OR_DIR}/vars.yaml ]] && {
+    or_version=$(busybox awk '/fromVersion/{print $2}' < "${OR_DIR}/vars.yaml")
+    log err "Openreplay installation ${BWHITE}${or_version}${RED} found. If you want to upgrade, run ${BWHITE}openreplay -u${RED}"
+  }
   # Installing OR
   log title "Installing OpenReplay"
   clone_repo

--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -16,7 +16,7 @@ tmp_dir=$(mktemp -d)
 }
 export PATH=/var/lib/openreplay:$PATH
 function xargs() {
-  /var/lib/openreplay/busybox xargs $@
+  /var/lib/openreplay/busybox xargs
 }
 
 tools=(
@@ -214,7 +214,8 @@ function install() {
 
 function cleanup() {
   # Confirmation for deletion. Do you want to delete Postgres/Minio(session) data before $date ?
-  delete_from_date=$(date +%Y-%m-%d -d "$1 day ago")
+  delete_from_number_days=$1
+  delete_from_date=$(date +%Y-%m-%d -d "$delete_from_number_days day ago")
   log debug "Do you want to delete data from postgres and minio before ${BWHITE}$delete_from_date${YELLOW}"
   read -p "Are you sure? " -n 1 -r
   echo    # (optional) move to a new line
@@ -235,6 +236,7 @@ function cleanup() {
   pgdatabase=$(awk '/postgresqlDatabase/{print $2}' < "${OR_DIR}/vars.yaml" | xargs)
   kubectl delete po -n ${APP_NS} pg-cleanup || true
   kubectl run pg-cleanup -n ${APP_NS} \
+    --restart=Never \
     --env PGHOST=$pghost \
     --env PGUSER=$pguser \
     --env PGDATABASE=$pgdatabase \
@@ -242,6 +244,17 @@ function cleanup() {
     --env PGPORT=$pgport \
     --image bitnami/postgresql -- psql -c "DELETE FROM public.sessions WHERE start_ts < extract(epoch from '${delete_from_date}'::date) * 1000;"
   # Run minio command
+  MINIO_ACCESS_KEY=$(awk '/accessKey/{print $NF}' < "${OR_DIR}/vars.yaml" | tail -n1 | xargs)
+  MINIO_SECRET_KEY=$(awk '/secretKey/{print $NF}' < "${OR_DIR}/vars.yaml" | tail -n1 | xargs)
+  MINIO_HOST=$(awk '/endpoint/{print $NF}' < "${OR_DIR}/vars.yaml" | tail -n1 | xargs)
+  kubectl delete po -n ${APP_NS} minio-cleanup || true
+  kubectl run minio-cleanup -n ${APP_NS} \
+    --restart=Never \
+    --env MINIO_HOST=$pghost \
+    --image bitnami/minio:2020.10.9-debian-10-r6 -- /bin/sh -c "
+      mc alias set minio $MINIO_HOST $MINIO_ACCESS_KEY $MINIO_SECRET_KEY &&
+      mc rm --recursive --dangerous --force --older-than ${delete_from_number_days}d minio/mobs
+      "
   return
 }
 

--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -234,7 +234,7 @@ function cleanup() {
   pghost=$(awk '/postgresqlHost/{print $2}' < "${OR_DIR}/vars.yaml" | xargs)
   pgport=$(awk '/postgresqlPort/{print $2}' < "${OR_DIR}/vars.yaml" | xargs)
   pgdatabase=$(awk '/postgresqlDatabase/{print $2}' < "${OR_DIR}/vars.yaml" | xargs)
-  kubectl delete po -n ${APP_NS} pg-cleanup || true
+  kubectl delete po -n ${APP_NS} pg-cleanup &> /dev/null || true
   kubectl run pg-cleanup -n ${APP_NS} \
     --restart=Never \
     --env PGHOST=$pghost \
@@ -247,7 +247,7 @@ function cleanup() {
   MINIO_ACCESS_KEY=$(awk '/accessKey/{print $NF}' < "${OR_DIR}/vars.yaml" | tail -n1 | xargs)
   MINIO_SECRET_KEY=$(awk '/secretKey/{print $NF}' < "${OR_DIR}/vars.yaml" | tail -n1 | xargs)
   MINIO_HOST=$(awk '/endpoint/{print $NF}' < "${OR_DIR}/vars.yaml" | tail -n1 | xargs)
-  kubectl delete po -n ${APP_NS} minio-cleanup || true
+  kubectl delete po -n ${APP_NS} minio-cleanup &> /dev/null || true
   kubectl run minio-cleanup -n ${APP_NS} \
     --restart=Never \
     --env MINIO_HOST=$pghost \

--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -255,6 +255,8 @@ function cleanup() {
       mc alias set minio $MINIO_HOST $MINIO_ACCESS_KEY $MINIO_SECRET_KEY &&
       mc rm --recursive --dangerous --force --older-than ${delete_from_number_days}d minio/mobs
       "
+  log info "Postgres data cleanup initiated. Postgres will auto vacuum marked for deletion data in idle time. Ideally clean up will complete in 1 to 2 days."
+  log info "Minio(s3) cleanup initiated. You should be able to see the data available, once the process completed. ${BWHITE}openreplay -s${GREEN} to check the status"
   return
 }
 

--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -217,7 +217,7 @@ function cleanup() {
   delete_from_number_days=$1
   delete_from_date=$(date +%Y-%m-%d -d "$delete_from_number_days day ago")
   log debug "Do you want to delete data from postgres and minio before ${BWHITE}$delete_from_date${YELLOW}"
-  read -p "Are you sure? " -n 1 -r
+  read -p "Are you sure[y/n]? " -n 1 -r
   echo    # (optional) move to a new line
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     log err "Cancelling data deletion"

--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -114,6 +114,7 @@ echo -e ${NC}
 log info '
   Usage: openreplay [ -h | --help ]
                     [ -s | --status ]
+                    [ -i | --install DOMAIN_NAME ]
                     [ -u | --upgrade ]
                     [ -U | --deprecated-upgrade /path/to/old_vars.yaml]
                     [ -r | --restart ]
@@ -184,6 +185,29 @@ function upgrade_old() {
   upgrade
 }
 
+function clone_repo() {
+  err_cd "$tmp_dir"
+  log info "Working directory $tmp_dir"
+  git_options="-b ${OR_VERSION:-main}"
+  eval git clone "${OR_REPO}" --depth 1 $git_options
+  return
+}
+
+function install() {
+  domain_name=$1
+  # TODO: Check existing installation
+  # Installing OR
+  log title "Installing OpenReplay"
+  clone_repo
+  err_cd "$tmp_dir/openreplay/scripts/helmcharts"
+  DOMAIN_NAME=$domain_name bash init.sh
+  return
+}
+
+function cleanup() {
+  Log title "Cleaning Up Data"
+}
+
 function upgrade() {
   # TODO:
   # 1. store vars.yaml in central place.
@@ -191,15 +215,12 @@ function upgrade() {
   # 3. How to update package. Because openreplay -u will be done from old update script
   # 4. Update from Version
   exists git || log err "Git not found. Please install"
-  log info "Working directory $tmp_dir"
-  err_cd "$tmp_dir"
   or_version=$(busybox awk '/fromVersion/{print $2}' < "${OR_DIR}/vars.yaml")
 
   # Creating backup dir of current installation
   [[ -d "$OR_DIR/openreplay" ]] && sudo cp -rfb "$OR_DIR/openreplay" "$OR_DIR/openreplay_${or_version//\"}" && sudo rm -rf ${OR_DIR}/openreplay
 
-  git_options="-b ${OR_VERSION:-main}"
-  eval git clone "${OR_REPO}" --depth 1 $git_options
+  clone_repo
   err_cd openreplay/scripts/helmcharts
   install_packages
   [[ -d /openreplay ]] && sudo chown -R 1001:1001 /openreplay
@@ -239,7 +260,7 @@ function clean_tmp_dir() {
   install_packages
 }
 
-PARSED_ARGUMENTS=$(busybox getopt -a -n openreplay -o Rrevpiuhsl:U: --long reload,edit,restart,verbose,install-packages,install,upgrade,help,status,logs,deprecated-upgrade: -- "$@")
+PARSED_ARGUMENTS=$(busybox getopt -a -n openreplay -o Rrevpi:uhsl:U: --long reload,edit,restart,verbose,install-packages,install:,upgrade,help,status,logs,deprecated-upgrade: -- "$@")
 VALID_ARGUMENTS=$?
 if [[ "$VALID_ARGUMENTS" != "0" ]]; then
   help
@@ -256,6 +277,12 @@ do
       clean_tmp_dir
       exit 0
       ;;
+    -i | --install)
+      log title "Installing OpenReplay"
+      install "$2"
+      clean_tmp_dir
+      exit 0
+    ;;
     -u | --upgrade)
       log title "Upgrading OpenReplay"
       upgrade

--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -15,6 +15,9 @@ tmp_dir=$(mktemp -d)
   sudo mkdir $OR_DIR
 }
 export PATH=/var/lib/openreplay:$PATH
+function xargs() {
+  /var/lib/openreplay/busybox xargs $@
+}
 
 tools=(
   zyedidia/eget
@@ -119,6 +122,7 @@ log info '
                     [ -U | --deprecated-upgrade /path/to/old_vars.yaml]
                     [ -r | --restart ]
                     [ -R | --Reload ]
+                    [ -c | --cleanup N(in days) ]
                     [ -e | --edit ]
                     [ -p | --install-packages ]
                     [ -l | --logs SERVICE ] 
@@ -209,7 +213,36 @@ function install() {
 }
 
 function cleanup() {
-  Log title "Cleaning Up Data"
+  # Confirmation for deletion. Do you want to delete Postgres/Minio(session) data before $date ?
+  delete_from_date=$(date +%Y-%m-%d -d "$1 day ago")
+  log debug "Do you want to delete data from postgres and minio before ${BWHITE}$delete_from_date${YELLOW}"
+  read -p "Are you sure? " -n 1 -r
+  echo    # (optional) move to a new line
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    log err "Cancelling data deletion"
+  fi
+
+  # Run pg command
+# $PGHOST
+# $PGPORT
+# $PGDATABASE
+# $PGUSER
+# $PGPASSWORD
+  pguser=$(awk '/postgresqlUser/{print $2}' < "${OR_DIR}/vars.yaml" | xargs)
+  pgpassword=$(awk '/postgresqlPassword/{print $2}' < "${OR_DIR}/vars.yaml" | xargs)
+  pghost=$(awk '/postgresqlHost/{print $2}' < "${OR_DIR}/vars.yaml" | xargs)
+  pgport=$(awk '/postgresqlPort/{print $2}' < "${OR_DIR}/vars.yaml" | xargs)
+  pgdatabase=$(awk '/postgresqlDatabase/{print $2}' < "${OR_DIR}/vars.yaml" | xargs)
+  kubectl delete po -n ${APP_NS} pg-cleanup || true
+  kubectl run pg-cleanup -n ${APP_NS} \
+    --env PGHOST=$pghost \
+    --env PGUSER=$pguser \
+    --env PGDATABASE=$pgdatabase \
+    --env PGPASSWORD=$pgpassword \
+    --env PGPORT=$pgport \
+    --image bitnami/postgresql -- psql -c "DELETE FROM public.sessions WHERE start_ts < extract(epoch from '${delete_from_date}'::date) * 1000;"
+  # Run minio command
+  return
 }
 
 function upgrade() {
@@ -264,7 +297,7 @@ function clean_tmp_dir() {
   install_packages
 }
 
-PARSED_ARGUMENTS=$(busybox getopt -a -n openreplay -o Rrevpi:uhsl:U: --long reload,edit,restart,verbose,install-packages,install:,upgrade,help,status,logs,deprecated-upgrade: -- "$@")
+PARSED_ARGUMENTS=$(busybox getopt -a -n openreplay -o Rrevpi:uhsl:U:c: --long reload,edit,restart,verbose,install-packages,install:,upgrade,help,status,logs,deprecated-upgrade:,cleanup: -- "$@")
 VALID_ARGUMENTS=$?
 if [[ "$VALID_ARGUMENTS" != "0" ]]; then
   help
@@ -296,6 +329,12 @@ do
     -U | --deprecated-upgrade)
       log title "[Deprected] Upgrading OpenReplay"
       upgrade_old "$2"
+      clean_tmp_dir
+      exit 0
+    ;;
+    -c | --cleanup)
+      log title "Cleaning up data older than $2 days"
+      cleanup "$2"
       clean_tmp_dir
       exit 0
     ;;

--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -216,19 +216,14 @@ function cleanup() {
   # Confirmation for deletion. Do you want to delete Postgres/Minio(session) data before $date ?
   delete_from_number_days=$1
   delete_from_date=$(date +%Y-%m-%d -d "$delete_from_number_days day ago")
-  log debug "Do you want to delete data from postgres and minio before ${BWHITE}$delete_from_date${YELLOW}"
+  log debug "Do you want to delete the data captured on and before ${BWHITE}$delete_from_date${YELLOW}?"
   read -p "Are you sure[y/n]? " -n 1 -r
   echo    # (optional) move to a new line
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     log err "Cancelling data deletion"
   fi
 
-  # Run pg command
-# $PGHOST
-# $PGPORT
-# $PGDATABASE
-# $PGUSER
-# $PGPASSWORD
+  # Run pg cleanup
   pguser=$(awk '/postgresqlUser/{print $2}' < "${OR_DIR}/vars.yaml" | xargs)
   pgpassword=$(awk '/postgresqlPassword/{print $2}' < "${OR_DIR}/vars.yaml" | xargs)
   pghost=$(awk '/postgresqlHost/{print $2}' < "${OR_DIR}/vars.yaml" | xargs)
@@ -243,7 +238,7 @@ function cleanup() {
     --env PGPASSWORD=$pgpassword \
     --env PGPORT=$pgport \
     --image bitnami/postgresql -- psql -c "DELETE FROM public.sessions WHERE start_ts < extract(epoch from '${delete_from_date}'::date) * 1000;"
-  # Run minio command
+  # Run minio cleanup
   MINIO_ACCESS_KEY=$(awk '/accessKey/{print $NF}' < "${OR_DIR}/vars.yaml" | tail -n1 | xargs)
   MINIO_SECRET_KEY=$(awk '/secretKey/{print $NF}' < "${OR_DIR}/vars.yaml" | tail -n1 | xargs)
   MINIO_HOST=$(awk '/endpoint/{print $NF}' < "${OR_DIR}/vars.yaml" | tail -n1 | xargs)
@@ -255,8 +250,9 @@ function cleanup() {
       mc alias set minio $MINIO_HOST $MINIO_ACCESS_KEY $MINIO_SECRET_KEY &&
       mc rm --recursive --dangerous --force --older-than ${delete_from_number_days}d minio/mobs
       "
-  log info "Postgres data cleanup initiated. Postgres will auto vacuum marked for deletion data in idle time. Ideally clean up will complete in 1 to 2 days."
-  log info "Minio(s3) cleanup initiated. You should be able to see the data available, once the process completed. ${BWHITE}openreplay -s${GREEN} to check the status"
+  log info "Postgres data cleanup process initiated. Postgres will automatically vacuum deleted rows when the database is idle. This may take up a few days to free the disk space."
+  log info "Minio (where recordings are stored) cleanup process initiated." 
+  log info "Run ${BWHITE}openreplay -s${GREEN} to check the status of the cleanup process and available disk space."
   return
 }
 


### PR DESCRIPTION
CLI Now support

1. `openreplay -e` -> Opens the config file, and after change, reloads the installation.

2. `openreplay -i openreplay.mydomain.com` -> Installs OpenReplay

3. `openreplay -c 14` -> Deletes data older than 14 days from OR instance