### PR TITLE
fix(DE-67): finish correction of clickhouse port semantics

### DIFF
--- a/scripts/docker-compose/hacks/tpls/docker-compose.tpl
+++ b/scripts/docker-compose/hacks/tpls/docker-compose.tpl
@@ -145,8 +145,8 @@ services:
       - ../schema/db/init_dbs/clickhouse/create/init_schema.sql:/tmp/init_schema.sql
     environment:
       CH_HOST: "{{.Values.global.clickhouse.chHost}}"
-      CH_PORT: "{{.Values.global.clickhouse.service.webPort}}"
-      CH_PORT_HTTP: "{{.Values.global.clickhouse.service.dataPort}}"
+      CH_PORT: "{{.Values.global.clickhouse.service.dataPort}}"
+      CH_PORT_HTTP: "{{.Values.global.clickhouse.service.webPort}}"
       CH_USERNAME: "{{.Values.global.clickhouse.username}}"
       CH_PASSWORD: "{{.Values.global.clickhouse.password}}"
     entrypoint:
@@ -155,13 +155,13 @@ services:
       - |
           # Checking variable is empty. Shell independant method.
           # Wait for Minio to be ready
-          until nc -z -v -w30 {{.Values.global.clickhouse.chHost}} {{.Values.global.clickhouse.service.webPort}}; do
+          until nc -z -v -w30 {{.Values.global.clickhouse.chHost}} {{.Values.global.clickhouse.service.dataPort}}; do
               echo "Waiting for Minio server to be ready..."
               sleep 1
           done
 
           echo "clickhouse is up - executing command"
-          clickhouse-client -h {{.Values.global.clickhouse.chHost}} --user {{.Values.global.clickhouse.username}} --port {{.Values.global.clickhouse.service.webPort}} --multiquery < /tmp/init_schema.sql || true
+          clickhouse-client -h {{.Values.global.clickhouse.chHost}} --user {{.Values.global.clickhouse.username}} --port {{.Values.global.clickhouse.service.dataPort}} --multiquery < /tmp/init_schema.sql || true
 
   {{- define "service" -}}
   {{- $service_name := . }}

--- a/scripts/helmcharts/databases/charts/clickhouse/templates/statefulset.yaml
+++ b/scripts/helmcharts/databases/charts/clickhouse/templates/statefulset.yaml
@@ -80,9 +80,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-          - containerPort: 9000
-            name: web
           - containerPort: 8123
+            name: web
+          - containerPort: 9000
             name: data
           volumeMounts:
           - name: default-chi-openreplay-clickhouse-replicated-0-0-0 

--- a/scripts/helmcharts/databases/charts/clickhouse/values.yaml
+++ b/scripts/helmcharts/databases/charts/clickhouse/values.yaml
@@ -70,10 +70,9 @@ backupEnv:
 # S3_DISABLE_SSL="true"
 # S3_DEBUG="true"
 
-
 service:
-  webPort: 9000
-  dataPort: 8123
+  webPort: 8123
+  dataPort: 9000
 
 resources:
   requests: {}

--- a/scripts/helmcharts/manifests/clickhouse-db.yaml
+++ b/scripts/helmcharts/manifests/clickhouse-db.yaml
@@ -25,11 +25,11 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 9000
+    - port: 8123
       targetPort: web
       protocol: TCP
       name: web
-    - port: 8123
+    - port: 9000
       targetPort: data
       protocol: TCP
       name: data
@@ -108,9 +108,9 @@ spec:
           image: "clickhouse/clickhouse-server:25.1-alpine"
           imagePullPolicy: IfNotPresent
           ports:
-          - containerPort: 9000
-            name: web
           - containerPort: 8123
+            name: web
+          - containerPort: 9000
             name: data
           volumeMounts:
           - name: default-chi-openreplay-clickhouse-replicated-0-0-0 


### PR DESCRIPTION
The commit https://github.com/openreplay/openreplay/commit/d150f723b98804edfec15b85f4991262352b15c2 began the process of correcting the port semantics for clickhouse.

The _INTENT_ was:
  - `8123`: web interface
  - `9000`: data interface

However this first commit missed a few locations.
This caused problems upon install.

This swapping of ports may have contributed to the following (my symptoms were the same as theirs):
fix: #4230
fix: #3096