### PR TITLE
feat: add scroll mode to session replay player

### DIFF
--- a/frontend/app/components/Session/Player/ReplayPlayer/PlayerInst.tsx
+++ b/frontend/app/components/Session/Player/ReplayPlayer/PlayerInst.tsx
@@ -62,6 +62,7 @@ function Player(props: IProps) {
   const { fullscreenOff } = uiPlayerStore;
   const { bottomBlock } = uiPlayerStore;
   const { fullscreen } = uiPlayerStore;
+  const { scrollMode } = uiPlayerStore;
   const defaultHeight = getDefaultPanelHeight();
   const [panelHeight, setPanelHeight] = React.useState(defaultHeight);
   const { activeTab, fullView } = props;
@@ -85,6 +86,12 @@ function Player(props: IProps) {
   React.useEffect(() => {
     playerContext.player.scale();
   }, [bottomBlock, fullscreen, playerContext.player, activeTab, fullView]);
+
+  React.useEffect(() => {
+    if (playerContext.player) {
+      playerContext.player.toggleScrollMode(scrollMode);
+    }
+  }, [scrollMode, playerContext.player]);
 
   if (!playerContext.player) return null;
 

--- a/frontend/app/components/Session/Player/ReplayPlayer/useShortcuts.ts
+++ b/frontend/app/components/Session/Player/ReplayPlayer/useShortcuts.ts
@@ -15,6 +15,7 @@ function useShortcuts({
   openPrevSession,
   setActiveTab,
   disableDevtools,
+  toggleScrollMode,
 }: {
   skipInterval: keyof typeof SKIP_INTERVALS;
   fullScreenOn: () => void;
@@ -24,6 +25,7 @@ function useShortcuts({
   openPrevSession: () => void;
   setActiveTab: (tab: string) => void;
   disableDevtools?: boolean;
+  toggleScrollMode?: () => void;
 }) {
   const { player, store } = useContext(PlayerContext);
 
@@ -84,6 +86,8 @@ function useShortcuts({
           case 'A':
             player.pause();
             return setActiveTab('EVENTS');
+          case 'S':
+            return toggleScrollMode?.();
           default:
             break;
         }

--- a/frontend/app/components/Session_/Player/Controls/Controls.tsx
+++ b/frontend/app/components/Session_/Player/Controls/Controls.tsx
@@ -17,6 +17,7 @@ import {
   LaunchPerformanceShortcut,
   LaunchStateShortcut,
   LaunchXRaShortcut,
+  LaunchScrollModeShortcut,
 } from 'Components/Session_/Player/Controls/components/KeyboardHelp';
 import { signalService } from 'App/services';
 import {
@@ -38,7 +39,7 @@ import {
   DashboardOutlined,
   ClusterOutlined,
 } from '@ant-design/icons';
-import { ArrowDownUp, ListCollapse, Merge, Timer } from 'lucide-react';
+import { ArrowDownUp, ListCollapse, Merge, Timer, ScanLine } from 'lucide-react';
 import { ReduxTime } from 'Components/Session_/Player/Controls/Time';
 
 import ControlButton from './ControlButton';
@@ -105,10 +106,12 @@ function Controls({ setActiveTab, activeTab, fullView }: any) {
       permissions.includes('SERVICE_DEV_TOOLS')
     );
   const { fullscreen } = uiPlayerStore;
+  const { scrollMode } = uiPlayerStore;
   const { bottomBlock } = uiPlayerStore;
   const { toggleBottomBlock } = uiPlayerStore;
   const { fullscreenOn } = uiPlayerStore;
   const { fullscreenOff } = uiPlayerStore;
+  const { toggleScrollMode } = uiPlayerStore;
   const { changeSkipInterval } = uiPlayerStore;
   const { skipInterval } = uiPlayerStore;
   const showStorageRedux = !uiPlayerStore.hiddenHints.storage;
@@ -150,6 +153,7 @@ function Controls({ setActiveTab, activeTab, fullView }: any) {
     openPrevSession: prevHandler,
     setActiveTab,
     disableDevtools,
+    toggleScrollMode,
   });
 
   React.useEffect(() => {
@@ -279,6 +283,8 @@ function Controls({ setActiveTab, activeTab, fullView }: any) {
               disabled={disabled}
               events={events}
               activeTab={activeTab}
+              scrollMode={scrollMode}
+              toggleScrollMode={toggleScrollMode}
             />
 
             <FullScreenButton
@@ -300,6 +306,8 @@ interface IDevtoolsButtons {
   disabled: boolean;
   events: any[];
   activeTab?: string;
+  scrollMode?: boolean;
+  toggleScrollMode?: () => void;
 }
 
 const DevtoolsButtons = observer(
@@ -310,6 +318,8 @@ const DevtoolsButtons = observer(
     disabled,
     events,
     activeTab,
+    scrollMode,
+    toggleScrollMode,
   }: IDevtoolsButtons) => {
     const { t } = useTranslation();
     const { aiSummaryStore, integrationsStore } = useStore();
@@ -509,6 +519,18 @@ const DevtoolsButtons = observer(
             shorten={showIcons}
           />
         ) : null}
+        <ControlButton
+          popover={
+            <div className="flex items-center gap-2">
+              <LaunchScrollModeShortcut />
+              <div>{t('Scroll below the fold')}</div>
+            </div>
+          }
+          customKey="scrollMode"
+          label={showIcons ? <ScanLine size={14} strokeWidth={2} /> : t('Scroll')}
+          onClick={() => toggleScrollMode?.()}
+          active={scrollMode}
+        />
         {possibleAudio.length ? (
           <DropdownAudioPlayer audioEvents={possibleAudio} />
         ) : null}

--- a/frontend/app/components/Session_/Player/Controls/components/KeyboardHelp.tsx
+++ b/frontend/app/components/Session_/Player/Controls/components/KeyboardHelp.tsx
@@ -56,6 +56,9 @@ export function LaunchMoreUserInfoShortcut() {
 export function LaunchOptionsMenuShortcut() {
   return <Key label="⇧ + M" />;
 }
+export function LaunchScrollModeShortcut() {
+  return <Key label="⇧ + S" />;
+}
 export function PlayNextSessionShortcut() {
   return <Key label="⇧ + >" />;
 }
@@ -84,6 +87,7 @@ export function ShortcutGrid() {
       <Cell shortcut="⇧ + F" text="Play Session in Fullscreen" />
       <Cell shortcut="Space" text="Play/Pause Session" />
       <Cell shortcut="⇧ + X" text="Launch X-Ray" />
+      <Cell shortcut="⇧ + S" text="Toggle Scroll Mode" />
       <Cell shortcut="⇧ + A" text="Launch User Actions" />
       <Cell shortcut="⇧ + I" text="Launch More User Info" />
       <Cell shortcut="⇧ + M" text="Launch Options Menu" />

--- a/frontend/app/mstore/uiPlayerStore.ts
+++ b/frontend/app/mstore/uiPlayerStore.ts
@@ -59,6 +59,7 @@ const DATA_SOURCE = '__DATA_SOURCE__';
 
 export default class UiPlayerStore {
   fullscreen = false;
+  scrollMode = false;
   showOnlySearchEvents = false;
   showSearchEventsSwitchButton = false;
 
@@ -108,6 +109,10 @@ export default class UiPlayerStore {
 
   fullscreenOn = () => {
     this.fullscreen = true;
+  };
+
+  toggleScrollMode = () => {
+    this.scrollMode = !this.scrollMode;
   };
 
   toggleBottomBlock = (block: number) => {

--- a/frontend/app/player/web/WebPlayer.ts
+++ b/frontend/app/player/web/WebPlayer.ts
@@ -237,6 +237,21 @@ export default class WebPlayer extends Player {
     });
   };
 
+  toggleScrollMode = (enabled?: boolean) => {
+    const isCurrentlyScrollMode =
+      this.screen.getScaleMode() === ScaleMode.AdjustParentHeight;
+    const shouldEnable = enabled !== undefined ? enabled : !isCurrentlyScrollMode;
+
+    this.screen.setScaleMode(
+      shouldEnable ? ScaleMode.AdjustParentHeight : ScaleMode.Embed,
+    );
+    this.scale();
+  };
+
+  isScrollMode = (): boolean => {
+    return this.screen?.getScaleMode() === ScaleMode.AdjustParentHeight;
+  };
+
   toggleUserName = (name?: string) => {
     this.screen.cursor.showTag(name);
   };


### PR DESCRIPTION
## Summary

- Adds a **Scroll Mode** toggle to the session replay player that lets users scroll below the fold to view content that was rendered but not visible in the user's viewport during recording
- Accessible via a **"Scroll"** button in the player toolbar and **Shift+S** keyboard shortcut
- Leverages the existing `ScaleMode.AdjustParentHeight` mechanism (already used by clickmaps) and makes it user-toggleable at runtime

## Problem

When watching session recordings, you can only see the portion of the page visible in the user's viewport at the time of recording. If the page had content below the fold (e.g., terms and conditions, footer text, form fields), there was no way to inspect it — the iframe is locked to `overflow: hidden` and sized to the viewport.

This is useful for auditing that content was present during the user's session (e.g., legal disclosures, required form fields).

## How It Works

1. User presses `Shift+S` or clicks the "Scroll" button in the toolbar
2. The player switches from `ScaleMode.Embed` (centered, viewport-sized) to `ScaleMode.AdjustParentHeight` (top-aligned, full `document.body.scrollHeight`)
3. A spacer div forces the parent container to become scrollable
4. User can scroll down to see all recorded page content
5. Pressing `Shift+S` again returns to the normal centered view

## Changes

| File | Change |
|------|--------|
| `Screen.ts` | Added `getScaleMode()`/`setScaleMode()`, scroll spacer management, cleanup on mode switch |
| `WebPlayer.ts` | Added `toggleScrollMode()` and `isScrollMode()` methods |
| `uiPlayerStore.ts` | Added `scrollMode` observable + `toggleScrollMode` action |
| `PlayerInst.tsx` | Added `useEffect` to sync store state → player |
| `useShortcuts.ts` | Added `Shift+S` → `toggleScrollMode` |
| `Controls.tsx` | Added "Scroll" `ControlButton` with `ScanLine` icon |
| `KeyboardHelp.tsx` | Added `⇧ + S` shortcut documentation |

## Test plan

- [ ] Open a session recording with a page taller than the viewport
- [ ] Press `Shift+S` — player should expand and become scrollable
- [ ] Scroll down to verify content below the fold is visible
- [ ] Press `Shift+S` again — player should snap back to centered viewport mode
- [ ] Click the "Scroll" button in the toolbar — same toggle behavior
- [ ] Verify play/pause, timeline, inspector mode, and devtools panels work in scroll mode
- [ ] Open keyboard shortcuts modal — verify `⇧ + S` row appears
- [ ] Test with a short page (no content below fold) — should show no meaningful difference

🤖 Generated with [Claude Code](https://claude.com/claude-code)