### PR TITLE
Updated patch build from main 0e469fd056e2d80146660cde8eb6e4a7a949e476

### DIFF
--- a/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.22.2"
+AppVersion: "v1.22.3"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, To update the latest tag, run the following workflow.
https://github.com/openreplay/openreplay/actions/workflows/update-tag.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the displayed application version in the Helm chart metadata to v1.22.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->