### PR TITLE
fix(helm): use bitnamilegacy images for all charts

### DIFF
--- a/scripts/helmcharts/databases/charts/kafka/charts/zookeeper/values.yaml
+++ b/scripts/helmcharts/databases/charts/kafka/charts/zookeeper/values.yaml
@@ -75,7 +75,7 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/zookeeper
+  repository: bitnamilegacy/zookeeper
   tag: 3.8.0-debian-11-r74
   digest: ""
   ## Specify a imagePullPolicy
@@ -657,7 +657,7 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
+    repository: bitnamilegacy/bitnami-shell
     tag: 11-debian-11-r69
     digest: ""
     pullPolicy: IfNotPresent

--- a/scripts/helmcharts/databases/charts/kafka/values.yaml
+++ b/scripts/helmcharts/databases/charts/kafka/values.yaml
@@ -68,7 +68,7 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/kafka
+  repository: bitnamilegacy/kafka
   tag: 3.3.1-debian-11-r34
   digest: ""
   ## Specify a imagePullPolicy
@@ -761,7 +761,7 @@ externalAccess:
     ##
     image:
       registry: docker.io
-      repository: bitnami/kubectl
+      repository: bitnamilegacy/kubectl
       tag: 1.25.5-debian-11-r11
       digest: ""
       ## Specify a imagePullPolicy
@@ -1000,7 +1000,7 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
+    repository: bitnamilegacy/bitnami-shell
     tag: 11-debian-11-r71
     digest: ""
     pullPolicy: IfNotPresent
@@ -1080,7 +1080,7 @@ metrics:
     ##
     image:
       registry: docker.io
-      repository: bitnami/kafka-exporter
+      repository: bitnamilegacy/kafka-exporter
       tag: 1.6.0-debian-11-r48
       digest: ""
       ## Specify a imagePullPolicy
@@ -1316,7 +1316,7 @@ metrics:
     ##
     image:
       registry: docker.io
-      repository: bitnami/jmx-exporter
+      repository: bitnamilegacy/jmx-exporter
       tag: 0.17.2-debian-11-r37
       digest: ""
       ## Specify a imagePullPolicy

--- a/scripts/helmcharts/databases/charts/minio/values-production.yaml
+++ b/scripts/helmcharts/databases/charts/minio/values-production.yaml
@@ -18,7 +18,7 @@ global:
 ##
 image:
   registry: docker.io
-  repository: bitnami/minio
+  repository: bitnamilegacy/minio
   tag: 2020.10.9-debian-10-r6
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -66,7 +66,7 @@ clusterDomain: cluster.local
 ##
 clientImage:
   registry: docker.io
-  repository: bitnami/minio-client
+  repository: bitnamilegacy/minio-client
   tag: 2020.10.3-debian-10-r9
 
 ## Init containers parameters:
@@ -76,7 +76,7 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/minideb
+    repository: bitnamilegacy/minideb
     tag: buster
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.

--- a/scripts/helmcharts/databases/charts/minio/values.yaml
+++ b/scripts/helmcharts/databases/charts/minio/values.yaml
@@ -20,7 +20,7 @@ global:
 ##
 image:
   registry: docker.io
-  repository: bitnami/minio
+  repository: bitnamilegacy/minio
   tag: 2023.2.10-debian-11-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -68,7 +68,7 @@ clusterDomain: cluster.local
 ##
 clientImage:
   registry: docker.io
-  repository: bitnami/minio-client
+  repository: bitnamilegacy/minio-client
   tag: 2020.10.3-debian-10-r9
 
 ## Init containers parameters:
@@ -78,7 +78,7 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/minideb
+    repository: bitnamilegacy/minideb
     tag: buster
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.

--- a/scripts/helmcharts/databases/charts/postgresql/values-production.yaml
+++ b/scripts/helmcharts/databases/charts/postgresql/values-production.yaml
@@ -14,7 +14,7 @@ global:
 ##
 image:
   registry: docker.io
-  repository: bitnami/postgresql
+  repository: bitnamilegacy/postgresql
   tag: 11.9.0-debian-10-r48
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -50,7 +50,7 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/minideb
+    repository: bitnamilegacy/minideb
     tag: buster
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -656,7 +656,7 @@ metrics:
 
   image:
     registry: docker.io
-    repository: bitnami/postgres-exporter
+    repository: bitnamilegacy/postgres-exporter
     tag: 0.8.0-debian-10-r242
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/scripts/helmcharts/databases/charts/postgresql/values.yaml
+++ b/scripts/helmcharts/databases/charts/postgresql/values.yaml
@@ -14,7 +14,7 @@ global:
 ##
 image:
   registry: docker.io
