### PR TITLE
fix(clickhouse): remove duplicate ORDER BY clause in product_analytics.users table

### DIFF
--- a/scripts/schema/db/init_dbs/clickhouse/create/init_schema.sql
+++ b/scripts/schema/db/init_dbs/clickhouse/create/init_schema.sql
@@ -189,7 +189,6 @@ CREATE TABLE IF NOT EXISTS product_analytics.users
     _is_deleted          UInt8 DEFAULT 0,
     _timestamp           DateTime DEFAULT now()
 ) ENGINE = ReplacingMergeTree(_timestamp, _is_deleted)
-      ORDER BY (project_id, "$user_id")
       PARTITION BY toYYYYMM(_timestamp)
       ORDER BY (project_id, "$user_id")
       TTL _deleted_at + INTERVAL 1 DAY DELETE WHERE _deleted_at != '1970-01-01 00:00:00'


### PR DESCRIPTION
## Summary

Fixes critical ClickHouse migration failure caused by duplicate ORDER BY clause in product_analytics.users table.

## Changes

Removed duplicate ORDER BY clause and reordered table clauses to follow correct ClickHouse syntax:
ENGINE -> PARTITION BY -> ORDER BY -> TTL -> SETTINGS

## Impact

- Fixes syntax error that prevented ClickHouse migration from completing
- Ensures all product_analytics tables are created successfully
- Resolves "Unknown table" errors in filters and events API