### PR TITLE
fix(github): align parameter names with base class interface

### DIFF
--- a/api/chalicelib/core/issue_tracking/github_issue.py
+++ b/api/chalicelib/core/issue_tracking/github_issue.py
@@ -28,9 +28,9 @@ class GithubIntegrationIssue(BaseIntegrationIssue):
 
         return meta
 
-    def create_new_assignment(self, project_id, title, description, assignee,
+    def create_new_assignment(self, integration_project_id, title, description, assignee,
                               issue_type):
-        repoId = project_id
+        repoId = integration_project_id
         assignees = [assignee]
         labels = [str(issue_type)]
 
@@ -59,11 +59,11 @@ class GithubIntegrationIssue(BaseIntegrationIssue):
     def get_by_ids(self, saved_issues):
         results = []
         for i in saved_issues:
-            results.append(self.get(project_id=i["integrationProjectId"], assignment_id=i["id"]))
+            results.append(self.get(integration_project_id=i["integrationProjectId"], assignment_id=i["id"]))
         return {"issues": results}
 
-    def get(self, project_id, assignment_id):
-        repoId = project_id
+    def get(self, integration_project_id, assignment_id):
+        repoId = integration_project_id
         issueNumber = assignment_id
         issue = self.__client.get(f"/repositories/{repoId}/issues/{issueNumber}")
         issue = formatter.issue(issue)
@@ -72,17 +72,17 @@ class GithubIntegrationIssue(BaseIntegrationIssue):
                                  self.__client.get(f"/repositories/{repoId}/issues/{issueNumber}/comments")]
         return issue
 
-    def comment(self, project_id, assignment_id, comment):
-        repoId = project_id
+    def comment(self, integration_project_id, assignment_id, comment):
+        repoId = integration_project_id
         issueNumber = assignment_id
         commentCreated = self.__client.post(f"/repositories/{repoId}/issues/{issueNumber}/comments",
                                             body={"body": comment})
         return formatter.comment(commentCreated)
 
-    def get_metas(self, project_id):
+    def get_metas(self, integration_project_id):
         current_user = self.get_current_user()
         try:
-            users = self.__client.get(f"/repositories/{project_id}/collaborators")
+            users = self.__client.get(f"/repositories/{integration_project_id}/collaborators")
         except Exception as e:
             users = []
         users = [formatter.user(u) for u in users]
@@ -92,7 +92,7 @@ class GithubIntegrationIssue(BaseIntegrationIssue):
         return {"provider": self.provider.lower(),
                 'users': users,
                 'issueTypes': [formatter.label(l) for l in
-                               self.__client.get(f"/repositories/{project_id}/labels")]
+                               self.__client.get(f"/repositories/{integration_project_id}/labels")]
                 }
 
     def get_projects(self):


### PR DESCRIPTION
## Summary
This PR fixes the GitHub integration issue creation bug reported in #4068.

## Problem
When creating a GitHub issue from a session recording, users get a 500 Internal Server Error:
```
TypeError: GithubIntegrationIssue.create_new_assignment() got an unexpected keyword argument 'integration_project_id'
```

## Root Cause
The `GithubIntegrationIssue` class methods used `project_id` as the parameter name, but:
- The `BaseIntegrationIssue` abstract class defines `integration_project_id`
- The caller in `sessions_assignments.py` passes `integration_project_id`

## Changes
Renamed `project_id` → `integration_project_id` in all methods of `github_issue.py`:
- `create_new_assignment()`
- `get()`
- `get_by_ids()` (internal call)
- `comment()`
- `get_metas()`

## Testing
- Verified the parameter names now match the base class interface
- The fix aligns with how other integrations (like Jira) implement these methods

Fixes #4068