### PR TITLE
fix(ui): cap video framerate for mobile to 10hz

### DIFF
--- a/frontend/app/components/Session/Player/MobilePlayer/ReplayWindow.tsx
+++ b/frontend/app/components/Session/Player/MobilePlayer/ReplayWindow.tsx
@@ -22,7 +22,8 @@ function ReplayWindow({ videoURL, userDevice }: Props) {
   React.useEffect(() => {
     if (videoRef.current) {
       const timeSecs = time / 1000
-      if (videoRef.current.duration >= timeSecs) {
+      const delta = videoRef.current.currentTime - timeSecs
+      if (videoRef.current.duration >= timeSecs && Math.abs(delta) > 0.1) {
         videoRef.current.currentTime = timeSecs
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy in seeking to the correct time in video replays on mobile, with a tolerance of 0.1 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->