### PR TITLE
refactor(backend): move from io/ioutil to io and os packages

### DIFF
--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -5,10 +5,10 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -62,7 +62,7 @@ func NewCacher(cfg *config.Config, store objectstorage.ObjectStorage) (*cacher, 
 			log.Fatalf("Error creating x509 keypair from the client cert file %s and client key file %s , Error: %s", err, cfg.ClientCertFilePath, cfg.ClientKeyFilePath)
 		}
 
-		caCert, err := ioutil.ReadFile(cfg.CaCertFilePath)
+		caCert, err := os.ReadFile(cfg.CaCertFilePath)
 		if err != nil {
 			log.Fatalf("Error opening cert file %s, Error: %s", cfg.CaCertFilePath, err)
 		}
@@ -128,7 +128,7 @@ func (c *cacher) cacheURL(t *Task) {
 		}
 		return
 	}
-	data, err := ioutil.ReadAll(io.LimitReader(res.Body, int64(c.sizeLimit+1)))
+	data, err := io.ReadAll(io.LimitReader(res.Body, int64(c.sizeLimit+1)))
 	if err != nil {
 		c.Errors <- errors.Wrap(err, t.urlContext)
 		return

--- a/backend/internal/http/router/handlers-mobile.go
+++ b/backend/internal/http/router/handlers-mobile.go
@@ -3,7 +3,7 @@ package router
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -200,7 +200,7 @@ func (e *Router) imagesUploadHandlerIOS(w http.ResponseWriter, r *http.Request) 
 				continue
 			}
 
-			data, err := ioutil.ReadAll(file)
+			data, err := io.ReadAll(file)
 			if err != nil {
 				log.Fatalf("failed reading data: %s", err)
 			}

--- a/backend/internal/http/router/handlers-web.go
+++ b/backend/internal/http/router/handlers-web.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/gorilla/mux"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
@@ -586,7 +585,7 @@ func (e *Router) imagesUploaderHandlerWeb(w http.ResponseWriter, r *http.Request
 			}
 
 			// Read the file content
