### PR TITLE
Update Redis version for docker compose

### DIFF
--- a/scripts/docker-compose/common.env
+++ b/scripts/docker-compose/common.env
@@ -14,7 +14,7 @@ COMMON_ASSIST_KEY="change_me_assist_key"
 ## DB versions
 ######################################
 POSTGRES_VERSION="17.2.0"
-REDIS_VERSION="7"
+REDIS_VERSION="7.4"
 MINIO_VERSION="2025.7.23"
 CLICKHOUSE_VERSION="25.1-alpine"
 ######################################


### PR DESCRIPTION
There is no `7` tag for bitnamilegacy/redis. Replaced it with `7.4` which does exist