### PR TITLE
refactor(helm): split image registry and repository in chart values

### DIFF
--- a/scripts/helmcharts/openreplay/charts/alerts/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/alerts/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/alerts/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/alerts/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/alerts"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: alerts
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/api/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/api/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/api/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/api/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/api"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: api
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/assets/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/assets/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/assets/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/assets/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/assets"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: assets
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/assist-api/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/assist-api/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/assist-api/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/assist-api/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/assist-api"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: assist-api
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/assist-stats/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/assist-stats/templates/deployment.yaml
@@ -35,9 +35,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/assist-stats/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/assist-stats/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/assist-stats"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: assist-stats
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/assist/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/assist/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/assist/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/assist/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/assist"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: assist
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/canvases/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/canvases/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/canvases/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/canvases/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/canvases"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: canvases
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/chalice/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/chalice/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/chalice/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/chalice/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/chalice"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: chalice
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/connector/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/connector/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/connector/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/connector/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/connector"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: connector
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/db/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/db/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/db/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/db/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/db"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: db
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/ender/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/ender/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/ender/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/ender/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/ender"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: ender
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/frontend/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/frontend/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/frontend"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: frontend
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/heuristics/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/heuristics/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/heuristics/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/heuristics/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/heuristics"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: heuristics
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/http/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/http/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/http/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/http/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/http"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: http
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/images/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/images/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/images/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/images/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/images"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: images
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/integrations/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/integrations/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/integrations/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/integrations/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/integrations"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: integrations
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/sink/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/sink/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/sink/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/sink/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/sink"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: sink
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/sourcemapreader/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/sourcemapreader/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/sourcemapreader/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/sourcemapreader/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/sourcemapreader"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: sourcemapreader
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/spot/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/spot/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/spot/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/spot/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/spot"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: spot
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/storage/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/storage/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.global.enterpriseEditionLicense }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-ee"
           {{- else }}
-          image: "{{ tpl .Values.image.repository . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ tpl .Values.image.registry . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.healthCheck}}

--- a/scripts/helmcharts/openreplay/charts/storage/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/storage/values.yaml
@@ -5,7 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: "{{ .Values.global.openReplayContainerRegistry }}/storage"
+  registry: "{{ .Values.global.openReplayContainerRegistry }}"
+  repository: storage
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/scripts/helmcharts/openreplay/charts/utilities/templates/api-crons.yaml
+++ b/scripts/helmcharts/openreplay/charts/utilities/templates/api-crons.yaml
@@ -44,7 +44,7 @@ spec:
           {{- end }}
           containers:
           - name: report-cron
-            image: "{{ tpl $job.image.repository . }}:{{ $job.image.tag | default .Chart.AppVersion }}-ee"
+            image: "{{ tpl $job.image.registry . }}/{{ $job.image.repository }}:{{ $job.image.tag | default .Chart.AppVersion }}-ee"
             imagePullPolicy: "{{ $job.image.pullPolicy}}"
             env:
               {{- range $key, $val := .Values.global.env }}

--- a/scripts/helmcharts/openreplay/charts/utilities/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/utilities/values.yaml
@@ -21,7 +21,8 @@ telemetry:
   # Midnight 12.05
   cron: "5 12 * * *"
   image:
-    repository: "{{ .Values.global.openReplayContainerRegistry }}/crons"
+    registry: "{{ .Values.global.openReplayContainerRegistry }}"
+    repository: crons
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -34,7 +35,8 @@ apiCrons:
     # Midnight 12.05
     cron: "0 * * * *"
     image:
-      repository: "{{ .Values.global.openReplayContainerRegistry }}/crons"
+      registry: "{{ .Values.global.openReplayContainerRegistry }}"
+      repository: crons
       pullPolicy: Always
       # Overrides the image tag whose default is the chart appVersion.
       tag: ""
@@ -45,7 +47,8 @@ apiCrons:
     # Monday morning 5am
     cron: "0 5 * * 1"
     image:
-      repository: "{{ .Values.global.openReplayContainerRegistry }}/crons"
+      registry: "{{ .Values.global.openReplayContainerRegistry }}"
+      repository: crons
       pullPolicy: Always
       # Overrides the image tag whose default is the chart appVersion.
       tag: ""
@@ -56,7 +59,8 @@ apiCrons:
     # Midnight 1.05
     cron: "5 1 * * *"
     image:
-      repository: "{{ .Values.global.openReplayContainerRegistry }}/crons"
+      registry: "{{ .Values.global.openReplayContainerRegistry }}"
+      repository: crons
       pullPolicy: Always
       # Overrides the image tag whose default is the chart appVersion.
       tag: ""
@@ -67,7 +71,8 @@ apiCrons:
     # Every 18 min
     cron: "*/18 * * * *"
     image:
