### PR TITLE
fix(ci): skip FOSS builds for assist-api service

### DIFF
--- a/.github/workflows/patch-build.yaml
+++ b/.github/workflows/patch-build.yaml
@@ -205,6 +205,7 @@ jobs:
                 cd "$WORKING_DIR"
 
                 local foss_build_args="" ee_build_args="" build_script="$BUILD_SCRIPT_NAME"
+                local is_ee_only=false
 
                 # Determine build configuration based on service type
                 if grep -q "$service" "$BACKEND_SERVICES_FILE"; then
@@ -217,6 +218,8 @@ jobs:
                     cd backend
                     foss_build_args="nil $service"
                     ee_build_args="ee $service"
+                    # Special case: assist-api is EE-only
+                    [[ $service == "assist-api" ]] && is_ee_only=true
                 else
                     # Non-backend service
                     case "$service" in
@@ -240,9 +243,11 @@ jobs:
                 local version
                 version=$(image_version "$service")
 
-                # Build FOSS and EE versions
-                build_service "$service" "$version" "$foss_build_args"
-                build_service "$service" "$version" "$foss_build_args" "$BUILD_SCRIPT_NAME" "$DOCKER_REPO_ARM" "arm64"
+                # Build FOSS and EE versions (skip FOSS for assist-api)
+                if [[ $is_ee_only == false ]]; then
+                    build_service "$service" "$version" "$foss_build_args"
+                    build_service "$service" "$version" "$foss_build_args" "$BUILD_SCRIPT_NAME" "$DOCKER_REPO_ARM" "arm64"
+                fi
                 build_service "$service" "${version}-ee" "$ee_build_args"
 
                 # Building managed


### PR DESCRIPTION
- Add is_ee_only flag to identify EE-only services
- Set flag to true specifically for assist-api
- Skip FOSS AMD64 and ARM64 builds when is_ee_only is true
- All other services continue to build both FOSS and EE versions
