### PR TITLE
feat(upgrade): migrate from k8s to nginx ingress controller

### DIFF
--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -475,8 +475,8 @@ function migrate_ingress_controller() {
         kubectl delete serviceaccount -n "${APP_NS}" -l app.kubernetes.io/name=ingress-nginx --ignore-not-found=true
 
         # Delete old IngressClass (may conflict with new one)
+        # Delete old IngressClass only if managed by old controller
         kubectl delete ingressclass openreplay --ignore-not-found=true 2>/dev/null || true
-        kubectl delete ingressclass nginx --ignore-not-found=true 2>/dev/null || true
 
         # Delete old admission webhooks that may block new controller
         kubectl delete validatingwebhookconfiguration -l app.kubernetes.io/name=ingress-nginx --ignore-not-found=true 2>/dev/null || true


### PR DESCRIPTION
Add automatic migration from kubernetes/ingress-nginx to
nginx/nginx-ingress controller for v1.24.0+ upgrades. The migration
cleanly removes old controller resources (deployments, services,
configmaps, RBAC, webhooks) that conflict with the new controller,
preserves old configuration as backup, and applies new CRDs.

This handles the incompatible configuration structure between the two
controllers by removing the old ingress-nginx.controller block from
vars.yaml while backing it up for reference, allowing new defaults to
be applied during helm upgrade.

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