-  repository: bitnami/postgresql
+  repository: bitnamilegacy/postgresql
   tag: 11.9.0-debian-10-r48
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -50,7 +50,7 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/minideb
+    repository: bitnamilegacy/minideb
     tag: buster
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -662,7 +662,7 @@ metrics:
 
   image:
     registry: docker.io
-    repository: bitnami/postgres-exporter
+    repository: bitnamilegacy/postgres-exporter
     tag: 0.8.0-debian-10-r242
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/scripts/helmcharts/databases/charts/redis/ci/production-sentinel-values.yaml
+++ b/scripts/helmcharts/databases/charts/redis/ci/production-sentinel-values.yaml
@@ -14,7 +14,7 @@ global:
 ##
 image:
   registry: docker.io
-  repository: bitnami/redis
+  repository: bitnamilegacy/redis
   ## Bitnami Redis(TM) image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
@@ -56,7 +56,7 @@ sentinel:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis-sentinel
+    repository: bitnamilegacy/redis-sentinel
     ## Bitnami Redis(TM) image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
@@ -526,7 +526,7 @@ metrics:
 
   image:
     registry: docker.io
-    repository: bitnami/redis-exporter
+    repository: bitnamilegacy/redis-exporter
     tag: 1.5.3-debian-10-r14
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -627,7 +627,7 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
+    repository: bitnamilegacy/bitnami-shell
     tag: "10"
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
@@ -657,7 +657,7 @@ sysctlImage:
   enabled: false
   command: []
   registry: docker.io
-  repository: bitnami/bitnami-shell
+  repository: bitnamilegacy/bitnami-shell
   tag: "10"
   pullPolicy: Always
   ## Optionally specify an array of imagePullSecrets.

--- a/scripts/helmcharts/databases/charts/redis/values.yaml
+++ b/scripts/helmcharts/databases/charts/redis/values.yaml
@@ -14,7 +14,7 @@ global:
 ##
 image:
   registry: docker.io
-  repository: bitnami/redis
+  repository: bitnamilegacy/redis
   ## Bitnami Redis(TM) image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
@@ -59,7 +59,7 @@ sentinel:
   ##
   image:
     registry: docker.io
-    repository: bitnami/redis-sentinel
+    repository: bitnamilegacy/redis-sentinel
     ## Bitnami Redis(TM) image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
@@ -185,7 +185,7 @@ sentinel:
     ##
     image:
       registry: docker.io
-      repository: bitnami/redis-sentinel-exporter
+      repository: bitnamilegacy/redis-sentinel-exporter
       tag: 1.7.1-debian-10-r105
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.
@@ -800,7 +800,7 @@ metrics:
 
   image:
     registry: docker.io
-    repository: bitnami/redis-exporter
+    repository: bitnamilegacy/redis-exporter
     tag: 1.20.0-debian-10-r12
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -932,7 +932,7 @@ volumePermissions:
   enabled: false
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
+    repository: bitnamilegacy/bitnami-shell
     tag: "10"
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
@@ -975,7 +975,7 @@ sysctlImage:
   enabled: false
   command: []
   registry: docker.io
-  repository: bitnami/bitnami-shell
+  repository: bitnamilegacy/bitnami-shell
   tag: "10"
   pullPolicy: Always
   ## Optionally specify an array of imagePullSecrets.

--- a/scripts/helmcharts/toolings/charts/kyverno/values.yaml
+++ b/scripts/helmcharts/toolings/charts/kyverno/values.yaml
@@ -304,7 +304,7 @@ webhooksCleanup:
   # -- Create a helm pre-delete hook to cleanup webhooks.
   enabled: false
   # -- `kubectl` image to run commands for deleting webhooks.
-  image: bitnami/kubectl:latest
+  image: bitnamilegacy/kubectl:latest
   # -- Image pull secrets
   imagePullSecrets: []
 
@@ -394,7 +394,7 @@ cleanupJobs:
       # -- (string) Image registry
       registry: ~
       # -- Image repository
-      repository: bitnami/kubectl
+      repository: bitnamilegacy/kubectl
       # -- Image tag
       # Defaults to `latest` if omitted
       tag: '1.26.4'
@@ -437,7 +437,7 @@ cleanupJobs:
       # -- (string) Image registry
       registry: ~
       # -- Image repository
-      repository: bitnami/kubectl
+      repository: bitnamilegacy/kubectl
       # -- Image tag
       # Defaults to `latest` if omitted
       tag: '1.26.4'


### PR DESCRIPTION
Switch all Bitnami image references in Helm chart values files to the bitnamilegacy repositories. This ensures compatibility with legacy Bitnami images and prevents issues with image pulls from deprecated or migrated repositories.