### PR TITLE
feat(deployment): Helper function to manage env merging with spefic keys skipping

### DIFF
--- a/scripts/helmcharts/openreplay/charts/chalice/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/chalice/templates/deployment.yaml
@@ -136,14 +136,8 @@ spec:
               value: '{{ .Values.global.email.emailSslCert }}'
             - name: EMAIL_FROM
               value: '{{ .Values.global.email.emailFrom }}'
-            {{- range $key, $val := .Values.global.env }}
-            - name: {{ $key }}
-              value: '{{ $val }}'
-            {{- end }}
-            {{- range $key, $val := .Values.env }}
-            - name: {{ $key }}
-              value: '{{ $val }}'
-            {{- end}}
+            {{- $skippedKeys := list "JWT_REFRESH_SECRET" "JWT_SPOT_REFRESH_SECRET" -}}
+            {{- include "openreplay.env" (dict "ctx" . "skippedKeys" $skippedKeys) | nindent 12}}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/scripts/helmcharts/openreplay/templates/_helpers.tpl
+++ b/scripts/helmcharts/openreplay/templates/_helpers.tpl
@@ -194,3 +194,18 @@ Create the volume mount config for redis TLS certificates
 name: {{ $secretName }}
 key: {{ $secretKey }}
 {{- end}}
+
+{{- /*
+{{- include "openreplay.env" (dict "ctx" . "skippedKeys" list("KEY1" "KEY2"))}}
+*/}}
+{{- define "openreplay.env" -}}
+{{- $ctx := .ctx -}}
+{{- $skippedKeys := .skippedKeys | default list -}}
+{{- $mergedEnv := merge $ctx.Values.env $ctx.Values.global.env -}}
+{{- range $key, $val := $mergedEnv }}
+{{- if not (has $key $skippedKeys) }}
+- name: {{ $key }}
+  value: '{{ $val }}'
+{{- end -}}
+{{- end}}
+{{- end}}


### PR DESCRIPTION
Merged .Values.global.env and .Values.env in deployment template, giving
priority to .Values.env for overlapping keys. Skipped secret keys from
automatic environment injection to prevent conflicts and improve
configuration flexibility.

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
