### PR TITLE
fix(scrips) Improve Docker Installation Scripts

### DIFF
--- a/scripts/docker-compose/install.sh
+++ b/scripts/docker-compose/install.sh
@@ -58,12 +58,20 @@ sudo apt update
 # Check if Docker is already installed
 if ! command -v docker &> /dev/null; then
 	info "Setting up Docker"
-	sudo apt install docker.io docker-compose -y
+	sudo apt install docker.io -y
 
 	# enable docker without sudo
 	sudo usermod -aG docker "${USER}" || true
 else
-    echo "Docker is already installed. Skipping installation."
+	echo "Docker is already installed. Skipping Docker installation."
+fi
+
+# Check if Docker Compose is already installed
+if ! command -v docker-compose &>/dev/null && ! command -v docker compose &>/dev/null; then
+	info "Setting up Docker Compose"
+	sudo apt install docker-compose -y
+else
+	echo "Docker Compose is already installed. Skipping Docker Compose installation."
 fi
 
 # Prompt for DOMAIN_NAME input
@@ -80,20 +88,20 @@ if [[ -z $DOMAIN_NAME ]]; then
 	fatal "DOMAIN_NAME variable is empty. Please provide a valid domain name to proceed."
 fi
 info "Using domain name: $DOMAIN_NAME 🌐"
-echo "CADDY_DOMAIN=\"$DOMAIN_NAME\"" >> common.env 
+echo "CADDY_DOMAIN=\"$DOMAIN_NAME\"" >> common.env
 
 read -p "Is the domain on a public DNS? (y/n) " yn
-case $yn in 
-	y ) echo "$DOMAIN_NAME is on a public DNS";
-        ;;
-	n ) echo "$DOMAIN_NAME is on a private DNS";
-		#add TLS internal to caddyfile
-		#In local network Caddy can't reach Let's Encrypt servers to get a certificate 
-		mv Caddyfile Caddyfile.public
-		mv Caddyfile.private Caddyfile
-		;;
-	* ) echo invalid response;
-		exit 1;;
+case $yn in
+y ) echo "$DOMAIN_NAME is on a public DNS";
+	;;
+n ) echo "$DOMAIN_NAME is on a private DNS";
+	#add TLS internal to caddyfile
+	#In local network Caddy can't reach Let's Encrypt servers to get a certificate
+	mv Caddyfile Caddyfile.public
+	mv Caddyfile.private Caddyfile
+	;;
+* ) echo invalid response;
+	exit 1;;
 esac
 
 # Create passwords if they don't exist
@@ -108,25 +116,25 @@ set +a
 # Use the `envsubst` command to substitute the shell environment variables into reference_var.env and output to a combined .env
 find ./ -type f \( -iname "*.env" -o -iname "docker-compose.yaml" \) ! -name "common.env" -exec /bin/bash -c 'file="{}"; git checkout -- "$file"; cp "$file" "$file.bak"; envsubst < "$file.bak" > "$file"; rm "$file.bak"' \;
 
-case $yn in 
-	y ) echo "$DOMAIN_NAME is on a public DNS";
-		##No changes needed
-        ;;
-	n ) echo "$DOMAIN_NAME is on a private DNS";
-		##Add a variable to chalice.env file
-		echo "SKIP_H_SSL=True" >> chalice.env
-		;;
-	* ) echo invalid response;
-		exit 1;;
+case $yn in
+y ) echo "$DOMAIN_NAME is on a public DNS";
+	##No changes needed
+	;;
+n ) echo "$DOMAIN_NAME is on a private DNS";
+	##Add a variable to chalice.env file
+	echo "SKIP_H_SSL=True" >> chalice.env
+	;;
+* ) echo invalid response;
+	exit 1;;
 esac
 
 if command -v docker-compose >/dev/null 2>&1; then
-    # Docker Compose V1 is installed.
-    sudo -E docker-compose --parallel 1 pull
+	# Docker Compose V1 is installed.
+	sudo -E docker-compose --parallel 1 pull
 	sudo -E docker-compose --profile migration up --force-recreate --build -d
 else
-    # Docker Compose V2 or higher is installed.
-    sudo -E docker compose --parallel 1 pull
+	# Docker Compose V2 or higher is installed.
+	sudo -E docker compose --parallel 1 pull
 	sudo -E docker compose --profile migration up --force-recreate --build -d
 fi
 

--- a/scripts/docker-compose/install.sh
+++ b/scripts/docker-compose/install.sh
@@ -88,20 +88,20 @@ if [[ -z $DOMAIN_NAME ]]; then
 	fatal "DOMAIN_NAME variable is empty. Please provide a valid domain name to proceed."
 fi
 info "Using domain name: $DOMAIN_NAME 🌐"
-echo "CADDY_DOMAIN=\"$DOMAIN_NAME\"" >> common.env
+echo "CADDY_DOMAIN=\"$DOMAIN_NAME\"" >> common.env 
 
 read -p "Is the domain on a public DNS? (y/n) " yn
-case $yn in
-y ) echo "$DOMAIN_NAME is on a public DNS";
-	;;
-n ) echo "$DOMAIN_NAME is on a private DNS";
-	#add TLS internal to caddyfile
-	#In local network Caddy can't reach Let's Encrypt servers to get a certificate
-	mv Caddyfile Caddyfile.public
-	mv Caddyfile.private Caddyfile
-	;;
-* ) echo invalid response;
-	exit 1;;
+case $yn in 
+	y ) echo "$DOMAIN_NAME is on a public DNS";
+        ;;
+	n ) echo "$DOMAIN_NAME is on a private DNS";
+		#add TLS internal to caddyfile
+		#In local network Caddy can't reach Let's Encrypt servers to get a certificate 
+		mv Caddyfile Caddyfile.public
+		mv Caddyfile.private Caddyfile
+		;;
+	* ) echo invalid response;
+		exit 1;;
 esac
 
 # Create passwords if they don't exist
@@ -116,16 +116,16 @@ set +a
 # Use the `envsubst` command to substitute the shell environment variables into reference_var.env and output to a combined .env
 find ./ -type f \( -iname "*.env" -o -iname "docker-compose.yaml" \) ! -name "common.env" -exec /bin/bash -c 'file="{}"; git checkout -- "$file"; cp "$file" "$file.bak"; envsubst < "$file.bak" > "$file"; rm "$file.bak"' \;
 
-case $yn in
-y ) echo "$DOMAIN_NAME is on a public DNS";
-	##No changes needed
-	;;
-n ) echo "$DOMAIN_NAME is on a private DNS";
-	##Add a variable to chalice.env file
-	echo "SKIP_H_SSL=True" >> chalice.env
-	;;
-* ) echo invalid response;
-	exit 1;;
+case $yn in 
+	y ) echo "$DOMAIN_NAME is on a public DNS";
+		##No changes needed
+        ;;
+	n ) echo "$DOMAIN_NAME is on a private DNS";
+		##Add a variable to chalice.env file
+		echo "SKIP_H_SSL=True" >> chalice.env
+		;;
+	* ) echo invalid response;
+		exit 1;;
 esac
 
 if command -v docker-compose >/dev/null 2>&1; then


### PR DESCRIPTION
This pull request fixes two issues in the docker install scripts:

- The bash script did not check if docker was already installed or not, which could cause issues or errors during installation. This fix adds a check for docker installation and skips the installation step if docker is already present.
- The bash script did not check the version of docker-compose and used docker-compose for both docker compose v1 and v2. This fix adds a check for docker-compose version and uses the appropriate command for each version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved the Docker installation script to check for existing installations, support for Docker Compose V1 and higher, and enable Docker usage without sudo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->