### PR TITLE
Use bitnami legacy image in CLI cleanup

### DIFF
--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -397,7 +397,7 @@ function cleanup() {
     kubectl run minio-cleanup -n "${APP_NS}" \
         --restart=Never \
         --env MINIO_HOST="$MINIO_HOST" \
-        --image bitnami/minio:2020.10.9-debian-10-r6 -- /bin/sh -c "
+        --image bitnamilegacy/minio -- /bin/sh -c "
       mc alias set minio $MINIO_HOST $MINIO_ACCESS_KEY $MINIO_SECRET_KEY &&
       mc rm --recursive --dangerous --force --older-than ${delete_from_number_days}d minio/mobs
       "


### PR DESCRIPTION
The `bitnami/minio` image no longer exists. Use `bitnamilegacy/minio` instead.