### PR TITLE
feat: Add support for self-hosted Sentry instances with configurable URL

### DIFF
--- a/backend/pkg/integrations/clients/sentry.go
+++ b/backend/pkg/integrations/clients/sentry.go
@@ -20,6 +20,7 @@ type sentryConfig struct {
 	OrganizationSlug string `json:"organization_slug"`
 	ProjectSlug      string `json:"project_slug"`
 	Token            string `json:"token"`
+	URL              string `json:"url"`
 }
 
 type SentryEvent struct {
@@ -46,8 +47,14 @@ func (s *sentryClient) FetchSessionData(credentials interface{}, sessionID uint6
 		if val, ok := strCfg["token"].(string); ok {
 			cfg.Token = val
 		}
+		if val, ok := strCfg["url"].(string); ok {
+			cfg.URL = val
+		}
 	}
-	requestUrl := fmt.Sprintf("https://sentry.io/api/0/projects/%s/%s/issues/", cfg.OrganizationSlug, cfg.ProjectSlug)
+	if cfg.URL == "" {
+		cfg.URL = "https://sentry.io" // Default to hosted Sentry if not specified
+	}
+	requestUrl := fmt.Sprintf("%s/api/0/projects/%s/%s/issues/", cfg.URL, cfg.OrganizationSlug, cfg.ProjectSlug)
 
 	testCallLimit := 1
 	params := url.Values{}


### PR DESCRIPTION
## what

Adds support for self-hosted Sentry instances with configurable URL.

## why

sentry.io was hardcoded which prevented the use of self-hosted Sentry instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a customizable Sentry URL in the configuration settings.
- **Bug Fixes**
	- Improved handling of credentials related to the Sentry integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->