### PR TITLE
fix postgresql.enabled

### DIFF
--- a/scripts/helmcharts/databases/values.yaml
+++ b/scripts/helmcharts/databases/values.yaml
@@ -111,6 +111,7 @@ postgresql:
     registry: ghcr.io
     repository: openreplay/postgres
     tag: 17
+  enabled: true
   resources:
     limits:
       cpu: 1
@@ -226,9 +227,6 @@ clickhouse:
   image:
     tag: "25.11-alpine"
   enabled: false
-
-postgreql:
-  enabled: true
 
 # For enterpriseEdition Only
 vault:


### PR DESCRIPTION
There is a typo in variable name `postgreql.enabled`, I have changed it to proper variable name `postgresql.enabled` and placed it after `image:` variable to match overall `values.yaml` style, through I don't like it.