### PR TITLE
Introducing OpenReplay Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Please refer to the [official OpenReplay documentation](https://docs.openreplay.
 - [Twitter](https://twitter.com/OpenReplayHQ) (Product updates, Great content)
 - [YouTube](https://www.youtube.com/channel/UCcnWlW-5wEuuPAwjTR1Ydxw) (How-to tutorials, past Community Calls)
 - [Website chat](https://openreplay.com) (Talk to us)
+- [OpenReplay Guru](https://gurubase.io/g/openreplay) (OpenReplay-focused AI to answer your questions.)
 
 ## Contributing
 
@@ -102,8 +103,3 @@ Also, feel free to join our [Slack](https://slack.openreplay.com) to ask questio
 
 This monorepo uses several licenses. See [LICENSE](/LICENSE) for more details.
 
-<p align="center">
-  <a href="https://gurubase.io/g/openreplay">
-    <img src="https://img.shields.io/badge/Gurubase-Ask%20OpenReplay%20Guru-006BFF" />
-  </a>
-</p>

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Please refer to the [official OpenReplay documentation](https://docs.openreplay.
 - [Twitter](https://twitter.com/OpenReplayHQ) (Product updates, Great content)
 - [YouTube](https://www.youtube.com/channel/UCcnWlW-5wEuuPAwjTR1Ydxw) (How-to tutorials, past Community Calls)
 - [Website chat](https://openreplay.com) (Talk to us)
-- [OpenReplay Guru](https://gurubase.io/g/openreplay) (OpenReplay-focused AI to answer your questions.)
+- [OpenReplay Guru](https://gurubase.io/g/openreplay) (OpenReplay-focused AI to answer your questions)
 
 ## Contributing
 
@@ -102,4 +102,3 @@ Also, feel free to join our [Slack](https://slack.openreplay.com) to ask questio
 ## License
 
 This monorepo uses several licenses. See [LICENSE](/LICENSE) for more details.
-

--- a/README.md
+++ b/README.md
@@ -101,3 +101,9 @@ Also, feel free to join our [Slack](https://slack.openreplay.com) to ask questio
 ## License
 
 This monorepo uses several licenses. See [LICENSE](/LICENSE) for more details.
+
+<p align="center">
+  <a href="https://gurubase.io/g/openreplay">
+    <img src="https://img.shields.io/badge/Gurubase-Ask%20OpenReplay%20Guru-006BFF" />
+  </a>
+</p>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [OpenReplay Guru](https://gurubase.io/g/openreplay) to Gurubase. OpenReplay Guru uses the data from this repo and data from the [docs](https://docs.openreplay.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "OpenReplay Guru", which highlights that OpenReplay now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable OpenReplay Guru in Gurubase, just let me know that's totally fine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new link to "OpenReplay Guru" for enhanced community support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->