### PR TITLE
Add verbose type

### DIFF
--- a/tracker/tracker/src/main/app/index.ts
+++ b/tracker/tracker/src/main/app/index.ts
@@ -161,6 +161,7 @@ type AppOptions = {
   }
 
   network?: NetworkOptions
+  verbose?: boolean
 } & WebworkerOptions &
   SessOptions
 


### PR DESCRIPTION
Saw this in the [docs](https://docs.openreplay.com/en/sdk/constructor/) but didn't see the type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `verbose` property in the application configuration, allowing users to enable detailed logging for improved debugging and runtime insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->