### PR TITLE
(feat): Chalice - Allow Windows Integrated Authentication for SAML

### DIFF
--- a/ee/api/chalicelib/utils/SAML2_helper.py
+++ b/ee/api/chalicelib/utils/SAML2_helper.py
@@ -23,9 +23,9 @@ SAML2 = {
         "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
         "x509cert": config("sp_crt", default=""),
         "privateKey": config("sp_key", default=""),
-        "security": {
-            "requestedAuthnContext": False
-        }
+    },
+    "security": {
+        "requestedAuthnContext": False
     },
     "idp": None
 }


### PR DESCRIPTION
… as well as the usual password method, users can now pass the authentication flow as SAML automatically passes the OS account as login. 

Without the extra AuthnContext restriction on Password login only, the login flow is faster.