### PR TITLE
feat(sink): sync session files before SessionEnd

### DIFF
--- a/backend/internal/sink/sessionwriter/writer.go
+++ b/backend/internal/sink/sessionwriter/writer.go
@@ -77,6 +77,10 @@ func (w *SessionWriter) sync(sid uint64) error {
 	return sess.Sync()
 }
 
+func (w *SessionWriter) SyncSession(sid uint64) error {
+	return w.sync(sid)
+}
+
 func (w *SessionWriter) Close(sid uint64) error {
 	sessObj, ok := w.sessions.LoadAndDelete(sid)
 	if !ok {


### PR DESCRIPTION
Add SyncSession method to SessionWriter and call it before publishing SessionEnd message to ensure files are fully written and fsynced before storage service reads them.