### PR TITLE
chore(api): asyncify `chalice.core.tenants.tenants_exists`, and propagate

### DIFF
--- a/api/NOTES.md
+++ b/api/NOTES.md
@@ -1,0 +1,25 @@
+#### psycopg3 API
+
+I mis-remember the psycopg v2 vs. v3 API.
+
+For the record, the expected psycopg3's async api looks like the
+following pseudo code:
+
+```python
+    async with orpy.get().database.connection() as cnx:
+         async with cnx.transaction():
+             row = await cnx.execute("SELECT EXISTS(SELECT 1 FROM public.tenants)")
+             row = await row.fetchone()
+             return row["exists"]
+```
+
+Minding the following:
+
+- Where `orpy.get().database` is the postgresql connection pooler.
+- Wrap explicit transaction with `async with cnx.transaction():
+  foobar()`
+- Most of the time the transaction object is not used;
+- Do execute await operation against `cnx`;
+- `await cnx.execute` returns a cursor object;
+- Do the `await cursor.fetchqux...` calls against the object return by
+  a call to execute.

--- a/api/app.py
+++ b/api/app.py
@@ -59,8 +59,7 @@ async def lifespan(app: FastAPI):
         "application_name": config("APP_NAME", default="PY"),
     }
 
-    database = " ".join("{}={}".format(k, v) for k, v in database.items())
-    database = psycopg_pool.AsyncConnectionPool(database, connection_class=ORPYAsyncConnection)
+    database = psycopg_pool.AsyncConnectionPool(kwargs=database, connection_class=ORPYAsyncConnection)
     orpy.set(orpy.Application(
         database,
     ))

--- a/api/app.py
+++ b/api/app.py
@@ -18,6 +18,7 @@ from routers.subs import insights, metrics, v1_api, health
 loglevel = config("LOGLEVEL", default=logging.WARNING)
 print(f">Loglevel set to: {loglevel}")
 logging.basicConfig(level=loglevel)
+from orpy import application
 
 
 @asynccontextmanager
@@ -38,10 +39,27 @@ async def lifespan(app: FastAPI):
     for job in app.schedule.get_jobs():
         ap_logger.info({"Name": str(job.id), "Run Frequency": str(job.trigger), "Next Run": str(job.next_run_time)})
 
+
+    database = {
+        "host": config("pg_host", default="localhost"),
+        "dbname": config("pg_dbname", default="orpy"),
+        "user": config("pg_user", default="orpy"),
+        "password": config("pg_password", default="orpy"),
+        "port": config("pg_port", cast=int, default=5432),
+        "application_name": config("APP_NAME", default="PY"),
+    }
+
+    database = " ".join("{}={}".format(k, v) for k, v in database.items())
+    database = psycopg_pool.AsyncConnectionPool(database)
+    application.set(Application(
+        database,
+    )
+
     # App listening
     yield
 
     # Shutdown
+    database.close()
     logging.info(">>>>> shutting down <<<<<")
     app.schedule.shutdown(wait=False)
     await pg_client.terminate()

--- a/api/app.py
+++ b/api/app.py
@@ -19,6 +19,14 @@ loglevel = config("LOGLEVEL", default=logging.WARNING)
 print(f">Loglevel set to: {loglevel}")
 logging.basicConfig(level=loglevel)
 from orpy import application
+from psycopg.rows import dict_row
+
+
+class ORPYAsyncConnection(AsyncConnection):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, row_factory=dict_row, **kwargs)
+
 
 
 @asynccontextmanager
@@ -50,7 +58,7 @@ async def lifespan(app: FastAPI):
     }
 
     database = " ".join("{}={}".format(k, v) for k, v in database.items())
