### PR TITLE
Fix (spot): tailwind behavior conflict with flex class

### DIFF
--- a/spot/entrypoints/notifications.js
+++ b/spot/entrypoints/notifications.js
@@ -13,10 +13,10 @@ export default defineUnlistedScript(() => {
 
   function injectCSS() {
     const cssText = `
-    .flex{display:flex}
-    .items-center {align-items:center}
-    .gap-3 {gap: .25rem}
-    .spinner {
+    .or-flex{display:flex}
+    .or-items-center {align-items:center}
+    .or-gap-3 {gap: .25rem}
+    .or-spinner {
         width: 18px;
         height: 18px;
         border: 2px solid rgba(0, 0, 0, 0.1);
@@ -40,10 +40,10 @@ export default defineUnlistedScript(() => {
     const message = event.data.message || "Recording has started successfully.";
 
     const notificationContent = `
-    <div class="flex gap-3 items-center">
-      <div class="spinner"></div>
+    <div class="or-flex or-gap-3 or-items-center">
+      <div class="or-spinner"></div>          
       <span>${message}</span>
-      </div>
+     </div>
     `;
 
     const notification = document.createElement("div");

--- a/spot/entrypoints/notifications.js
+++ b/spot/entrypoints/notifications.js
@@ -41,7 +41,7 @@ export default defineUnlistedScript(() => {
 
     const notificationContent = `
     <div class="or-flex or-gap-3 or-items-center">
-      <div class="or-spinner"></div>          
+      <div class="or-spinner"></div>
       <span>${message}</span>
      </div>
     `;


### PR DESCRIPTION
The flex class from the injected spot extension in notification.js causes the Tailwind pseudo-class to not be considered in certain cases, such as when applying a class like ‘flex md:hidden’. In this case, the md:hidden is no longer applied.

![Capture d’écran 2024-09-26 à 20 44 29](https://github.com/user-attachments/assets/46b7c91d-532f-45d2-84e6-76403a3e02a2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated CSS class names in notification content for improved consistency and to align with new naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->