### PR TITLE
feat(ci): support building images from custom git refs

### DIFF
--- a/.github/workflows/build-base-images.yaml
+++ b/.github/workflows/build-base-images.yaml
@@ -6,6 +6,10 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
     inputs:
+      ref:
+        description: 'Git ref (branch/tag/SHA) to build from'
+        required: false
+        default: 'dev'
       images:
         description: 'Specific images to build (comma-separated, e.g., postgres,nginx) or "all" for all images'
         required: false
@@ -18,6 +22,10 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ${{ github.repository_owner }}
+  # NOTE:
+  # - schedule workflows are always evaluated from the repository default branch.
+  # - to build Docker images from the dev branch anyway, we explicitly checkout dev.
+  TARGET_REF: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.ref) || 'dev' }}
 
 jobs:
   prepare:
@@ -28,22 +36,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_REF }}
 
       - name: Set up build matrix
         id: set-matrix
         run: |
           IMAGES_INPUT="${{ github.event.inputs.images }}"
-          
-          # Define all available images (excluding alpine, ingress-controller, maintnance)
-          ALL_IMAGES='["kafka", "minio", "nginx", "postgres", "redis"]'
-          
+
+          # Define all available images with their versions
+          # Format: image:version or just image (for single version)
+          ALL_IMAGES='["kafka", "minio", "postgres:17", "postgres:18", "valkey"]'
+
           if [[ "$IMAGES_INPUT" == "all" ]] || [[ -z "$IMAGES_INPUT" ]]; then
             MATRIX="$ALL_IMAGES"
           else
             # Convert comma-separated input to JSON array
+            # Support both "postgres" (builds all versions) and "postgres:17" (specific version)
             MATRIX=$(echo "$IMAGES_INPUT" | jq -R -c 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')
           fi
-          
+
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
           echo "Building images: $MATRIX"
 
@@ -61,6 +73,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_REF }}
+
+      - name: Parse image and version
+        id: parse
+        run: |
+          IMAGE_FULL="${{ matrix.image }}"
+
+          # Split image:version format
+          if [[ "$IMAGE_FULL" == *":"* ]]; then
+            IMAGE_NAME="${IMAGE_FULL%%:*}"
+            IMAGE_VERSION="${IMAGE_FULL##*:}"
+            CONTEXT_PATH="./scripts/dockerfiles/${IMAGE_NAME}/${IMAGE_VERSION}"
+          else
+            IMAGE_NAME="$IMAGE_FULL"
+            IMAGE_VERSION=""
+            CONTEXT_PATH="./scripts/dockerfiles/${IMAGE_NAME}"
+          fi
+
+          echo "name=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "version=$IMAGE_VERSION" >> $GITHUB_OUTPUT
+          echo "context=$CONTEXT_PATH" >> $GITHUB_OUTPUT
+          echo "Parsed: name=$IMAGE_NAME, version=$IMAGE_VERSION, context=$CONTEXT_PATH"
 
       - name: Set up platform pair
         id: platform
@@ -71,50 +106,59 @@ jobs:
       - name: Extract version from Dockerfile
         id: app-version
         run: |