-    database = psycopg_pool.AsyncConnectionPool(database)
+    database = psycopg_pool.AsyncConnectionPool(database, connection_class=ORPYAsyncConnection)
     application.set(Application(
         database,
     )

--- a/api/app.py
+++ b/api/app.py
@@ -61,7 +61,7 @@ async def lifespan(app: FastAPI):
 
     database = " ".join("{}={}".format(k, v) for k, v in database.items())
     database = psycopg_pool.AsyncConnectionPool(database, connection_class=ORPYAsyncConnection)
-    orpy.application.set(orpy.Application(
+    orpy.set(orpy.Application(
         database,
     ))
 

--- a/api/chalicelib/core/signup.py
+++ b/api/chalicelib/core/signup.py
@@ -11,10 +11,10 @@ from chalicelib.utils.TimeUTC import TimeUTC
 logger = logging.getLogger(__name__)
 
 
-def create_tenant(data: schemas.UserSignupSchema):
+async def create_tenant(data: schemas.UserSignupSchema):
     logger.info(f"==== Signup started at {TimeUTC.to_human_readable(TimeUTC.now())} UTC")
     errors = []
-    if tenants.tenants_exists():
+    if await tenants.tenants_exists():
         return {"errors": ["tenants already registered"]}
 
     email = data.email

--- a/api/chalicelib/core/tenants.py
+++ b/api/chalicelib/core/tenants.py
@@ -53,9 +53,9 @@ def edit_tenant(tenant_id, changes):
 
 
 def tenants_exists_sync(use_pool=True):
-    with application.get().database as cnx:
-        cnx.execute("SELECT EXISTS(SELECT 1 FROM public.tenants)")
-        return cnx.fetchone()["exists"]
+    with pg_client.PostgresClient(use_pool=use_pool) as cur:
+        cur.execute("SELECT EXISTS(SELECT 1 FROM public.tenants)")
+        return cur.fetchone()["exists"]
 
 
 async def tenants_exists(use_pool=True):

--- a/api/chalicelib/core/tenants.py
+++ b/api/chalicelib/core/tenants.py
@@ -52,7 +52,14 @@ def edit_tenant(tenant_id, changes):
         return helper.dict_to_camel_case(cur.fetchone())
 
 
-def tenants_exists(use_pool=True):
-    with pg_client.PostgresClient(use_pool=use_pool) as cur:
-        cur.execute(f"SELECT EXISTS(SELECT 1 FROM public.tenants)")
-        return cur.fetchone()["exists"]
+def tenants_exists_sync(use_pool=True):
+    with application.get().database as cnx:
+        cnx.execute("SELECT EXISTS(SELECT 1 FROM public.tenants)")
+        return cnx.fetchone()["exists"]
+
+
+async def tenants_exists(use_pool=True):
+    async with application.get().database as cnx:
+        async with cnx.transaction() as txn:
+            row = await txn.execute("SELECT EXISTS(SELECT 1 FROM public.tenants)")
+            return await row.fetchone()["exists"]

--- a/api/chalicelib/core/tenants.py
+++ b/api/chalicelib/core/tenants.py
@@ -56,7 +56,8 @@ def edit_tenant(tenant_id, changes):
 def tenants_exists_sync(use_pool=True):
     with pg_client.PostgresClient(use_pool=use_pool) as cur:
         cur.execute("SELECT EXISTS(SELECT 1 FROM public.tenants)")
-        return cur.fetchone()["exists"]
+        out = cur.fetchone()["exists"]
+        return out
 
 
 async def tenants_exists(use_pool=True):

--- a/api/chalicelib/core/tenants.py
+++ b/api/chalicelib/core/tenants.py
@@ -1,3 +1,4 @@
+import orpy
 from chalicelib.core import license
 from chalicelib.utils import helper
 from chalicelib.utils import pg_client
@@ -59,7 +60,7 @@ def tenants_exists_sync(use_pool=True):
 
 
 async def tenants_exists(use_pool=True):
-    async with application.get().database.connection() as cnx:
+    async with orpy.application.get().database.connection() as cnx:
         async with cnx.transaction() as txn:
             row = await txn.execute("SELECT EXISTS(SELECT 1 FROM public.tenants)")
             return await row.fetchone()["exists"]

--- a/api/chalicelib/core/tenants.py
+++ b/api/chalicelib/core/tenants.py
@@ -59,7 +59,7 @@ def tenants_exists_sync(use_pool=True):
 
 
 async def tenants_exists(use_pool=True):
-    async with application.get().database as cnx:
+    async with application.get().database.connection() as cnx:
         async with cnx.transaction() as txn:
             row = await txn.execute("SELECT EXISTS(SELECT 1 FROM public.tenants)")
             return await row.fetchone()["exists"]

--- a/api/chalicelib/core/tenants.py
+++ b/api/chalicelib/core/tenants.py
@@ -60,7 +60,8 @@ def tenants_exists_sync(use_pool=True):
 
 
 async def tenants_exists(use_pool=True):
-    async with orpy.application.get().database.connection() as cnx:
+    async with orpy.get().database.connection() as cnx:
         async with cnx.transaction() as txn:
-            row = await txn.execute("SELECT EXISTS(SELECT 1 FROM public.tenants)")
-            return await row.fetchone()["exists"]
+            row = await cnx.execute("SELECT EXISTS(SELECT 1 FROM public.tenants)")
+            row = await row.fetchone()
+            return row["exists"]

--- a/api/orpy.py
+++ b/api/orpy.py
@@ -1,6 +1,4 @@
 from collections import namedtuple
-from contextvars import ContextVar
-from typing import Optional
 
 Application = namedtuple(
     "Application",
@@ -8,4 +6,15 @@ Application = namedtuple(
         "database",
     ),
 )
-application: ContextVar[Optional[Application]] = ContextVar("application", default=None)
+
+
+APPLICATION = None
+
+
+def set(application):
+    global APPLICATION
+    APPLICATION = application
+
+
+def get():
+    return APPLICATION

--- a/api/orpy.py
+++ b/api/orpy.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from contextvars import ContextVar
-
+from typing import Optional
 
 Application = namedtuple(
     "Application",
@@ -8,4 +8,4 @@ Application = namedtuple(
         "database",
     ),
 )
-application: Application = ContextVar("application", default=None)
+application: ContextVar[Optional[Application]] = ContextVar("application", default=None)

--- a/api/orpy.py
+++ b/api/orpy.py
@@ -1,0 +1,11 @@
+from collections import namedtuple
+from contextvars import ContextVar
+
+
+Application = namedtuple(
+    "Application",
+    (
+        "database",
+    ),
+)
+application: Application = ContextVar("application", default=None)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -18,4 +18,3 @@ apscheduler==3.10.4
 redis==5.0.1
 
 psycopg[pool,binary]==3.1.12
-httpx==0.25.1

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -16,3 +16,6 @@ pydantic[email]==2.3.0
 apscheduler==3.10.4
 
 redis==5.0.1
+
+psycopg[pool,binary]==3.1.12
+httpx==0.25.1

--- a/api/routers/core_dynamic.py
+++ b/api/routers/core_dynamic.py
@@ -31,18 +31,19 @@ async def get_all_signup():
 
 
 
-@public_app.post('/signup', tags=['signup'])
-@public_app.put('/signup', tags=['signup'])
-async def signup_handler(data: schemas.UserSignupSchema = Body(...)):
-    content = await signup.create_tenant(data)
-    if "errors" in content:
-        return content
-    refresh_token = content.pop("refreshToken")
-    refresh_token_max_age = content.pop("refreshTokenMaxAge")
-    response = JSONResponse(content=content)
-    response.set_cookie(key="refreshToken", value=refresh_token, path="/api/refresh",
-                        max_age=refresh_token_max_age, secure=True, httponly=True)
-    return response
+if not tenants.tenants_exists_sync(use_pool=False):
+    @public_app.post('/signup', tags=['signup'])
+    @public_app.put('/signup', tags=['signup'])
+    async def signup_handler(data: schemas.UserSignupSchema = Body(...)):
+        content = await signup.create_tenant(data)
+        if "errors" in content:
+            return content
+        refresh_token = content.pop("refreshToken")
+        refresh_token_max_age = content.pop("refreshTokenMaxAge")
+        response = JSONResponse(content=content)
+        response.set_cookie(key="refreshToken", value=refresh_token, path="/api/refresh",
+                            max_age=refresh_token_max_age, secure=True, httponly=True)
+        return response
 
 
 @public_app.post('/login', tags=["authentication"])

--- a/api/routers/core_dynamic.py
+++ b/api/routers/core_dynamic.py
@@ -22,27 +22,27 @@ public_app, app, app_apikey = get_routers()
 
 
 @public_app.get('/signup', tags=['signup'])
-def get_all_signup():
-    return {"data": {"tenants": tenants.tenants_exists(),
+async def get_all_signup():
+    return {"data": {"tenants": await tenants.tenants_exists(),
                      "sso": None,
                      "ssoProvider": None,
                      "enforceSSO": None,
                      "edition": license.EDITION}}
 
 
-if not tenants.tenants_exists(use_pool=False):
-    @public_app.post('/signup', tags=['signup'])
-    @public_app.put('/signup', tags=['signup'])
-    def signup_handler(data: schemas.UserSignupSchema = Body(...)):
-        content = signup.create_tenant(data)
-        if "errors" in content:
-            return content
-        refresh_token = content.pop("refreshToken")
-        refresh_token_max_age = content.pop("refreshTokenMaxAge")
-        response = JSONResponse(content=content)
-        response.set_cookie(key="refreshToken", value=refresh_token, path="/api/refresh",
-                            max_age=refresh_token_max_age, secure=True, httponly=True)
-        return response
+
+@public_app.post('/signup', tags=['signup'])
+@public_app.put('/signup', tags=['signup'])
+async def signup_handler(data: schemas.UserSignupSchema = Body(...)):
+    content = await signup.create_tenant(data)
+    if "errors" in content:
+        return content
+    refresh_token = content.pop("refreshToken")
+    refresh_token_max_age = content.pop("refreshTokenMaxAge")
+    response = JSONResponse(content=content)
+    response.set_cookie(key="refreshToken", value=refresh_token, path="/api/refresh",
+                        max_age=refresh_token_max_age, secure=True, httponly=True)
+    return response
 
 
 @public_app.post('/login', tags=["authentication"])

--- a/api/routers/subs/health.py
+++ b/api/routers/subs/health.py
@@ -14,10 +14,9 @@ def get_global_health_status():
     return {"data": health.get_health()}
 
 
-if not tenants.tenants_exists(use_pool=False):
-    @public_app.get('/health', tags=["health-check"])
-    def get_public_health_status():
-        if tenants.tenants_exists():
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Not Found")
+@public_app.get('/health', tags=["health-check"])
+async def get_public_health_status():
+    if await tenants.tenants_exists():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Not Found")
 
-        return {"data": health.get_health()}
+    return {"data": health.get_health()}

--- a/api/routers/subs/health.py
+++ b/api/routers/subs/health.py
@@ -14,9 +14,10 @@ def get_global_health_status():
     return {"data": health.get_health()}
 
 
-@public_app.get('/health', tags=["health-check"])
-async def get_public_health_status():
-    if await tenants.tenants_exists():
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Not Found")
+if not tenants.tenants_exists_sync(use_pool=False):
+    @public_app.get('/health', tags=["health-check"])
+    async def get_public_health_status():
+        if await tenants.tenants_exists():
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Not Found")
 
-    return {"data": health.get_health()}
+        return {"data": health.get_health()}

--- a/ee/api/chalicelib/core/signup.py
+++ b/ee/api/chalicelib/core/signup.py
@@ -13,10 +13,10 @@ from chalicelib.utils.TimeUTC import TimeUTC
 logger = logging.getLogger(__name__)
 
 
-def create_tenant(data: schemas.UserSignupSchema):
+async def create_tenant(data: schemas.UserSignupSchema):
     logger.info(f"==== Signup started at {TimeUTC.to_human_readable(TimeUTC.now())} UTC")
     errors = []
-    if not config("MULTI_TENANTS", cast=bool, default=False) and tenants.tenants_exists():
+    if not config("MULTI_TENANTS", cast=bool, default=False) and await tenants.tenants_exists():
         return {"errors": ["tenants already registered"]}
 
     email = data.email

--- a/ee/api/chalicelib/core/tenants.py
+++ b/ee/api/chalicelib/core/tenants.py
@@ -78,7 +78,8 @@ def edit_tenant(tenant_id, changes):
         return helper.dict_to_camel_case(cur.fetchone())
 
 
-def tenants_exists(use_pool=True):
-    with pg_client.PostgresClient(use_pool=use_pool) as cur:
-        cur.execute(f"SELECT EXISTS(SELECT 1 FROM public.tenants)")
-        return cur.fetchone()["exists"]
+async def tenants_exists(use_pool=True):
+    async with application.get().database. as cnx:
+        async with cnx.transaction():
+            row = await cnx.execute(f"SELECT EXISTS(SELECT 1 FROM public.tenants)")
+            return await row.fetchone()["exists"]

--- a/ee/api/chalicelib/core/tenants.py
+++ b/ee/api/chalicelib/core/tenants.py
@@ -78,8 +78,14 @@ def edit_tenant(tenant_id, changes):
         return helper.dict_to_camel_case(cur.fetchone())
 
 
+def tenants_exists_sync(use_pool=True):
+    with pg_client.PostgresClient(use_pool=use_pool) as cur:
+        cur.execute("SELECT EXISTS(SELECT 1 FROM public.tenants)")
+        return cur.fetchone()["exists"]
+
+
 async def tenants_exists(use_pool=True):
-    async with application.get().database. as cnx:
-        async with cnx.transaction():
-            row = await cnx.execute(f"SELECT EXISTS(SELECT 1 FROM public.tenants)")
+    async with application.get().database as cnx:
+        async with cnx.transaction() as txn:
+            row = await txn.execute(f"SELECT EXISTS(SELECT 1 FROM public.tenants)")
             return await row.fetchone()["exists"]

--- a/ee/api/requirements.txt
+++ b/ee/api/requirements.txt
@@ -26,3 +26,5 @@ python-multipart==0.0.6
 redis==5.0.1
 #confluent-kafka==2.1.0
 azure-storage-blob==12.19.0
+
+psycopg[pool,binary]==3.1.12

--- a/ee/api/routers/subs/health.py
+++ b/ee/api/routers/subs/health.py
@@ -14,10 +14,9 @@ def get_global_health_status(context: schemas.CurrentContext = Depends(OR_contex
     return {"data": health.get_health(tenant_id=context.tenant_id)}
 
 
-if not tenants.tenants_exists(use_pool=False):
-    @public_app.get('/health', tags=["health-check"])
-    def get_public_health_status():
-        if tenants.tenants_exists():
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Not Found")
+@public_app.get('/health', tags=["health-check"])
+async def get_public_health_status():
+    if await tenants.tenants_exists():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Not Found")
 
-        return {"data": health.get_health()}
+    return {"data": health.get_health()}

--- a/ee/api/routers/subs/health.py
+++ b/ee/api/routers/subs/health.py
@@ -14,9 +14,10 @@ def get_global_health_status(context: schemas.CurrentContext = Depends(OR_contex
     return {"data": health.get_health(tenant_id=context.tenant_id)}
 
 
-@public_app.get('/health', tags=["health-check"])
-async def get_public_health_status():
-    if await tenants.tenants_exists():
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Not Found")
+if not tenants.tenants_exists(use_pool=False):
+    @public_app.get('/health', tags=["health-check"])
+    async def get_public_health_status():
+        if await tenants.tenants_exists():
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Not Found")
 
-    return {"data": health.get_health()}
+        return {"data": health.get_health()}


### PR DESCRIPTION
- Add async database pooler from psycopg3 aka `psycopg`
- Make it available through a global available at runtime as `orpy.get().database`

And make async `chalice.core.tenants.tenants_exists` and all functions depending on it. Keep around the synchronous version to be able to call it at top-level, and exclude some routes after a restart of the application server for security reasons.