### PR TITLE
feat(redis): update image to ghcr.io/openreplay/redis

### DIFF
--- a/scripts/helmcharts/databases/charts/redis/values.yaml
+++ b/scripts/helmcharts/databases/charts/redis/values.yaml
@@ -13,8 +13,8 @@ global:
 ## ref: https://hub.docker.com/r/bitnami/redis/tags/
 ##
 image:
-  registry: docker.io
-  repository: rjshrjndrn/redis
+  registry: ghcr.io
+  repository: openreplay/redis
   ## Bitnami Redis(TM) image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##

--- a/scripts/helmcharts/databases/values.yaml
+++ b/scripts/helmcharts/databases/values.yaml
@@ -86,6 +86,8 @@ affinity: {}
 ## Child charts
 redis:
   image:
+    registry: ghcr.io
+    repository: openreplay/redis
     tag: 7
   enabled: true
   fullnameOverride: redis


### PR DESCRIPTION
Switch Redis image registry and repository to ghcr.io/openreplay/redis in both
the main and subchart values files. This aligns Redis deployments with the
OpenReplay-maintained image and centralizes image management.

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
