### PR TITLE
fix(retention): harden kafka defaults and optional MinIO lifecycle controls

### DIFF
--- a/scripts/helmcharts/openreplay/files/minio.sh
+++ b/scripts/helmcharts/openreplay/files/minio.sh
@@ -6,6 +6,10 @@ cd /tmp
 
 buckets=("mobs" "sessions-assets" "static" "sourcemaps" "sessions-mobile-assets" "quickwit" "vault-data" "records" "spots")
 
+ENABLE_MINIO_LIFECYCLE=${ENABLE_MINIO_LIFECYCLE:-false}
+MOB_RETENTION_DAYS=${MOB_RETENTION_DAYS:-180}
+TAGGED_DELETE_DAYS=${TAGGED_DELETE_DAYS:-30}
+
 mc alias set minio $MINIO_HOST $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
 
 function init() {
@@ -16,20 +20,20 @@ function init() {
   "Rules": [
     {
       "Expiration": {
-        "Days": 180
+        "Days": ${MOB_RETENTION_DAYS}
       },
       "ID": "Delete old mob files",
       "Status": "Enabled"
     },
     {
       "Expiration": {
-        "Days": 30
+        "Days": ${TAGGED_DELETE_DAYS}
       },
-      "ID": "Delete flagged mob files after 30 days",
+      "ID": "Delete flagged mob files after configured days",
       "Filter": {
         "Tag": {
           "Key": "to_delete_in_days",
-          "Value": "30"
+          "Value": "${TAGGED_DELETE_DAYS}"
         }
       },
       "Status": "Enabled"
@@ -41,8 +45,9 @@ EOF
     for bucket in ${buckets[*]}; do
         mc mb minio/${bucket} || true
     done
-    # eg: How to setup the lifecycle policy
-    # mc ilm import minio/mobs </tmp/lifecycle.json || true
+    if [[ "$ENABLE_MINIO_LIFECYCLE" == "true" ]]; then
+        mc ilm import minio/mobs </tmp/lifecycle.json || true
+    fi
 
     #####################################################
     # Creating public bucket; Do not change this block!

--- a/scripts/helmcharts/openreplay/templates/job.yaml
+++ b/scripts/helmcharts/openreplay/templates/job.yaml
@@ -558,7 +558,7 @@ spec:
             value: '{{ $val }}'
           {{- end }}
           - name: RETENTION_TIME
-            value: "{{ .Values.global.kafka.retentionTime }}"
+            value: "{{ default "345600000" .Values.global.kafka.retentionTime }}"
           - name: KAFKA_HOST
             value: "{{ .Values.global.kafka.kafkaHost }}"
           - name: KAFKA_PORT

--- a/scripts/helmcharts/vars.yaml
+++ b/scripts/helmcharts/vars.yaml
@@ -36,6 +36,9 @@ quickwit: &quickwit
 kafka: &kafka
   # For enterpriseEdition
   # enabled: true
+  # EE topic-level retention in milliseconds.
+  # Used by migration job when configuring topic `retention.ms`.
+  # retentionTime: "345600000"
   kafkaHost: "kafka.db.svc.cluster.local"
   # For now, clickhouse doesn't support zookeeper tls intgration.
   # So we need http endpoint
@@ -174,6 +177,18 @@ global:
   #   existingSecret: "my-license-secret"
   #   existingSecretKey: "license-key"
   domainName: ""
+  # Global env var overrides passed to OpenReplay services.
+  # Uncomment and adjust for retention tuning:
+  # env:
+  #   SCH_DELETE_DAYS: "30"             # API tag-for-deletion window in days
+  #   RETENTION: "default"              # Default object tag for EE uploads
+  #   RETENTION_D_VALUE: "default"      # Tag when session leaves vault
+  #   RETENTION_L_VALUE: "vault"        # Tag when session is in vault
+  #   USE_S3_TAGS: "true"               # Enable object tagging on backend uploads
+  #   ENABLE_MINIO_LIFECYCLE: "true"    # Apply lifecycle policy to `mobs` bucket
+  #   MOB_RETENTION_DAYS: "180"         # Lifecycle expiration for all `mobs` objects
+  #   TAGGED_DELETE_DAYS: "30"          # Lifecycle expiration for tagged deletions
+  #   CLEANUP_READ_GAP: "48h"           # Ender cleanup read-back window
 
 # chalice:
   # env:
@@ -206,4 +221,3 @@ global:
 #     requests:
 #       cpu: 512m
 #       memory: 2056Mi
-


### PR DESCRIPTION
## Summary

Hi all

I was trying to get retention to work and saw that the minio lifecycle policy was not enabled/commented out.
Was there a special reason for it?

I added back some functionality if that's helpful.

Many thanks!

- fix EE kafka migration retention env by defaulting `RETENTION_TIME` to `345600000` when `global.kafka.retentionTime` is unset
- add optional MinIO lifecycle application for `mobs` bucket behind `ENABLE_MINIO_LIFECYCLE`
- parameterize MinIO lifecycle retention days with `MOB_RETENTION_DAYS` and `TAGGED_DELETE_DAYS`
- document retention-related env/value knobs in `scripts/helmcharts/vars.yaml`

## Why
- avoids empty retention config in EE migration flow
- makes object lifecycle retention configurable while preserving backward-compatible defaults

## Validation
- rendered helm charts for OSS and EE successfully
- verified EE render now sets `RETENTION_TIME: "345600000"`
- validated `minio.sh` syntax with `bash -n`
