### PR TITLE
feat(nginx): add integrations endpoint with CORS support

### DIFF
--- a/scripts/docker-compose/nginx.conf
+++ b/scripts/docker-compose/nginx.conf
@@ -54,6 +54,25 @@ server {
       add_header 'Access-Control-Allow-Headers' 'Content-Type,Authorization,Content-Encoding';
       add_header 'Access-Control-Expose-Headers' 'Content-Length';
     }
+    location /integrations/ {
+      rewrite ^/integrations/(.*) /$1 break;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+      proxy_set_header X-Forwarded-For $real_ip;
+      proxy_set_header X-Forwarded-Host $real_ip;
+      proxy_set_header X-Real-IP $real_ip;
+      proxy_set_header Host $host;
+      proxy_pass http://integrations-openreplay:8080;
+      proxy_read_timeout 300;
+      proxy_connect_timeout 120;
+      proxy_send_timeout 300;
+      # CORS Headers
+      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow-Methods' 'POST,PATCH,OPTIONS,DELETE';
+      add_header 'Access-Control-Allow-Headers' 'Content-Type,Authorization,Content-Encoding,X-Openreplay-Batch';
+      add_header 'Access-Control-Expose-Headers' 'Content-Length';
+    }
 
     location /api/ {
       rewrite ^/api/(.*) /$1 break;


### PR DESCRIPTION
Add new /integrations/ location block that proxies requests to
integrations-openreplay:8080 service. Includes proper CORS headers
for cross-origin requests and WebSocket upgrade support.

- Rewrite /integrations/ path to root
- Configure proxy headers for forwarding
- Set connection timeouts for stability
- Add CORS headers for API access


Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for proxying requests to the integrations backend via the `/integrations/` path.
  - Enabled CORS for integration endpoints, allowing cross-origin requests with various HTTP methods and headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->