### PR TITLE
Sanitizer allows "+" character in emails

### DIFF
--- a/tracker/tracker/src/main/app/sanitizer.ts
+++ b/tracker/tracker/src/main/app/sanitizer.ts
@@ -74,7 +74,7 @@ export default class Sanitizer {
       data = data.replace(/\d/g, '0')
     }
     if (this.options.obscureTextEmails) {
-      data = data.replace(/^\w+([.-]\w+)*@\w+([.-]\w+)*\.\w{2,3}$/g, (email) => {
+      data = data.replace(/^\w+([+.-]\w+)*@\w+([.-]\w+)*\.\w{2,3}$/g, (email) => {
         const [name, domain] = email.split('@')
         const [domainName, host] = domain.split('.')
         return `${stars(name)}@${stars(domainName)}.${stars(host)}`


### PR DESCRIPTION
It seems the `+` character was breaking the regex catching emails:

![image](https://github.com/openreplay/openreplay/assets/645641/cebbdaf3-8c12-4518-be57-d9a0225e5847)

This should fix it, see the interactive examples: https://regex101.com/r/Qy2tdL/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved email obscuring by allowing `+` characters in the email addresses for more accurate matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->