-			fileBytes, err := ioutil.ReadAll(file)
+			fileBytes, err := io.ReadAll(file)
 			if err != nil {
 				file.Close()
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/backend/internal/http/router/handlers.go
+++ b/backend/internal/http/router/handlers.go
@@ -3,7 +3,6 @@ package router
 import (
 	gzip "github.com/klauspost/pgzip"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"time"
@@ -32,7 +31,7 @@ func (e *Router) pushMessages(w http.ResponseWriter, r *http.Request, sessionID 
 		reader = body
 	}
 	log.Println("Reader after switch:", reader)
-	buf, err := ioutil.ReadAll(reader)
+	buf, err := io.ReadAll(reader)
 	if err != nil {
 		ResponseWithError(w, http.StatusInternalServerError, err, start, r.URL.Path, 0)
 		return

--- a/backend/internal/videostorage/service.go
+++ b/backend/internal/videostorage/service.go
@@ -3,14 +3,15 @@ package videostorage
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
-	config "openreplay/backend/internal/config/videostorage"
-	"openreplay/backend/pkg/objectstorage"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
+
+	config "openreplay/backend/internal/config/videostorage"
+	"openreplay/backend/pkg/objectstorage"
 )
 
 type Task struct {
@@ -53,7 +54,7 @@ func New(cfg *config.Config, objStorage objectstorage.ObjectStorage) (*VideoStor
 }
 
 func (v *VideoStorage) makeVideo(sessID uint64, filesPath string) error {
-	files, err := ioutil.ReadDir(filesPath)
+	files, err := os.ReadDir(filesPath)
 	if err != nil || len(files) == 0 {
 		return err // nil error is there is no screenshots
 	}
@@ -85,7 +86,7 @@ func (v *VideoStorage) makeCanvasVideo(sessID uint64, filesPath, canvasMix strin
 	name := strings.TrimSuffix(canvasMix, "-list")
 	mixList := fmt.Sprintf("%s%s", filesPath, canvasMix)
 	// check that mixList exists
-	if _, err := ioutil.ReadFile(mixList); err != nil {
+	if _, err := os.ReadFile(mixList); err != nil {
 		return err
 	}
 	videoPath := fmt.Sprintf("%s%s.mp4", filesPath, name)
@@ -114,7 +115,7 @@ func (v *VideoStorage) makeCanvasVideo(sessID uint64, filesPath, canvasMix strin
 func (v *VideoStorage) sendToS3(task *Task) {
 	start := time.Now()
 	// Read video file from disk
-	video, err := ioutil.ReadFile(task.path)
+	video, err := os.ReadFile(task.path)
 	if err != nil {
 		log.Fatalf("Failed to read video file: %v", err)
 	}

--- a/backend/pkg/integrations/clients/bugsnag.go
+++ b/backend/pkg/integrations/clients/bugsnag.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -66,7 +65,7 @@ func (b *bugsnag) Request(c *client) error {
 		// Status code
 		//  401 (unauthorised)
 		if resp.StatusCode >= 400 {
-			io.Copy(ioutil.Discard, resp.Body) // Read the body to free socket
+			io.Copy(io.Discard, resp.Body) // Read the body to free socket
 			return fmt.Errorf("Bugsnag: server respond with the code %v | data: %v ", resp.StatusCode, *b)
 		}
 

--- a/backend/pkg/integrations/clients/datadog.go
+++ b/backend/pkg/integrations/clients/datadog.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -85,7 +84,7 @@ func (d *datadog) Request(c *client) error {
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode >= 400 {
-			io.Copy(ioutil.Discard, resp.Body) // Read the body to free socket
+			io.Copy(io.Discard, resp.Body) // Read the body to free socket
 			return fmt.Errorf("Datadog: server respond with the code %v", resp.StatusCode)
 		}
 		var ddResp datadogResponce

--- a/backend/pkg/integrations/clients/newrelic.go
+++ b/backend/pkg/integrations/clients/newrelic.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -64,7 +63,7 @@ func (nr *newrelic) Request(c *client) error {
 	//  401 (unauthorised) if wrong XQueryKey/deploymentServer is wrong or 403 (Forbidden) if ApplicationId is wrong
 	// 400 if Query has problems
 	if resp.StatusCode >= 400 {
-		io.Copy(ioutil.Discard, resp.Body) // Read the body to free socket
+		io.Copy(io.Discard, resp.Body) // Read the body to free socket
 		return fmt.Errorf("Newrelic: server respond with the code %v| Request: ", resp.StatusCode, *req)
 	}
 	// Pagination depending on returning metadata ?

--- a/backend/pkg/integrations/clients/rollbar.go
+++ b/backend/pkg/integrations/clients/rollbar.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -87,7 +86,7 @@ func (rb *rollbar) Request(c *client) error {
 	// status != 200 || 201
 	// status can be 403 then should report about wrong token
 	if resp.StatusCode >= 400 {
-		io.Copy(ioutil.Discard, resp.Body) // Read the body to free socket
+		io.Copy(io.Discard, resp.Body) // Read the body to free socket
 		return fmt.Errorf("Rollbar: server respond with the code %v", resp.StatusCode)
 	}
 

--- a/backend/pkg/integrations/clients/sentry.go
+++ b/backend/pkg/integrations/clients/sentry.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -58,7 +57,7 @@ PageLoop:
 		defer resp.Body.Close()
 
 		if resp.StatusCode >= 400 {
-			io.Copy(ioutil.Discard, resp.Body) // Read the body to free socket
+			io.Copy(io.Discard, resp.Body) // Read the body to free socket
 			return fmt.Errorf("Sentry: server respond with the code %v", resp.StatusCode)
 		}
 

--- a/backend/pkg/integrations/clients/sumologic.go
+++ b/backend/pkg/integrations/clients/sumologic.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -62,7 +61,7 @@ func (sl *sumologic) deleteJob(jobId string, errChan chan<- error) {
 		errChan <- fmt.Errorf("Error on DELETE request: %v", err)
 		return
 	}
-	io.Copy(ioutil.Discard, resp.Body)
+	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 }
 
@@ -104,7 +103,7 @@ func (sl *sumologic) Request(c *client) error {
 	// https://help.sumologic.com/APIs/Search-Job-API/About-the-Search-Job-API#status-codes
 	// responce body is NOT the same as in docs (look at the sumologic_job_start.json)
 	if resp.StatusCode >= 400 {
-		io.Copy(ioutil.Discard, resp.Body) // Read the body to free socket
+		io.Copy(io.Discard, resp.Body) // Read the body to free socket
 		return fmt.Errorf("Sumologic: server respond with the code %v | req %v |Resp: %v", resp.StatusCode, *req, *resp)
 	}
 	sl.cookies = resp.Cookies()


### PR DESCRIPTION
The `io/ioutil` package has been deprecated as of Go 1.16 [^1]. This commit replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

[^1]: https://golang.org/doc/go1.16#ioutil

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated file and response body reading methods across various backend components for improved performance and adherence to modern standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->