### PR TITLE
fix(sec): upgrade apache-airflow to 2.6.2

### DIFF
--- a/ee/recommendation/ml_trainer/requirements.txt
+++ b/ee/recommendation/ml_trainer/requirements.txt
@@ -1,3 +1,3 @@
 argcomplete==3.0.8
-apache-airflow==2.6.1
+apache-airflow==2.6.2
 airflow-code-editor==7.2.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in apache-airflow 2.6.1
- [CVE-2023-35005](https://www.oscs1024.com/hd/CVE-2023-35005)


### What did I do？
Upgrade apache-airflow from 2.6.1 to 2.6.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS