### PR TITLE
Running buffer slicing when browser is idle

### DIFF
--- a/tracker/tracker/src/main/app/index.ts
+++ b/tracker/tracker/src/main/app/index.ts
@@ -1648,9 +1648,15 @@ export default class App {
         endIndex++;
       }
 
-      const messagesBatch = buffer.splice(0, endIndex);
-      this.postToWorker(messagesBatch);
-      res(null);
+      requestIdleCb(() => {
+        const messagesBatch = buffer.splice(0, endIndex);
+
+        const clonedBatch = JSON.parse(JSON.stringify(messagesBatch));
+
+        this.postToWorker(clonedBatch);
+
+        res(null);
+      })
     })
   }
 


### PR DESCRIPTION
This makes it so when the user has done an offline session and the buffer is uploading everything to OpenReplay, the browser and UI thread are not frozen for the duration of the upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced error handling during message processing, ensuring proper reporting of issues and maintaining data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->