### PR TITLE
fix(webAnimations): add missing check for last keyframe in animation finish event

### DIFF
--- a/tracker/tracker/src/main/modules/webAnimations.ts
+++ b/tracker/tracker/src/main/modules/webAnimations.ts
@@ -23,6 +23,7 @@ function webAnimations(app: App, options: Options = {}) {
       'finish',
       () => {
         const lastKF = anim.effect.getKeyframes().at(-1)
+        if (!lastKF) return
         const computedStyle = getComputedStyle(el)
         const keys = Object.keys(lastKF).filter((p) => !toIgnore.includes(p))
         // @ts-ignore


### PR DESCRIPTION
In some cases `anim.effect.getKeyframes()` is empty, which makes `at(-1)` return `undefined`, which, in turn, makes `Object.keys(lastKF)` throw.