### PR TITLE
feat(dashboard): set initial drill down period

### DIFF
--- a/frontend/app/components/Dashboard/components/WidgetWrapper/WidgetWrapperNew.tsx
+++ b/frontend/app/components/Dashboard/components/WidgetWrapper/WidgetWrapperNew.tsx
@@ -83,6 +83,7 @@ function WidgetWrapperNew(props: Props & RouteComponentProps) {
   });
 
   const onChartClick = () => {
+    dashboardStore.setDrillDownPeriod(dashboardStore.period);
     // if (!isWidget || isPredefined) return;
     props.history.push(
       withSiteId(

--- a/frontend/app/mstore/dashboardStore.ts
+++ b/frontend/app/mstore/dashboardStore.ts
@@ -34,7 +34,7 @@ export default class DashboardStore {
 
   comparisonFilter: Filter = new Filter();
 
-  drillDownPeriod: Record<string, any> = Period({ rangeName: LAST_7_DAYS });
+  drillDownPeriod: Record<string, any> = Period({ rangeName: LAST_24_HOURS });
 
   selectedDensity: number = 7; // depends on default drilldown, 7 points here!!!;
 


### PR DESCRIPTION
Change default drill down period from LAST_7_DAYS to LAST_24_HOURS and preserve current period when drilling down on chart click