### PR TITLE
chore(postgres): add compatibility for postgres 18

### DIFF
--- a/scripts/helmcharts/openreplay/templates/job.yaml
+++ b/scripts/helmcharts/openreplay/templates/job.yaml
@@ -224,7 +224,7 @@ spec:
         args:
           - |
             lowVersion=16.4
-            highVersion=17
+            highVersion=18
             pg_version=`psql -c "SHOW server_version;" -t | tr -d ' '`
             echo $pg_version |\
               awk -v pg_version=$pg_version -v low="$lowVersion" -v high="$highVersion" -F. '{


### PR DESCRIPTION
Hi all

I have been using postgres 18 with openreplay, no issues :)

I would like to upgrade to the new openreplay version and it gives me a compatibility error.

Here to PR to change it, hope that's fine!