-          DOCKERFILE="./scripts/dockerfiles/${{ matrix.image }}/Dockerfile"
-          
-          # Extract version based on the image
-          case "${{ matrix.image }}" in
-            kafka)
-              VERSION=$(grep -oP "kafka~\K[0-9]+" "$DOCKERFILE" || echo "3")
-              ;;
-            minio)
-              VERSION=$(grep -oP "minio>=0\.2025\K[0-9]{4}" "$DOCKERFILE" || echo "2025")
-              ;;
-            nginx)
-              VERSION=$(grep -oP "FROM openresty/openresty:\K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" "$DOCKERFILE" || echo "1.27.1.2")
-              ;;
-            postgres)
-              VERSION=$(grep -oP "postgresql-\K[0-9]+" "$DOCKERFILE" | head -1 || echo "17")
-              ;;
-            redis)
-              VERSION=$(grep -oP "redis>=\K[0-9]+" "$DOCKERFILE" || echo "7")
-              ;;
-            *)
-              VERSION="latest"
-              ;;
-          esac
-          
+          DOCKERFILE="${{ steps.parse.outputs.context }}/Dockerfile"
+          IMAGE_NAME="${{ steps.parse.outputs.name }}"
+
+          # If version is explicitly provided in matrix, use it
+          if [[ -n "${{ steps.parse.outputs.version }}" ]]; then
+            VERSION="${{ steps.parse.outputs.version }}"
+          else
+            # Extract version based on the image
+            case "$IMAGE_NAME" in
+              kafka)
+                VERSION=$(grep -oP "kafka~\K[0-9]+" "$DOCKERFILE" || echo "3")
+                ;;
+              minio)
+                VERSION=$(grep -oP "minio>=0\.\K[0-9]{4}" "$DOCKERFILE" || echo "2025")
+                ;;
+              nginx)
+                VERSION=$(grep -oP "FROM openresty/openresty:\K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" "$DOCKERFILE" || echo "1.27.1.2")
+                ;;
+              postgres)
+                VERSION=$(grep -oP "postgresql-\K[0-9]+" "$DOCKERFILE" | head -1 || echo "17")
+                ;;
+              valkey)
+                VERSION=$(grep -oP "valkey>=\K[0-9]+" "$DOCKERFILE" | head -1 || echo "8")
+                ;;
+              *)
+                VERSION="latest"
+                ;;
+            esac
+          fi
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Detected version for ${{ matrix.image }}: $VERSION"
+          echo "major_version=${VERSION%%.*}" >> $GITHUB_OUTPUT
+          echo "Detected version for $IMAGE_NAME: $VERSION"
 
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ steps.parse.outputs.name }}
           tags: |
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ matrix.image == 'postgres:18' || (matrix.image != 'postgres:17' && steps.parse.outputs.version == '') }}
             type=raw,value=${{ steps.app-version.outputs.version }}
+            type=raw,value=${{ steps.app-version.outputs.major_version }},enable=${{ steps.parse.outputs.name == 'valkey' }}
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=sha,prefix={{date 'YYYYMMDD'}}-
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: nick-fields/retry@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -125,10 +169,10 @@ jobs:
         with:
           project: ${{ secrets.DEPOT_PROJECT_ID }}
           token: ${{ secrets.DEPOT_TOKEN }}
