### PR TITLE
fix(api): fastapi requires uvicorn workers in gunicorn

### DIFF
--- a/ee/api/entrypoint.sh
+++ b/ee/api/entrypoint.sh
@@ -4,4 +4,5 @@ source /tmp/.env.override
 
 #uvicorn app:app --host 0.0.0.0 --port $LISTEN_PORT --proxy-headers
 NB_WORKERS="${NB_WORKERS:=4}"
-gunicorn app:app --workers $NB_WORKERS --bind 0.0.0.0:$LISTEN_PORT  --log-level ${S_LOGLEVEL:-warning}
+gunicorn app:app --workers $NB_WORKERS --worker-class uvicorn.workers.UvicornWorker \
+                 --bind 0.0.0.0:$LISTEN_PORT  --log-level ${S_LOGLEVEL:-warning}


### PR DESCRIPTION
Even if FastAPI routes are synchronous, FastAPI rely on ASGI.

Revert "feat(api): use the default sync worker class, and only one worker."

This reverts commit 39ca414137b60885c1a439e0cae03290009199c7.