### PR TITLE
Updated patch build from main 3ba40a4811cde3374f748576c9528e9c587e1853

### DIFF
--- a/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.10
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.22.23"
+AppVersion: "v1.22.24"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, To update the latest tag, run the following workflow.
https://github.com/openreplay/openreplay/actions/workflows/update-tag.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the application version in the frontend Helm chart metadata to v1.22.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->