### PR TITLE
fix(docker-compose): add PostgreSQL healthcheck and startup ordering for Go services

### DIFF
--- a/scripts/docker-compose/docker-compose.yaml
+++ b/scripts/docker-compose/docker-compose.yaml
@@ -15,6 +15,12 @@ services:
           - postgresql.db.svc.cluster.local
     environment:
       POSTGRESQL_PASSWORD: "${COMMON_PG_PASSWORD}"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   clickhouse:
     image: clickhouse/clickhouse-server:${CLICKHOUSE_VERSION}
@@ -184,6 +190,9 @@ services:
     image: public.ecr.aws/p1t3u8a3/api:${COMMON_VERSION}
     domainname: app.svc.cluster.local
     container_name: api
+    depends_on:
+      postgresql:
+        condition: service_healthy
     networks:
       openreplay-net:
         aliases:
@@ -191,6 +200,8 @@ services:
           - api-openreplay.app.svc.cluster.local
     volumes:
       - shared-volume:/mnt/efs
+      - ./wait-for-pg.sh:/scripts/wait-for-pg.sh:ro
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
     env_file:
       - docker-envs/api.env
     environment: {}  # Fallback empty environment if env_file is missing
@@ -201,6 +212,9 @@ services:
     image: public.ecr.aws/p1t3u8a3/http:${COMMON_VERSION}
     domainname: app.svc.cluster.local
     container_name: http
+    depends_on:
+      postgresql:
+        condition: service_healthy
     networks:
       openreplay-net:
         aliases:
@@ -208,6 +222,8 @@ services:
           - http-openreplay.app.svc.cluster.local
     volumes:
       - shared-volume:/mnt/efs
+      - ./wait-for-pg.sh:/scripts/wait-for-pg.sh:ro
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
     env_file:
       - docker-envs/http.env
     environment: {}  # Fallback empty environment if env_file is missing
@@ -235,6 +251,9 @@ services:
     image: public.ecr.aws/p1t3u8a3/integrations:${COMMON_VERSION}
     domainname: app.svc.cluster.local
     container_name: integrations
+    depends_on:
+      postgresql:
+        condition: service_healthy
     networks:
       openreplay-net:
         aliases:
@@ -242,6 +261,8 @@ services:
           - integrations-openreplay.app.svc.cluster.local
     volumes:
       - shared-volume:/mnt/efs
+      - ./wait-for-pg.sh:/scripts/wait-for-pg.sh:ro
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
     env_file:
       - docker-envs/integrations.env
     environment: {}  # Fallback empty environment if env_file is missing
@@ -252,6 +273,9 @@ services:
     image: public.ecr.aws/p1t3u8a3/sink:${COMMON_VERSION}
     domainname: app.svc.cluster.local
     container_name: sink
+    depends_on:
+      postgresql:
+        condition: service_healthy
     networks:
       openreplay-net:
         aliases:
@@ -259,6 +283,8 @@ services:
           - sink-openreplay.app.svc.cluster.local
     volumes:
       - shared-volume:/mnt/efs
+      - ./wait-for-pg.sh:/scripts/wait-for-pg.sh:ro
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
     env_file:
       - docker-envs/sink.env
     environment: {}  # Fallback empty environment if env_file is missing
@@ -286,6 +312,9 @@ services:
     image: public.ecr.aws/p1t3u8a3/spot:${COMMON_VERSION}
     domainname: app.svc.cluster.local
     container_name: spot
+    depends_on:
+      postgresql:
+        condition: service_healthy
     networks:
       openreplay-net:
         aliases:
@@ -293,6 +322,8 @@ services:
           - spot-openreplay.app.svc.cluster.local
     volumes:
       - shared-volume:/mnt/efs
+      - ./wait-for-pg.sh:/scripts/wait-for-pg.sh:ro
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
     env_file:
       - docker-envs/spot.env
     environment: {}  # Fallback empty environment if env_file is missing
@@ -303,6 +334,9 @@ services:
     image: public.ecr.aws/p1t3u8a3/storage:${COMMON_VERSION}
     domainname: app.svc.cluster.local
     container_name: storage
+    depends_on:
+      postgresql:
+        condition: service_healthy
     networks:
       openreplay-net:
         aliases:
@@ -310,6 +344,8 @@ services:
           - storage-openreplay.app.svc.cluster.local
     volumes:
       - shared-volume:/mnt/efs
+      - ./wait-for-pg.sh:/scripts/wait-for-pg.sh:ro
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
     env_file:
       - docker-envs/storage.env
     environment: {}  # Fallback empty environment if env_file is missing
@@ -354,6 +390,9 @@ services:
     image: public.ecr.aws/p1t3u8a3/canvases:${COMMON_VERSION}
     domainname: app.svc.cluster.local
     container_name: canvases
+    depends_on:
+      postgresql:
+        condition: service_healthy
     networks:
       openreplay-net:
         aliases:
@@ -361,6 +400,8 @@ services:
           - canvases-openreplay.app.svc.cluster.local
     volumes:
       - shared-volume:/mnt/efs
