### PR TITLE
use smtpilb send_message #1829

### DIFF
--- a/api/chalicelib/utils/email_handler.py
+++ b/api/chalicelib/utils/email_handler.py
@@ -69,7 +69,7 @@ def send_html(BODY_HTML, SUBJECT, recipient, bcc=None):
                 r += [bcc]
             try:
                 logging.info(f"Email sending to: {r}")
-                s.sendmail(msg['FROM'], r, msg.as_string().encode('ascii'))
+                s.send_message(msg)
             except Exception as e:
                 logging.error("!!! Email error!")
                 logging.error(e)
@@ -84,7 +84,7 @@ def send_text(recipients, text, subject):
         body = MIMEText(text)
         msg.attach(body)
         try:
-            s.sendmail(msg['FROM'], recipients, msg.as_string().encode('ascii'))
+            s.send_message(msg)
         except Exception as e:
             logging.error("!! Text-email failed: " + subject),
             logging.error(e)

--- a/api/chalicelib/utils/smtp.py
+++ b/api/chalicelib/utils/smtp.py
@@ -10,6 +10,8 @@ class EmptySMTP:
     def sendmail(self, from_addr, to_addrs, msg, mail_options=(), rcpt_options=()):
         logging.error("!! CANNOT SEND EMAIL, NO VALID SMTP CONFIGURATION FOUND")
 
+    def send_message(self, msg):
+        self.sendmail( msg["FROM"], msg["TO"], msg.as_string() )
 
 class SMTPClient:
     server = None


### PR DESCRIPTION
fixes blank messages due to encoding problem

Doing `encode('ascii')` for some reason makes body part to go blank. Snooping the traffic, I can see the entire message including the body being sent. However relay does not like the encoded format, losing the body when my email client receives.

Removing this or using the `send_message()` which accepts `Email` object fixes this problem.
I am unable to test this within Open Replay. However I duplicated minimal code in a standalone test code. This test was able to reproduce the problem, and show the fix to work for me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved email sending mechanisms for enhanced reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->