### PR TITLE
feat(helm): fix quickwit deployment

### DIFF
--- a/scripts/helmcharts/openreplay/charts/quickwit/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/quickwit/templates/deployment.yaml
@@ -50,7 +50,6 @@ spec:
               value: "{{ .Values.global.s3.region }}"
             - name: QW_S3_ENDPOINT
               value: '{{ .Values.global.s3.endpoint }}'
-              {{- end}}
             - name: AWS_ACCESS_KEY_ID
               value: {{ .Values.global.s3.accessKey }}
             - name: AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Helm templating currently fails due to a stray `{{- end}}` tag. The issue was introduced here: [scripts/helmcharts/openreplay/charts/quickwit/templates/deployment.yaml](https://github.com/openreplay/openreplay/pull/836/files#diff-06845d64fe4d60dd0e9a7ef5d81eab86f0101dae5b43f1f083e72d04b9f9390e)