### PR TITLE
refactor(chalice): use format instead of % for sourcemaps-url

### DIFF
--- a/api/chalicelib/core/sourcemaps_parser.py
+++ b/api/chalicelib/core/sourcemaps_parser.py
@@ -6,9 +6,9 @@ SMR_URL = config("sourcemaps_reader")
 
 if '%s' in SMR_URL:
     if config("SMR_KEY", default=None) is not None:
-        SMR_URL = SMR_URL % config("SMR_KEY")
+        SMR_URL = SMR_URL.format(config("SMR_KEY"))
     else:
-        SMR_URL = SMR_URL % "smr"
+        SMR_URL = SMR_URL.format("smr")
 
 
 def get_original_trace(key, positions, is_url=False):

--- a/api/env.default
+++ b/api/env.default
@@ -57,6 +57,6 @@ sessions_bucket=mobs
 sessions_region=us-east-1
 SITE_URL=
 sourcemaps_bucket=sourcemaps
-sourcemaps_reader=http://sourcemapreader-openreplay.app.svc.cluster.local:9000/sourcemaps/%s/sourcemaps
+sourcemaps_reader=http://sourcemapreader-openreplay.app.svc.cluster.local:9000/sourcemaps/{}/sourcemaps
 STAGE=default-foss
 TZ=UTC

--- a/ee/api/env.default
+++ b/ee/api/env.default
@@ -77,6 +77,6 @@ sessions_bucket=mobs
 sessions_region=us-east-1
 SITE_URL=
 sourcemaps_bucket=sourcemaps
-sourcemaps_reader=http://sourcemapreader-openreplay.app.svc.cluster.local:9000/sourcemaps/%s/sourcemaps
+sourcemaps_reader=http://sourcemapreader-openreplay.app.svc.cluster.local:9000/sourcemaps/{}/sourcemaps
 TRACE_PERIOD=300
 TZ=UTC


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated string formatting methods in sourcemaps processing for enhanced reliability and dynamic configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->