### PR TITLE
feat(cli): add auto-update check for CLI during release upgrades

### DIFF
--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -5,6 +5,8 @@ OR_DIR="/var/lib/openreplay"
 APP_NS="${APP_NS:-app}"
 DB_NS="${DB_NS:-db}"
 OR_REPO="${OR_REPO:-'https://github.com/openreplay/openreplay'}"
+# Detect where the CLI is installed
+CLI_PATH="$(command -v openreplay 2>/dev/null || echo "/bin/openreplay")"
 # For example HELM_OPTIONS="--set dbMigrationUpstreamBranch=dev"
 #HELM_OPTIONS=""
 # If you want to install the dev version. It can be any branch or tag.
@@ -431,11 +433,11 @@ function upgrade() {
         fi
 
         # Compare if download was successful
-        if [[ -f "$tmp_cli" ]] && ! cmp -s "$tmp_cli" /bin/openreplay; then
+        if [[ -f "$tmp_cli" ]] && ! cmp -s "$tmp_cli" "$CLI_PATH"; then
             log warn "A new version of the OpenReplay CLI is available."
             log warn "Updating CLI to the latest version..."
-            sudo mv "$tmp_cli" /bin/openreplay
-            sudo chmod +x /bin/openreplay
+            sudo mv "$tmp_cli" "$CLI_PATH"
+            sudo chmod +x "$CLI_PATH"
             log info "CLI has been updated successfully."
             log info "Please run the upgrade command again to complete the upgrade:"
             log info "${BWHITE}RELEASE_UPGRADE=1 openreplay -u${NC}"
@@ -463,8 +465,8 @@ function upgrade() {
     # Update the version
     busybox sed -i "s/fromVersion.*/fromVersion: ${or_new_version}/" vars.yaml
     patch_version
-    sudo mv ./openreplay-cli /bin/openreplay
-    sudo chmod +x /bin/openreplay
+    sudo mv ./openreplay-cli "$CLI_PATH"
+    sudo chmod +x "$CLI_PATH"
     sudo mv ./vars.yaml "$OR_DIR"
     sudo rm -rf "$OR_DIR/openreplay" || true
     sudo cp -rf "${tmp_dir}/openreplay" "$OR_DIR/"


### PR DESCRIPTION
When performing a release upgrade (RELEASE_UPGRADE=1), the CLI now
checks if a newer version exists on GitHub before proceeding. If
detected, it automatically updates itself and prompts the user to
re-run the upgrade command with the new CLI version.

This ensures users always use the correct CLI version for their target
release, preventing compatibility issues during upgrades.

The check compares the remote CLI file with the local installation and
falls back gracefully if the remote fetch fails, allowing the upgrade
to continue.

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