+      - ./wait-for-pg.sh:/scripts/wait-for-pg.sh:ro
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
     env_file:
       - docker-envs/canvases.env
     environment: {}  # Fallback empty environment if env_file is missing
@@ -388,6 +429,9 @@ services:
     image: public.ecr.aws/p1t3u8a3/db:${COMMON_VERSION}
     domainname: app.svc.cluster.local
     container_name: db
+    depends_on:
+      postgresql:
+        condition: service_healthy
     networks:
       openreplay-net:
         aliases:
@@ -395,6 +439,8 @@ services:
           - db-openreplay.app.svc.cluster.local
     volumes:
       - shared-volume:/mnt/efs
+      - ./wait-for-pg.sh:/scripts/wait-for-pg.sh:ro
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
     env_file:
       - docker-envs/db.env
     environment: {}  # Fallback empty environment if env_file is missing
@@ -405,6 +451,9 @@ services:
     image: public.ecr.aws/p1t3u8a3/ender:${COMMON_VERSION}
     domainname: app.svc.cluster.local
     container_name: ender
+    depends_on:
+      postgresql:
+        condition: service_healthy
     networks:
       openreplay-net:
         aliases:
@@ -412,6 +461,8 @@ services:
           - ender-openreplay.app.svc.cluster.local
     volumes:
       - shared-volume:/mnt/efs
+      - ./wait-for-pg.sh:/scripts/wait-for-pg.sh:ro
+    entrypoint: ["/bin/sh", "/scripts/wait-for-pg.sh"]
     env_file:
       - docker-envs/ender.env
     environment: {}  # Fallback empty environment if env_file is missing

--- a/scripts/docker-compose/wait-for-pg.sh
+++ b/scripts/docker-compose/wait-for-pg.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Wait for PostgreSQL to be reachable before starting the service.
+# Handles both initial startup and restart-after-crash scenarios.
+
+PG_HOST="${PG_HOST:-postgresql.db.svc.cluster.local}"
+PG_PORT="${PG_PORT:-5432}"
+MAX_WAIT=60
+WAITED=0
+
+echo "Waiting for PostgreSQL at ${PG_HOST}:${PG_PORT}..."
+until nc -z -w3 "$PG_HOST" "$PG_PORT" 2>/dev/null; do
+    WAITED=$((WAITED + 2))
+    if [ $WAITED -ge $MAX_WAIT ]; then
+        echo "ERROR: PostgreSQL not reachable after ${MAX_WAIT}s, starting anyway"
+        break
+    fi
+    echo "PostgreSQL not ready, retrying in 2s... (${WAITED}/${MAX_WAIT}s)"
+    sleep 2
+done
+
+if [ $WAITED -lt $MAX_WAIT ]; then
+    echo "PostgreSQL is ready (waited ${WAITED}s), starting service"
+    # Brief pause to let PG fully accept connections (not just TCP)
+    sleep 2
+fi
+
+exec /home/openreplay/service


### PR DESCRIPTION
## Summary

- Go services (`api`, `http`, `sink`, `db`, `ender`, `spot`, `storage`, `integrations`, `canvases`) have no retry logic for PostgreSQL connections. If PostgreSQL has a transient connectivity issue, the Go services restart via Docker's `restart: unless-stopped` policy but fail to re-establish database connections, entering a **zombie state** where they're running but return errors on all requests (401 on ingest, 404 on API routes, no ClickHouse writes).

- This PR adds three changes to prevent this:
  1. **PostgreSQL healthcheck** using `pg_isready` — enables `depends_on` with `service_healthy` condition
  2. **`depends_on: postgresql: condition: service_healthy`** on all Go services — prevents startup before PostgreSQL is ready
  3. **`wait-for-pg.sh` entrypoint wrapper** — waits for PostgreSQL TCP connectivity before launching the Go binary, handling the restart-after-crash scenario that `depends_on` alone doesn't cover

## Problem

When PostgreSQL experiences even a brief connectivity hiccup:

1. Go services detect it via `pgConn.Ping()` and restart internally
2. Docker sees the container as "running" (no crash = no restart)
3. The Go binary reconnects but PostgreSQL may still be recovering
4. Services enter zombie state: HTTP server runs, but database handle is broken
5. `http` returns 401 on all ingest (can't validate project keys)
6. `api` returns 404 on all routes (routes never register)
7. `db` silently drops all ClickHouse writes
8. No sessions are recorded until manual restart

This can go undetected for hours/days since the containers appear healthy.

## Solution

The `wait-for-pg.sh` wrapper uses `nc` (available in Alpine) to test TCP connectivity to PostgreSQL before launching `/home/openreplay/service`. It retries every 2 seconds for up to 60 seconds, then starts anyway (to avoid infinite hang). This runs on every container start, including restarts triggered by Docker's restart policy.

## Test plan

- [ ] `docker compose up -d` — verify Go services wait for PostgreSQL healthcheck before starting
- [ ] Stop PostgreSQL briefly, verify Go services wait on restart
- [ ] Confirm `wait-for-pg.sh` logs are visible in container logs
- [ ] Verify no behavioral changes when PostgreSQL is immediately available