-      repository: "{{ .Values.global.openReplayContainerRegistry }}/crons"
+      registry: "{{ .Values.global.openReplayContainerRegistry }}"
+      repository: crons
       pullPolicy: Always
       # Overrides the image tag whose default is the chart appVersion.
       tag: ""
@@ -78,7 +83,8 @@ apiCrons:
     # Sunday at 5am
     cron: "0 5 * * 0"
     image:
-      repository: "{{ .Values.global.openReplayContainerRegistry }}/crons"
+      registry: "{{ .Values.global.openReplayContainerRegistry }}"
+      repository: crons
       pullPolicy: Always
       # Overrides the image tag whose default is the chart appVersion.
       tag: ""

--- a/scripts/helmcharts/openreplay/templates/job.yaml
+++ b/scripts/helmcharts/openreplay/templates/job.yaml
@@ -171,7 +171,7 @@ spec:
         - name: datadir
           mountPath: /mnt/efs
       - name: postgres-check
-        image: "{{.Values.postgresql.image.repository}}:{{.Values.postgresql.image.tag}}"
+        image: "{{.Values.postgresql.image.registry}}/{{.Values.postgresql.image.repository}}:{{.Values.postgresql.image.tag}}"
         env:
           - name: PGHOST
             value: "{{ .Values.global.postgresql.postgresqlHost }}"
@@ -209,7 +209,7 @@ spec:
               exit 101
             }
       - name: clickhouse-check
-        image: "{{.Values.clickhouse.image.repository}}:{{.Values.clickhouse.image.tag}}"
+        image: "{{.Values.clickhouse.image.registry}}/{{.Values.clickhouse.image.repository}}:{{.Values.clickhouse.image.tag}}"
         env:
           {{- range $key, $val := .Values.global.env }}
           - name: {{ $key }}
@@ -300,7 +300,7 @@ spec:
           - name: {{ $key }}
             value: '{{ $val }}'
           {{- end }}
-        image: "{{.Values.postgresql.image.repository}}:{{.Values.postgresql.image.tag}}"
+        image: "{{.Values.postgresql.image.registry}}/{{.Values.postgresql.image.repository}}:{{.Values.postgresql.image.tag}}"
         command: 
         - /bin/bash
         - /opt/migrations/dbops.sh
@@ -313,7 +313,7 @@ spec:
           mountPath: /opt/migrations/
       {{- if or .Values.minio.enabled .Values.minio.forceInit }}
       - name: minio
-        image: "{{.Values.minio.image.repository}}:{{.Values.minio.image.tag}}"
+        image: "{{.Values.minio.image.registry}}/{{.Values.minio.image.repository}}:{{.Values.minio.image.tag}}"
         env:
           - name: OPENREPLAY_VERSION
             valueFrom:
@@ -445,7 +445,7 @@ spec:
           mountPath: /opt/openreplay
       {{- end }}
       - name: kafka
-        image: "{{.Values.kafka.image.repository}}:{{.Values.kafka.image.tag}}"
+        image: "{{.Values.kafka.image.registry}}/{{.Values.kafka.image.repository}}:{{.Values.kafka.image.tag}}"
         env:
           - name: OPENREPLAY_VERSION
             valueFrom:
@@ -487,7 +487,7 @@ spec:
           mountPath: /opt/migrations/
         {{- end}}
       - name: clickhouse
-        image: "{{.Values.clickhouse.image.repository}}:{{.Values.clickhouse.image.tag}}"
+        image: "{{.Values.clickhouse.image.registry}}/{{.Values.clickhouse.image.repository}}:{{.Values.clickhouse.image.tag}}"
         env:
           - name: OPENREPLAY_VERSION
             valueFrom:

--- a/scripts/helmcharts/openreplay/values.yaml
+++ b/scripts/helmcharts/openreplay/values.yaml
@@ -4,11 +4,13 @@ migrationJob:
 
 postgresql:
   image:
+    registry: docker.io
     repository: bitnamilegacy/postgresql
     tag: 17.6.0
 
 kafka:
   image:
+    registry: docker.io
     repository: bitnamilegacy/kafka
     tag: 3.9
 
@@ -66,12 +68,14 @@ minio:
   # Force initialize minio, even if the instance is not provisioned by OR
   forceInit: false
   image:
+    registry: docker.io
     repository: bitnamilegacy/minio
     tag: 2025.7.23
 
 clickhouse: &clickhouse
   password: ""
   image:
+    registry: docker.io
     repository: clickhouse/clickhouse-server
     tag: 25.9-alpine
 


### PR DESCRIPTION
Separate image.registry and image.repository fields across all OpenReplay
charts to allow independent configuration of container registry and image
names. Update deployment templates to construct full image paths by
combining registry and repository values.

This change provides better flexibility for using alternative container
registries while maintaining consistent image naming conventions.

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
