### PR TITLE
fix: remove -b flag from git checkout in patch workflow

### DIFF
--- a/.github/workflows/patch-build-old.yaml
+++ b/.github/workflows/patch-build-old.yaml
@@ -91,7 +91,7 @@ jobs:
         set -exo pipefail
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git checkout -b $BRANCH_NAME
+        git checkout $BRANCH_NAME
         working_dir=$(pwd)
         function image_version(){
           local service=$1


### PR DESCRIPTION
Remove the -b flag from git checkout command as the branch already
exists and we just need to switch to it, not create it.

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
