### PR TITLE
fix: fetch entire git history

### DIFF
--- a/.github/workflows/patch-build-old.yaml
+++ b/.github/workflows/patch-build-old.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
       with:
-        fetch-depth: 4
+        fetch-depth: 0
         ref: ${{ github.event.inputs.tag }}
 
     - name: Set Remote with GITHUB_TOKEN


### PR DESCRIPTION
without the complete history, the git checkout will fail

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
