### PR TITLE
fix: invitation password set

### DIFF
--- a/api/chalicelib/core/users.py
+++ b/api/chalicelib/core/users.py
@@ -449,9 +449,7 @@ def change_password(tenant_id, user_id, email, old_password, new_password):
 
 
 def set_password_invitation(user_id, new_password):
-    changes = {"password": new_password,
-               "invitationToken": None, "invitedAt": None,
-               "changePwdExpireAt": None, "changePwdToken": None}
+    changes = {"password": new_password}
     user = update(tenant_id=-1, user_id=user_id, changes=changes)
     r = authenticate(user['email'], new_password)
 

--- a/ee/api/chalicelib/core/users.py
+++ b/ee/api/chalicelib/core/users.py
@@ -528,9 +528,7 @@ def change_password(tenant_id, user_id, email, old_password, new_password):
 
 
 def set_password_invitation(tenant_id, user_id, new_password):
-    changes = {"password": new_password,
-               "invitationToken": None, "invitedAt": None,
-               "changePwdExpireAt": None, "changePwdToken": None}
+    changes = {"password": new_password}
     user = update(tenant_id=tenant_id, user_id=user_id, changes=changes)
     r = authenticate(user['email'], new_password)
 


### PR DESCRIPTION
Fixes #1794

These fields are set in the `update` function and should be set twice in the SQL `UPDATE`.

I'm new to the project and only have basic knowledge of Python so feel free, to make changes if this isn't the solution.

I'm also not too sure how I can test my changes, either locally or on a server with OpenReplay installed. If someone wants to provide instructions on how this can be achieved this would be greatly appreciated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the password setting process by removing unnecessary fields from the invitation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->