### PR TITLE
Fix volume paths for docker-compose

### DIFF
--- a/scripts/docker-compose/docker-compose.yaml
+++ b/scripts/docker-compose/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     image: bitnami/postgresql:${POSTGRES_VERSION}
     container_name: postgres
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/bitnami/postgresql/data
     networks:
       - openreplay-net
     environment:
@@ -15,7 +15,7 @@ services:
     image: bitnami/redis:${REDIS_VERSION}
     container_name: redis
     volumes:
-      - redisdata:/var/lib/postgresql/data
+      - redisdata:/bitnami/redis/data
     networks:
       - openreplay-net
     environment:


### PR DESCRIPTION
Currently the Docker volumes `pgdata` and `redisdata` remain empty. This is casued by wrong mount points.