### PR TITLE
fix(redis): improve AOF file recovery logic on startup

### DIFF
--- a/scripts/helmcharts/databases/charts/redis/templates/redis-master-statefulset.yaml
+++ b/scripts/helmcharts/databases/charts/redis/templates/redis-master-statefulset.yaml
@@ -179,12 +179,15 @@ spec:
                   - /bin/bash
                   - -c
                   - |
-                    # Fix AOF files if they exist
-                    for aof_file in /data/appendonlydir/appendonly.aof.*.incr.aof; do
-                      if [ -f "$aof_file" ]; then
-                        redis-check-aof --fix "$aof_file" > /dev/null 2>&1 || rm "$aof_file"
-                      fi
-                    done
+                     # Fix AOF files if they exist
+                     if [ -f /data/appendonlydir/appendonly.aof ]; then
+                       redis-check-aof --fix /data/appendonlydir/appendonly.aof > /dev/null 2>&1
+                     fi
+                     for aof_file in /data/appendonlydir/appendonly.aof.*.incr.aof; do
+                       if [ -f "$aof_file" ]; then
+                         redis-check-aof --fix "$aof_file" > /dev/null 2>&1
+                       fi
+                     done
             preStop:
               exec:
                 command:


### PR DESCRIPTION
Refactor the postStart lifecycle hook to first check and fix the main
appendonly.aof file if it exists, then iterate and fix any incremental
AOF files. This ensures both the main and incremental AOF files are
properly recovered, reducing the risk of data loss or startup issues
due to corrupted AOF files.

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
