### PR TITLE
refactor(cleanup): replace kubectl run with pod manifest for MinIO

### DIFF
--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -394,13 +394,31 @@ function cleanup() {
     MINIO_SECRET_KEY=$(yq 'explode(.) | .global.s3.secretKey' ${OR_DIR}/vars.yaml)
     MINIO_HOST=$(yq 'explode(.) | .global.s3.endpoint' ${OR_DIR}/vars.yaml)
     kubectl delete po -n "${APP_NS}" minio-cleanup &>/dev/null || true
-    kubectl run minio-cleanup -n "${APP_NS}" \
-        --restart=Never \
-        --env MINIO_HOST="$MINIO_HOST" \
-        --image bitnami/minio:2020.10.9-debian-10-r6 -- /bin/sh -c "
-      mc alias set minio $MINIO_HOST $MINIO_ACCESS_KEY $MINIO_SECRET_KEY &&
-      mc rm --recursive --dangerous --force --older-than ${delete_from_number_days}d minio/mobs
-      "
+    cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: minio-cleanup
+  namespace: ${APP_NS}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: minio-cleanup
+    image: ghcr.io/openreplay/minio
+    command: ["/bin/bash"]
+    args:
+      - -c
+      - |
+        mc alias set minio \$MINIO_HOST \$MINIO_ACCESS_KEY \$MINIO_SECRET_KEY
+        mc rm --recursive --dangerous --force --older-than ${delete_from_number_days}d minio/mobs
+    env:
+    - name: MINIO_HOST
+      value: "$MINIO_HOST"
+    - name: MINIO_ACCESS_KEY
+      value: "$MINIO_ACCESS_KEY"
+    - name: MINIO_SECRET_KEY
+      value: "$MINIO_SECRET_KEY"
+EOF
     log info "Postgres data cleanup process initiated. Postgres will automatically vacuum deleted rows when the database is idle. This may take up a few days to free the disk space."
     log info "Minio (where recordings are stored) cleanup process initiated."
     log info "Run ${BWHITE}openreplay -s${GREEN} to check the status of the cleanup process and available disk space."


### PR DESCRIPTION
Replaced the usage of `kubectl run` with a declarative pod manifest for
MinIO cleanup. This improves compatibility and aligns with best practices
for Kubernetes resource management.

Signed-off-by: rjshrjndrn <rjshrjndrn@gmail.com>