-          context: ./scripts/dockerfiles/${{ matrix.image }}
+          context: ${{ steps.parse.outputs.context }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ steps.parse.outputs.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -139,7 +183,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.image }}-${{ steps.platform.outputs.pair }}
+          name: digests-${{ steps.parse.outputs.name }}-${{ steps.parse.outputs.version || 'latest' }}-${{ steps.platform.outputs.pair }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -155,12 +199,35 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_REF }}
+
+      - name: Parse image and version
+        id: parse
+        run: |
+          IMAGE_FULL="${{ matrix.image }}"
+
+          # Split image:version format
+          if [[ "$IMAGE_FULL" == *":"* ]]; then
+            IMAGE_NAME="${IMAGE_FULL%%:*}"
+            IMAGE_VERSION="${IMAGE_FULL##*:}"
+            CONTEXT_PATH="./scripts/dockerfiles/${IMAGE_NAME}/${IMAGE_VERSION}"
+          else
+            IMAGE_NAME="$IMAGE_FULL"
+            IMAGE_VERSION=""
+            CONTEXT_PATH="./scripts/dockerfiles/${IMAGE_NAME}"
+          fi
+
+          echo "name=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "version=$IMAGE_VERSION" >> $GITHUB_OUTPUT
+          echo "context=$CONTEXT_PATH" >> $GITHUB_OUTPUT
+          echo "Parsed: name=$IMAGE_NAME, version=$IMAGE_VERSION, context=$CONTEXT_PATH"
 
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-${{ matrix.image }}-*
+          pattern: digests-${{ steps.parse.outputs.name }}-${{ steps.parse.outputs.version || 'latest' }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -169,60 +236,69 @@ jobs:
       - name: Extract version from Dockerfile
         id: app-version
         run: |
-          DOCKERFILE="./scripts/dockerfiles/${{ matrix.image }}/Dockerfile"
-          
-          # Extract version based on the image
-          case "${{ matrix.image }}" in
-            kafka)
-              VERSION=$(grep -oP "kafka~\K[0-9]+" "$DOCKERFILE" || echo "3")
-              ;;
-            minio)
-              VERSION=$(grep -oP "minio>=0\.2025\K[0-9]{4}" "$DOCKERFILE" || echo "2025")
-              ;;
-            nginx)
-              VERSION=$(grep -oP "FROM openresty/openresty:\K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" "$DOCKERFILE" || echo "1.27.1.2")
-              ;;
-            postgres)
-              VERSION=$(grep -oP "postgresql-\K[0-9]+" "$DOCKERFILE" | head -1 || echo "17")
-              ;;
-            redis)
-              VERSION=$(grep -oP "redis>=\K[0-9]+" "$DOCKERFILE" || echo "7")
-              ;;
-            *)
-              VERSION="latest"
-              ;;
-          esac
-          
+          DOCKERFILE="${{ steps.parse.outputs.context }}/Dockerfile"
+          IMAGE_NAME="${{ steps.parse.outputs.name }}"
+
+          # If version is explicitly provided in matrix, use it
+          if [[ -n "${{ steps.parse.outputs.version }}" ]]; then
+            VERSION="${{ steps.parse.outputs.version }}"
+          else
+            # Extract version based on the image
+            case "$IMAGE_NAME" in
+              kafka)
+                VERSION=$(grep -oP "kafka~\K[0-9]+" "$DOCKERFILE" || echo "3")
+                ;;
+              minio)
+                VERSION=$(grep -oP "minio>=0\.\K[0-9]{4}" "$DOCKERFILE" || echo "2025")
+                ;;
+              nginx)
+                VERSION=$(grep -oP "FROM openresty/openresty:\K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" "$DOCKERFILE" || echo "1.27.1.2")
+                ;;
+              postgres)
+                VERSION=$(grep -oP "postgresql-\K[0-9]+" "$DOCKERFILE" | head -1 || echo "17")
+                ;;
+              valkey)
+                VERSION=$(grep -oP "valkey>=\K[0-9]+" "$DOCKERFILE" | head -1 || echo "8")
+                ;;
+              *)
+                VERSION="latest"
+                ;;
+            esac
+          fi
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Detected version for ${{ matrix.image }}: $VERSION"
+          echo "major_version=${VERSION%%.*}" >> $GITHUB_OUTPUT
+          echo "Detected version for $IMAGE_NAME: $VERSION"
 
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ steps.parse.outputs.name }}
           tags: |
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ matrix.image == 'postgres:18' || (matrix.image != 'postgres:17' && steps.parse.outputs.version == '') }}
             type=raw,value=${{ steps.app-version.outputs.version }}
+            type=raw,value=${{ steps.app-version.outputs.major_version }},enable=${{ steps.parse.outputs.name == 'valkey' }}
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=sha,prefix={{date 'YYYYMMDD'}}-
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: nick-fields/retry@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
 
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ steps.parse.outputs.name }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ steps.parse.outputs.name }}:${{ steps.app-version.outputs.version }}
 
   notify:
     name: Notify Build Status
@@ -251,4 +327,3 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEB_HOOK }}
           SLACK_USERNAME: "OR Bot"
           SLACK_MESSAGE: "Base images built successfully :white_check_mark:"
-


### PR DESCRIPTION
Allow specifying a git ref (branch, tag, or SHA) when triggering the
build-base-images workflow. Ensures images can be built from branches
other than the default, especially for workflow_dispatch events.

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
