### PR TITLE
fix(frontend): for Past 7 Days range, return an exact 7.00 days timep…

### DIFF
--- a/frontend/app/types/app/period.js
+++ b/frontend/app/types/app/period.js
@@ -36,7 +36,7 @@ function getRange(rangeName, offset) {
             );
         case LAST_7_DAYS:
             return Interval.fromDateTimes(
-              now.minus({ days: 7 }).startOf("day"),
+              now.minus({ days: 7 }).endOf("day"),
               now.endOf("day")
             );
         case LAST_30_DAYS:


### PR DESCRIPTION
…eriod instead of 7.99 days timeperiod