### PR TITLE
refactor(ci): replace docker layer caching with buildx

### DIFF
--- a/.github/workflows/alerts-ee.yaml
+++ b/.github/workflows/alerts-ee.yaml
@@ -73,10 +73,18 @@ jobs:
           kubeconfig: ${{ secrets.EE_KUBECONFIG }} # Use content of kubeconfig in secret.
         id: setcontext
 
-      # Caching docker images
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
+      # Set up Docker Buildx for caching support
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Cache Docker layers using GitHub's native cache
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-alerts-ee-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-alerts-ee-
 
       - name: Building and Pushing api image
         id: build-image

--- a/.github/workflows/alerts.yaml
+++ b/.github/workflows/alerts.yaml
@@ -63,10 +63,18 @@ jobs:
           kubeconfig: ${{ secrets.OSS_KUBECONFIG }} # Use content of kubeconfig in secret.
         id: setcontext
 
-      # Caching docker images
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
+      # Set up Docker Buildx for caching support
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Cache Docker layers using GitHub's native cache
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-alerts-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-alerts-
 
       - name: Building and Pushing Alerts image
         id: build-image

--- a/.github/workflows/api-ee.yaml
+++ b/.github/workflows/api-ee.yaml
@@ -70,10 +70,18 @@ jobs:
           kubeconfig: ${{ secrets.EE_KUBECONFIG }} # Use content of kubeconfig in secret.
         id: setcontext
 
-      # Caching docker images
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
+      # Set up Docker Buildx for caching support
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Cache Docker layers using GitHub's native cache
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-api-ee-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-api-ee-
 
       - name: Building and Pushing api image
         id: build-image

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -61,10 +61,18 @@ jobs:
           kubeconfig: ${{ secrets.OSS_KUBECONFIG }} # Use content of kubeconfig in secret.
         id: setcontext
 
-      # Caching docker images
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
+      # Set up Docker Buildx for caching support
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Cache Docker layers using GitHub's native cache
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-api-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-api-
 
       - name: Building and Pushing api image
         id: build-image

--- a/.github/workflows/assist-stats.yaml
+++ b/.github/workflows/assist-stats.yaml
@@ -59,10 +59,18 @@ jobs:
           kubeconfig: ${{ secrets.OSS_KUBECONFIG }} # Use content of kubeconfig in secret.
         id: setcontext
 
-      # Caching docker images
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
+      # Set up Docker Buildx for caching support
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Cache Docker layers using GitHub's native cache
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-assist-stats-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-assist-stats-
 
       - name: Building and Pushing assist-stats image
         id: build-image

--- a/.github/workflows/crons-ee.yaml
+++ b/.github/workflows/crons-ee.yaml
@@ -73,10 +73,18 @@ jobs:
           kubeconfig: ${{ secrets.EE_KUBECONFIG }} # Use content of kubeconfig in secret.
         id: setcontext
 
-      # Caching docker images
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
+      # Set up Docker Buildx for caching support
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Cache Docker layers using GitHub's native cache
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-crons-ee-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-crons-ee-
 
       - name: Building and Pushing api image
         id: build-image

--- a/.github/workflows/sourcemaps-reader-ee.yaml
+++ b/.github/workflows/sourcemaps-reader-ee.yaml
@@ -62,10 +62,18 @@ jobs:
           kubeconfig: ${{ secrets.EE_KUBECONFIG }} # Use content of kubeconfig in secret.
         id: setcontext
 
-      # Caching docker images
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
+      # Set up Docker Buildx for caching support
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Cache Docker layers using GitHub's native cache
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-sourcemaps-reader-ee-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-sourcemaps-reader-ee-
 
       - name: Building and Pushing sourcemaps-reader image
         id: build-image

--- a/.github/workflows/sourcemaps-reader.yaml
+++ b/.github/workflows/sourcemaps-reader.yaml
@@ -58,10 +58,18 @@ jobs:
           kubeconfig: ${{ secrets.OSS_KUBECONFIG }} # Use content of kubeconfig in secret.
         id: setcontext
 
-      # Caching docker images
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
+      # Set up Docker Buildx for caching support
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Cache Docker layers using GitHub's native cache
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-sourcemaps-reader-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-sourcemaps-reader-
 
       - name: Building and Pushing sourcemaps-reader image
         id: build-image


### PR DESCRIPTION
Replace deprecated satackey/action-docker-layer-caching action with
the modern docker/setup-buildx-action and GitHub's native cache
action across all workflow files.

This change:
- Uses docker/setup-buildx-action@v3 for Docker Buildx setup
- Uses actions/cache@v4 with /tmp/.buildx-cache for layer caching
- Provides unique cache keys per workflow and runner OS
- Maintains cache efficiency through restore-keys fallback

Affected workflows:
- alerts-ee, alerts
- api-ee, api
- assist-stats
- crons-ee
- sourcemaps-reader-ee, sourcemaps-reader

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
