### PR TITLE
fix(helm): use bitnamilegacy images till we move images to own repo

### DIFF
--- a/scripts/helmcharts/openreplay/templates/job.yaml
+++ b/scripts/helmcharts/openreplay/templates/job.yaml
@@ -157,7 +157,7 @@ spec:
         - name: datadir
           mountPath: /mnt/efs
       - name: postgres-check
-        image: bitnami/postgresql:16.3.0
+        image: bitnamilegacy/postgresql:16.3.0
         env:
           - name: PGHOST
             value: "{{ .Values.global.postgresql.postgresqlHost }}"
@@ -297,7 +297,7 @@ spec:
           - name: {{ $key }}
             value: '{{ $val }}'
           {{- end }}
-        image: bitnami/postgresql:16.3.0
+        image: bitnamilegacy/postgresql:16.3.0
         command: 
         - /bin/bash
         - /opt/migrations/dbops.sh
@@ -310,7 +310,7 @@ spec:
           mountPath: /opt/migrations/
       {{- if or .Values.minio.enabled .Values.minio.forceInit }}
       - name: minio
-        image: bitnami/minio:2023.11.20
+        image: bitnamilegacy/minio:2023.11.20
         env:
           - name: OPENREPLAY_VERSION
             valueFrom:
@@ -453,7 +453,7 @@ spec:
           mountPath: /opt/openreplay
       {{- end }}
       - name: kafka
-        image: bitnami/kafka:2.6.0-debian-10-r30
+        image: bitnamilegacy/kafka:2.6.0-debian-10-r30
         env:
           - name: OPENREPLAY_VERSION
             valueFrom:


### PR DESCRIPTION
Switches image references from the current Bitnami registry to the bitnamilegacy registry for PostgreSQL, MinIO, and Kafka in the migration job template. This ensures compatibility with legacy image sources and avoids potential issues with image availability or changes in the main Bitnami repository.