### PR TITLE
fix(helm): remove conditional wrapper around redis config

### DIFF
--- a/scripts/helmcharts/openreplay/templates/_helpers.tpl
+++ b/scripts/helmcharts/openreplay/templates/_helpers.tpl
@@ -106,7 +106,6 @@ Create the name of the service account to use
 Create the environment configuration for REDIS_STRING
 */}}
 {{- define "openreplay.env.redis_string" -}}
-{{- if .enabled }}
 {{- $scheme := (eq (.tls | default dict).enabled true) | ternary "rediss" "redis" -}}
 {{- $auth := "" -}}
 {{- if or .existingSecret .redisPassword -}}
@@ -124,7 +123,6 @@ Create the environment configuration for REDIS_STRING
 {{- end}}
 - name: REDIS_STRING
   value: '{{ $scheme }}://{{ $auth }}{{ .redisHost }}:{{ .redisPort }}'
-{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
The redis_string helper template was wrapped in an unnecessary
conditional check that prevented the Redis connection string from
being generated when needed. This removes the outer conditional
while preserving the internal logic for TLS scheme selection,
authentication, and connection string formatting.
