### PR TITLE
refactor(auth): separate SSO support from enterprise edition

### DIFF
--- a/frontend/app/components/Login/SSOLogin.tsx
+++ b/frontend/app/components/Login/SSOLogin.tsx
@@ -14,7 +14,7 @@ interface SSOLoginProps {
 const SSOLogin = ({ authDetails, enforceSSO = false }: SSOLoginProps) => {
   const { userStore } = useStore();
   const { t } = useTranslation();
-  const { isEnterprise } = userStore;
+  const { isSSOSupported } = userStore;
 
   const getSSOLink = () =>
     window !== window.top
@@ -23,7 +23,7 @@ const SSOLogin = ({ authDetails, enforceSSO = false }: SSOLoginProps) => {
 
   const ssoLink = getSSOLink();
   const ssoButtonText = `${t('Login with SSO')} ${authDetails.ssoProvider ? `(${authDetails.ssoProvider})` : ''
-    }`;
+  }`;
 
   if (enforceSSO) {
     return (
@@ -47,7 +47,7 @@ const SSOLogin = ({ authDetails, enforceSSO = false }: SSOLoginProps) => {
         <Tooltip
           title={
             <div className="text-center">
-              {isEnterprise ? (
+              {isSSOSupported ? (
                 <span>
                   {t('SSO has not been configured.')}
                   <br />

--- a/frontend/app/mstore/userStore.ts
+++ b/frontend/app/mstore/userStore.ts
@@ -114,10 +114,12 @@ class UserStore {
   get isEnterprise() {
     return (
       this.account?.edition === 'ee' ||
-      this.account?.edition === 'msaas' ||
-      this.authStore.authDetails?.edition === 'ee' ||
-      this.authStore.authDetails?.edition === 'msaas'
+      this.authStore.authDetails?.edition === 'ee'
     );
+  }
+
+  get isSSOSupported() {
+    return this.isEnterprise || this.account?.edition === 'msaas' || this.authStore.authDetails?.edition === 'msaas';
   }
 
   get isLoggedIn() {


### PR DESCRIPTION
Add dedicated isSSOSupported property to correctly identify when SSO authentication is available, properly handling the 'msaas' edition case separately from enterprise edition checks. This fixes SSO visibility in the login interface.