### PR TITLE
fix(api): source ClickHouse password from secret

### DIFF
--- a/scripts/helmcharts/openreplay/charts/api/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/api/templates/deployment.yaml
@@ -78,7 +78,8 @@ spec:
             - name: CH_USERNAME
               value: '{{ .Values.global.clickhouse.username }}'
             - name: CH_PASSWORD
-              value: '{{ .Values.global.clickhouse.password }}'
+              valueFrom:
+                secretKeyRef: {{- include "openreplay.secrets" (dict "key" "clickhouse-password" "ctx" .) | nindent 18 }}
             - name: CLICKHOUSE_STRING
               value: '{{ .Values.global.clickhouse.chHost }}:{{.Values.global.clickhouse.service.webPort}}/{{.Values.env.ch_db}}'
             - name: CLICKHOUSE_HTTP_STRING


### PR DESCRIPTION
Switches ClickHouse password environment variable in the API deployment
to use Kubernetes secret reference instead of plain value.

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
