### PR TITLE
removed duplicate dependency entry 🙂🙂

### DIFF
--- a/scripts/helmcharts/databases/Chart.yaml
+++ b/scripts/helmcharts/databases/Chart.yaml
@@ -24,10 +24,6 @@ version: 0.1.0
 appVersion: "1.16.0"
 
 dependencies:
-  - name: minio
-    repository: file://charts/minio
-    version: 3.7.4
-    condition: minio.enabled
   - name: kafka
     repository: file://charts/kafka
     version: 11.8.6


### PR DESCRIPTION
There was a duplicate entry for minio in the database chart's Chart.yaml file that prevents it from being deployed using helm upgrade like the Kubernetes deployment guide says it should.