### PR TITLE
chore(docker): upgrade Redis and MinIO versions #3994

### DIFF
--- a/scripts/docker-compose/common.env
+++ b/scripts/docker-compose/common.env
@@ -14,7 +14,7 @@ COMMON_ASSIST_KEY="change_me_assist_key"
 ## DB versions
 ######################################
 POSTGRES_VERSION="17.2.0"
-REDIS_VERSION="6.0.12-debian-10-r33"
-MINIO_VERSION="2023.2.10-debian-11-r1"
+REDIS_VERSION="7"
+MINIO_VERSION="2025.7.23"
 CLICKHOUSE_VERSION="25.1-alpine"
 ######################################


### PR DESCRIPTION
- Upgrade Redis from 6.0.12 to version 7
- Upgrade MinIO from 2023.2.10 to 2025.7.23

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
