### PR TITLE
feat(helm): add optional SCIM authentication secrets

### DIFF
--- a/scripts/helmcharts/openreplay/charts/chalice/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/chalice/templates/deployment.yaml
@@ -136,6 +136,16 @@ spec:
               value: '{{ .Values.global.email.emailSslCert }}'
             - name: EMAIL_FROM
               value: '{{ .Values.global.email.emailFrom }}'
+            - name: SCIM_ACCESS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  {{- include "openreplay.secrets" (dict "key" "scim-access-secret-key" "ctx" .) | nindent 18 }}
+                  optional: true
+            - name: SCIM_REFRESH_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  {{- include "openreplay.secrets" (dict "key" "scim-refresh-secret-key" "ctx" .) | nindent 18 }}
+                  optional: true
             {{- $skippedKeys := list "JWT_REFRESH_SECRET" "JWT_SPOT_REFRESH_SECRET" -}}
             {{- include "openreplay.env" (dict "ctx" . "skippedKeys" $skippedKeys) | nindent 12}}
             - name: POD_NAMESPACE

--- a/scripts/helmcharts/openreplay/templates/secrets.yaml
+++ b/scripts/helmcharts/openreplay/templates/secrets.yaml
@@ -17,6 +17,12 @@
   {{- $_ := set $secretData "token-secret" (.Values.global.tokenSecret | b64enc) }}
   {{- $_ := set $secretData "jwt-refresh-secret" (.Values.global.jwtRefreshSecret | b64enc) }}
   {{- $_ := set $secretData "jwt-spot-refresh-secret" (.Values.global.jwtSpotRefreshSecret | b64enc) }}
+  {{- if .Values.global.scimAccessSecretKey }}
+  {{- $_ := set $secretData "scim-access-secret-key" (.Values.global.scimAccessSecretKey | b64enc) }}
+  {{- end }}
+  {{- if .Values.global.scimRefreshSecretKey }}
+  {{- $_ := set $secretData "scim-refresh-secret-key" (.Values.global.scimRefreshSecretKey | b64enc) }}
+  {{- end }}
 {{- end }}
 {{- if gt (len $secretData) 0 }}
 apiVersion: v1
@@ -37,7 +43,7 @@ There are 2 kinds of secrets:
 1. External application secrets like PG, S3, clickhouse etc
 2. OpenReplay Application secrets
 
-Type 1 can have clubed or dedicated secrets, and passwords keys are customizable.
+Type 1 can have clubed or dedicated secrets
 Type 2 will be clubbed to a single secret, password keys are constant.
 */ -}}
 {{- range $key, $value := $secretData }}

--- a/scripts/helmcharts/vars.yaml
+++ b/scripts/helmcharts/vars.yaml
@@ -122,6 +122,10 @@ global:
   tokenSecret: "{{randAlphaNum 20}}"
   jwtRefreshSecret: "{{randAlphaNum 20}}"
   jwtSpotRefreshSecret: "{{randAlphaNum 20}}"
+  # SCIM authentication secrets for chalice service (optional)
+  # Uncomment and set these values if SCIM authentication is required
+  # scimAccessSecretKey: "{{randAlphaNum 20}}"
+  # scimRefreshSecretKey: "{{randAlphaNum 20}}"
   # In case of multiple nodes in the kubernetes cluster,
   # we'll have to create an RWX PVC for shared components.
   # If it's a single node, we'll use hostVolume, which is the default for the community/oss edition.


### PR DESCRIPTION
Add support for SCIM authentication in the chalice service by
introducing two optional secret keys:
- scimAccessSecretKey: Used for SCIM access token authentication
- scimRefreshSecretKey: Used for SCIM refresh token authentication

These secrets are conditionally included in the deployment when
configured in values, allowing SCIM integration without requiring
changes for existing deployments.

The secrets are marked as optional in the deployment to maintain
backward compatibility with installations that don't use SCIM.

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
