### PR TITLE
feat(dashboard): persist default time range

### DIFF
--- a/api/chalicelib/core/metrics/dashboards.py
+++ b/api/chalicelib/core/metrics/dashboards.py
@@ -9,10 +9,11 @@ from chalicelib.utils.TimeUTC import TimeUTC
 
 def create_dashboard(project_id, user_id, data: schemas.CreateDashboardSchema):
     with pg_client.PostgresClient() as cur:
-        pg_query = f"""INSERT INTO dashboards(project_id, user_id, name, is_public, is_pinned, description) 
-                        VALUES(%(projectId)s, %(userId)s, %(name)s, %(is_public)s, %(is_pinned)s, %(description)s)
+        pg_query = f"""INSERT INTO dashboards(project_id, user_id, name, is_public, is_pinned, description, config)
+                        VALUES(%(projectId)s, %(userId)s, %(name)s, %(is_public)s, %(is_pinned)s, %(description)s, %(config)s::jsonb)
                         RETURNING *"""
         params = {"userId": user_id, "projectId": project_id, **data.model_dump()}
+        params["config"] = json.dumps(data.config.model_dump(by_alias=True))
         if data.metrics is not None and len(data.metrics) > 0:
             pg_query = f"""WITH dash AS ({pg_query})
                          INSERT INTO dashboard_widgets(dashboard_id, metric_id, user_id, config)
@@ -118,22 +119,28 @@ def update_dashboard(project_id, user_id, dashboard_id, data: schemas.EditDashbo
         cur.execute(cur.mogrify(pg_query, params))
         row = cur.fetchone()
         offset = row["count"]
+        params["config"] = (
+            json.dumps(data.config.model_dump(by_alias=True))
+            if data.config is not None
+            else None
+        )
         pg_query = f"""UPDATE dashboards
                        SET name = %(name)s,
                           description= %(description)s
+                            {", config = %(config)s::jsonb" if data.config is not None else ""}
                             {", is_public = %(is_public)s" if data.is_public is not None else ""}
                             {", is_pinned = %(is_pinned)s" if data.is_pinned is not None else ""}
                        WHERE dashboards.project_id = %(projectId)s
                           AND dashboard_id = %(dashboard_id)s
                           AND (dashboards.user_id = %(userId)s OR is_public)
-                       RETURNING dashboard_id,name,description,is_public,created_at"""
+                       RETURNING dashboard_id,name,description,is_public,config,created_at"""
         if data.metrics is not None and len(data.metrics) > 0:
             pg_query = f"""WITH dash AS ({pg_query})
                            INSERT INTO dashboard_widgets(dashboard_id, metric_id, user_id, config)
                            VALUES {",".join([f"(%(dashboard_id)s, %(metric_id_{i})s, %(userId)s, (SELECT default_config FROM metrics WHERE metric_id=%(metric_id_{i})s)||%(config_{i})s)" for i in range(len(data.metrics))])}
                            RETURNING (SELECT dashboard_id FROM dash),(SELECT name FROM dash),
                                      (SELECT description FROM dash),(SELECT is_public FROM dash),
-                                     (SELECT created_at FROM dash);"""
+                                     (SELECT config FROM dash),(SELECT created_at FROM dash);"""
             for i, m in enumerate(data.metrics):
                 params[f"metric_id_{i}"] = m
                 # params[f"config_{i}"] = schemas.AddWidgetToDashboardPayloadSchema.schema() \

--- a/api/schemas/schemas.py
+++ b/api/schemas/schemas.py
@@ -1509,17 +1509,30 @@ class ProjectSettings(BaseModel):
     conditions: List[ProjectConditions] = Field(default_factory=list)
 
 
+class DashboardPeriodSchema(BaseModel):
+    range_name: str = Field(...)
+    start: Optional[int] = Field(default=None)
+    end: Optional[int] = Field(default=None)
+
+
+class DashboardConfigSchema(BaseModel):
+    default_period: Optional[DashboardPeriodSchema] = Field(default=None)
+
+
 class CreateDashboardSchema(BaseModel):
+
     name: str = Field(..., min_length=1)
     description: Optional[str] = Field(default="")
     is_public: bool = Field(default=False)
     is_pinned: bool = Field(default=False)
     metrics: Optional[List[int]] = Field(default_factory=list)
+    config: DashboardConfigSchema = Field(default_factory=DashboardConfigSchema)
 
 
 class EditDashboardSchema(CreateDashboardSchema):
     is_public: Optional[bool] = Field(default=None)
     is_pinned: Optional[bool] = Field(default=None)
+    config: Optional[DashboardConfigSchema] = Field(default=None)
 
 
 class UpdateWidgetPayloadSchema(BaseModel):

--- a/backend/pkg/analytics/dashboards/dashboards.go
+++ b/backend/pkg/analytics/dashboards/dashboards.go
@@ -35,13 +35,19 @@ func New(log logger.Logger, conn pool.Pool) (Dashboards, error) {
 }
 
 func (s *dashboardsImpl) Create(projectId int, userID uint64, req *CreateDashboardRequest) (*GetDashboardResponse, error) {
+	configJSON, err := json.Marshal(req.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal dashboard config: %w", err)
+	}
+
 	sql := `
-		INSERT INTO dashboards (project_id, user_id, name, description, is_public, is_pinned)
-		VALUES ($1, $2, $3, $4, $5, $6)
-		RETURNING dashboard_id, project_id, user_id, name, description, is_public, is_pinned, created_at`
+		INSERT INTO dashboards (project_id, user_id, name, description, is_public, is_pinned, config)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING dashboard_id, project_id, user_id, name, description, is_public, is_pinned, config, created_at`
 
 	dashboard := &GetDashboardResponse{}
-	err := s.pgconn.QueryRow(sql, projectId, userID, req.Name, req.Description, req.IsPublic, req.IsPinned).Scan(
+	var rawConfig []byte
+	err = s.pgconn.QueryRow(sql, projectId, userID, req.Name, req.Description, req.IsPublic, req.IsPinned, configJSON).Scan(
 		&dashboard.DashboardID,
 		&dashboard.ProjectID,
 		&dashboard.UserID,
@@ -49,10 +55,14 @@ func (s *dashboardsImpl) Create(projectId int, userID uint64, req *CreateDashboa
 		&dashboard.Description,
 		&dashboard.IsPublic,
 		&dashboard.IsPinned,
+		&rawConfig,
 		&dashboard.CreatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create dashboard: %w", err)
+	}
+	if err := json.Unmarshal(rawConfig, &dashboard.Config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal dashboard config: %w", err)
 	}
 	return dashboard, nil
 }
@@ -79,6 +89,7 @@ func (s *dashboardsImpl) Get(projectId int, dashboardID int, userID uint64) (*Ge
 			d.description,
 			d.is_public,
 			d.is_pinned,
+			d.config,
 			d.user_id,
 			d.created_at,
 			COALESCE(json_agg(
@@ -101,10 +112,11 @@ func (s *dashboardsImpl) Get(projectId int, dashboardID int, userID uint64) (*Ge
 		LEFT JOIN metrics m ON dw.metric_id = m.metric_id
 		LEFT JOIN series_agg s ON m.metric_id = s.metric_id
 		WHERE d.dashboard_id = $1 AND d.project_id = $2 AND d.deleted_at IS NULL
-		GROUP BY d.dashboard_id, d.project_id, d.name, d.description, d.is_public, d.is_pinned, d.user_id, d.created_at`
+		GROUP BY d.dashboard_id, d.project_id, d.name, d.description, d.is_public, d.is_pinned, d.config, d.user_id, d.created_at`
 
 	dashboard := &GetDashboardResponse{}
 	var ownerID int
+	var rawConfig []byte
 	var metricsJSON []byte
 
 	err := s.pgconn.QueryRow(sql, dashboardID, projectId).Scan(
@@ -114,6 +126,7 @@ func (s *dashboardsImpl) Get(projectId int, dashboardID int, userID uint64) (*Ge
 		&dashboard.Description,
 		&dashboard.IsPublic,
 		&dashboard.IsPinned,
+		&rawConfig,
 		&ownerID,
 		&dashboard.CreatedAt,
 		&metricsJSON,
@@ -126,6 +139,9 @@ func (s *dashboardsImpl) Get(projectId int, dashboardID int, userID uint64) (*Ge
 		return nil, fmt.Errorf("error fetching dashboard: %w", err)
 	}
 
+	if err := json.Unmarshal(rawConfig, &dashboard.Config); err != nil {
+		return nil, fmt.Errorf("error unmarshalling config: %w", err)
+	}
 	if err := json.Unmarshal(metricsJSON, &dashboard.Metrics); err != nil {
 		return nil, fmt.Errorf("error unmarshalling metrics: %w", err)
 	}
@@ -139,7 +155,7 @@ func (s *dashboardsImpl) Get(projectId int, dashboardID int, userID uint64) (*Ge
 
 func (s *dashboardsImpl) GetAll(projectId int, userID uint64) (*GetDashboardsResponse, error) {
 	sql := `
-		SELECT d.dashboard_id, d.user_id, d.project_id, d.name, d.description, d.is_public, d.is_pinned, u.email AS owner_email, u.name AS owner_name, d.created_at
+		SELECT d.dashboard_id, d.user_id, d.project_id, d.name, d.description, d.is_public, d.is_pinned, d.config, u.email AS owner_email, u.name AS owner_name, d.created_at
 		FROM dashboards d
 		LEFT JOIN users u ON d.user_id = u.user_id
 		WHERE (d.is_public = true OR d.user_id = $1) AND d.user_id IS NOT NULL AND d.deleted_at IS NULL AND d.project_id = $2
@@ -153,10 +169,14 @@ func (s *dashboardsImpl) GetAll(projectId int, userID uint64) (*GetDashboardsRes
 	var dashboards []Dashboard
 	for rows.Next() {
 		var dashboard Dashboard
+		var rawConfig []byte
 
-		err := rows.Scan(&dashboard.DashboardID, &dashboard.UserID, &dashboard.ProjectID, &dashboard.Name, &dashboard.Description, &dashboard.IsPublic, &dashboard.IsPinned, &dashboard.OwnerEmail, &dashboard.OwnerName, &dashboard.CreatedAt)
+		err := rows.Scan(&dashboard.DashboardID, &dashboard.UserID, &dashboard.ProjectID, &dashboard.Name, &dashboard.Description, &dashboard.IsPublic, &dashboard.IsPinned, &rawConfig, &dashboard.OwnerEmail, &dashboard.OwnerName, &dashboard.CreatedAt)
 		if err != nil {
 			return nil, err
+		}
+		if err := json.Unmarshal(rawConfig, &dashboard.Config); err != nil {
+			return nil, fmt.Errorf("error unmarshalling dashboard config: %w", err)
 		}
 
 		dashboards = append(dashboards, dashboard)
@@ -196,6 +216,7 @@ func (s *dashboardsImpl) GetAllPaginated(projectId int, userID uint64, req *GetD
 	var dashboards []Dashboard
 	for rows.Next() {
 		var dashboard Dashboard
+		var rawConfig []byte
 		err := rows.Scan(
 			&dashboard.DashboardID,
 			&dashboard.UserID,
@@ -204,12 +225,16 @@ func (s *dashboardsImpl) GetAllPaginated(projectId int, userID uint64, req *GetD
 			&dashboard.Description,
 			&dashboard.IsPublic,
 			&dashboard.IsPinned,
+			&rawConfig,
 			&dashboard.OwnerEmail,
 			&dashboard.OwnerName,
 			&dashboard.CreatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("error scanning dashboard: %w", err)
+		}
+		if err := json.Unmarshal(rawConfig, &dashboard.Config); err != nil {
+			return nil, fmt.Errorf("error unmarshalling dashboard config: %w", err)
 		}
 		dashboards = append(dashboards, dashboard)
 	}
@@ -227,14 +252,37 @@ func (s *dashboardsImpl) Update(projectId int, dashboardID int, userID uint64, r
 		return nil, fmt.Errorf("failed to get dashboard: %w", err)
 	}
 
+	config := DashboardConfig{}
+	if req.Config != nil {
+		config = *req.Config
+	}
+
+	configJSON, err := json.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal dashboard config: %w", err)
+	}
+
 	sql := `
 		UPDATE dashboards
-		SET name = $1, description = $2, is_public = $3, is_pinned = $4
+		SET name = $1, description = $2, is_public = $3, is_pinned = $4`
+	args := []interface{}{req.Name, req.Description, req.IsPublic, req.IsPinned}
+
+	if req.Config != nil {
+		sql += `, config = $5`
+		args = append(args, configJSON, dashboardID, projectId)
+		sql += `
+		WHERE dashboard_id = $6 AND project_id = $7 AND deleted_at IS NULL
+		RETURNING dashboard_id, project_id, user_id, name, description, is_public, is_pinned, config, created_at`
+	} else {
+		args = append(args, dashboardID, projectId)
+		sql += `
 		WHERE dashboard_id = $5 AND project_id = $6 AND deleted_at IS NULL
-		RETURNING dashboard_id, project_id, user_id, name, description, is_public, is_pinned, created_at`
+		RETURNING dashboard_id, project_id, user_id, name, description, is_public, is_pinned, config, created_at`
+	}
 
 	dashboard := &GetDashboardResponse{}
-	err = s.pgconn.QueryRow(sql, req.Name, req.Description, req.IsPublic, req.IsPinned, dashboardID, projectId).Scan(
+	var rawConfig []byte
+	err = s.pgconn.QueryRow(sql, args...).Scan(
 		&dashboard.DashboardID,
 		&dashboard.ProjectID,
 		&dashboard.UserID,
@@ -242,10 +290,14 @@ func (s *dashboardsImpl) Update(projectId int, dashboardID int, userID uint64, r
 		&dashboard.Description,
 		&dashboard.IsPublic,
 		&dashboard.IsPinned,
+		&rawConfig,
 		&dashboard.CreatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error updating dashboard: %w", err)
+	}
+	if err := json.Unmarshal(rawConfig, &dashboard.Config); err != nil {
+		return nil, fmt.Errorf("error unmarshalling dashboard config: %w", err)
 	}
 	return dashboard, nil
 }
@@ -288,7 +340,7 @@ func buildBaseQuery(projectId int, userID uint64, req *GetDashboardsRequest) (st
 	whereClause := "WHERE " + fmt.Sprint(conditions)
 
 	baseSQL := fmt.Sprintf(`
-		SELECT d.dashboard_id, d.user_id, d.project_id, d.name, d.description, d.is_public, d.is_pinned,
+		SELECT d.dashboard_id, d.user_id, d.project_id, d.name, d.description, d.is_public, d.is_pinned, d.config,
 		       u.email AS owner_email, u.name AS owner_name, d.created_at
 		FROM dashboards d
 		LEFT JOIN users u ON d.user_id = u.user_id

--- a/backend/pkg/analytics/dashboards/model.go
+++ b/backend/pkg/analytics/dashboards/model.go
@@ -13,10 +13,21 @@ type Dashboard struct {
 	Description string           `json:"description"`
 	IsPublic    bool             `json:"isPublic"`
 	IsPinned    bool             `json:"isPinned"`
+	Config      DashboardConfig  `json:"config"`
 	OwnerEmail  string           `json:"ownerEmail"`
 	OwnerName   string           `json:"ownerName"`
 	CreatedAt   time.Time        `json:"createdAt"`
 	Metrics     []cards.CardBase `json:"widgets"`
+}
+
+type DashboardConfig struct {
+	DefaultPeriod *DashboardPeriod `json:"defaultPeriod,omitempty"`
+}
+
+type DashboardPeriod struct {
+	RangeName string `json:"rangeName"`
+	Start     *int64 `json:"start,omitempty"`
+	End       *int64 `json:"end,omitempty"`
 }
 
 type CreateDashboardResponse struct {
@@ -39,11 +50,12 @@ type GetDashboardsResponse struct {
 // REQUESTS
 
 type CreateDashboardRequest struct {
-	Name        string `json:"name" validate:"required,min=3,max=150"`
-	Description string `json:"description" validate:"max=500"`
-	IsPublic    bool   `json:"isPublic"`
-	IsPinned    bool   `json:"isPinned"`
-	Metrics     []int  `json:"metrics"`
+	Name        string          `json:"name" validate:"required,min=3,max=150"`
+	Description string          `json:"description" validate:"max=500"`
+	IsPublic    bool            `json:"isPublic"`
+	IsPinned    bool            `json:"isPinned"`
+	Config      DashboardConfig `json:"config"`
+	Metrics     []int           `json:"metrics"`
 }
 
 type GetDashboardsRequest struct {
@@ -56,11 +68,12 @@ type GetDashboardsRequest struct {
 }
 
 type UpdateDashboardRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	IsPublic    bool   `json:"isPublic"`
-	IsPinned    bool   `json:"isPinned"`
-	Metrics     []int  `json:"metrics"`
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	IsPublic    bool             `json:"isPublic"`
+	IsPinned    bool             `json:"isPinned"`
+	Config      *DashboardConfig `json:"config,omitempty"`
+	Metrics     []int            `json:"metrics"`
 }
 
 type PinDashboardRequest struct {

--- a/ee/scripts/schema/db/init_dbs/postgresql/1.27.0/1.27.0.sql
+++ b/ee/scripts/schema/db/init_dbs/postgresql/1.27.0/1.27.0.sql
@@ -1,0 +1,29 @@
+\set previous_version 'v1.26.0-ee'
+\set next_version 'v1.27.0-ee'
+SELECT openreplay_version()                       AS current_version,
+       openreplay_version() = :'previous_version' AS valid_previous,
+       openreplay_version() = :'next_version'     AS is_next
+\gset
+
+\if :valid_previous
+\echo valid previous DB version :'previous_version', starting DB upgrade to :'next_version'
+BEGIN;
+SELECT format($fn_def$
+CREATE OR REPLACE FUNCTION openreplay_version()
+    RETURNS text AS
+$$
+SELECT '%1$s'
+$$ LANGUAGE sql IMMUTABLE;
+$fn_def$, :'next_version')
+\gexec
+
+ALTER TABLE public.dashboards
+    ADD COLUMN IF NOT EXISTS config jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMIT;
+
+\elif :is_next
+\echo new version detected :'next_version', nothing to do
+\else
+\warn skipping DB upgrade of :'next_version', expected previous version :'previous_version', found :'current_version'
+\endif

--- a/ee/scripts/schema/db/init_dbs/postgresql/init_schema.sql
+++ b/ee/scripts/schema/db/init_dbs/postgresql/init_schema.sql
@@ -1,4 +1,4 @@
-\set or_version 'v1.26.0-ee'
+\set or_version 'v1.27.0-ee'
 SET client_min_messages TO NOTICE;
 \set ON_ERROR_STOP true
 SELECT EXISTS (SELECT 1
@@ -881,6 +881,7 @@ CREATE TABLE public.dashboards
     description  text      NOT NULL DEFAULT '',
     is_public    boolean   NOT NULL DEFAULT TRUE,
     is_pinned    boolean   NOT NULL DEFAULT FALSE,
+    config       jsonb     NOT NULL DEFAULT '{}'::jsonb,
     created_at   timestamp NOT NULL DEFAULT timezone('utc'::text, now()),
     deleted_at   timestamp NULL     DEFAULT NULL
 );

--- a/ee/scripts/schema/db/rollback_dbs/postgresql/1.27.0/1.27.0.sql
+++ b/ee/scripts/schema/db/rollback_dbs/postgresql/1.27.0/1.27.0.sql
@@ -1,0 +1,29 @@
+\set previous_version 'v1.27.0-ee'
+\set next_version 'v1.26.0-ee'
+SELECT openreplay_version()                       AS current_version,
+       openreplay_version() = :'previous_version' AS valid_previous,
+       openreplay_version() = :'next_version'     AS is_next
+\gset
+
+\if :valid_previous
+\echo valid previous DB version :'previous_version', starting DB downgrade to :'next_version'
+BEGIN;
+SELECT format($fn_def$
+CREATE OR REPLACE FUNCTION openreplay_version()
+    RETURNS text AS
+$$
+SELECT '%1$s'
+$$ LANGUAGE sql IMMUTABLE;
+$fn_def$, :'next_version')
+\gexec
+
+ALTER TABLE public.dashboards
+    DROP COLUMN IF EXISTS config;
+
+COMMIT;
+
+\elif :is_next
+\echo new version detected :'next_version', nothing to do
+\else
+\warn skipping DB downgrade of :'next_version', expected previous version :'previous_version', found :'current_version'
+\endif

--- a/frontend/app/components/Dashboard/components/DashboardEditModal/DashboardEditModal.tsx
+++ b/frontend/app/components/Dashboard/components/DashboardEditModal/DashboardEditModal.tsx
@@ -5,6 +5,11 @@ import { Button } from 'antd';
 import { CloseOutlined } from '@ant-design/icons';
 import { useStore } from 'App/mstore';
 import { useTranslation } from 'react-i18next';
+import SelectDateRange from 'Shared/SelectDateRange';
+import {
+  getDashboardDefaultPeriod,
+  getSerializedDashboardPeriod,
+} from 'App/mstore/types/dashboardPeriod';
 
 interface Props {
   show: boolean;
@@ -32,6 +37,13 @@ function DashboardEditModal(props: Props) {
 
   const write = ({ target: { value, name } }) =>
     dashboard.update({ [name]: value });
+  const writePeriod = (period: any) =>
+    dashboard.update({
+      config: {
+        ...dashboard.config,
+        defaultPeriod: getSerializedDashboardPeriod(period),
+      },
+    });
 
   return (
     <Modal open={show} onClose={closeHandler}>
@@ -98,6 +110,16 @@ function DashboardEditModal(props: Props) {
                 </span>
               </div>
             </div>
+          </Form.Field>
+
+          <Form.Field>
+            <label>{t('Default Time Range:')}</label>
+            <SelectDateRange
+              period={getDashboardDefaultPeriod(dashboard.config)}
+              onChange={writePeriod}
+              isAnt
+              useButtonStyle
+            />
           </Form.Field>
         </Form>
       </Modal.Content>

--- a/frontend/app/components/Dashboard/components/DashboardView/DashboardView.tsx
+++ b/frontend/app/components/Dashboard/components/DashboardView/DashboardView.tsx
@@ -62,7 +62,6 @@ function DashboardView(props: Props) {
   };
 
   useEffect(() => {
-    dashboardStore.resetPeriod();
     if (queryParams.has('modal')) {
       onAddWidgets();
       trimQuery();

--- a/frontend/app/mstore/dashboardStore.ts
+++ b/frontend/app/mstore/dashboardStore.ts
@@ -10,6 +10,7 @@ import { calculateGranularities } from '@/components/Dashboard/components/Widget
 import { HEATMAP } from '@/constants/card';
 import { sessionStore } from 'App/mstore';
 import { CUSTOM_RANGE } from '@/dateRange';
+import { getDashboardDefaultPeriod } from './types/dashboardPeriod';
 
 interface DashboardFilter {
   query?: string;
@@ -267,10 +268,14 @@ export default class DashboardStore {
       description: string;
       isPublic: boolean;
       createdAt: number;
+      config?: any;
     },
   ) {
     if (this.selectedDashboard !== null) {
       this.selectedDashboard.updateInfo(info);
+      if (this.selectedDashboard.dashboardId === id) {
+        this.setPeriod(getDashboardDefaultPeriod(this.selectedDashboard.config));
+      }
     }
     const index = this.dashboards.findIndex((d) => d.dashboardId === id);
     this.dashboards[index].updateInfo(info);
@@ -366,6 +371,7 @@ export default class DashboardStore {
     this.selectedDashboard =
       this.dashboards.find((d) => d.dashboardId == dashboardId) ||
       new Dashboard();
+    this.setPeriod(getDashboardDefaultPeriod(this.selectedDashboard.config));
   };
 
   getDashboardById = async (dashboardId: string) => {
@@ -390,6 +396,7 @@ export default class DashboardStore {
 
     if (dashboard) {
       this.selectedDashboard = dashboard;
+      this.setPeriod(getDashboardDefaultPeriod(dashboard.config));
       return true;
     }
     this.selectedDashboard = null;
@@ -470,6 +477,10 @@ export default class DashboardStore {
   }
 
   resetPeriod = () => {
+    if (this.selectedDashboard?.config?.defaultPeriod?.rangeName) {
+      this.setPeriod(getDashboardDefaultPeriod(this.selectedDashboard.config));
+      return;
+    }
     if (this.period) {
       const range = this.period.rangeName;
       if (range !== CUSTOM_RANGE) {

--- a/frontend/app/mstore/types/dashboard.test.ts
+++ b/frontend/app/mstore/types/dashboard.test.ts
@@ -1,0 +1,37 @@
+import Period, { CUSTOM_RANGE, LAST_24_HOURS } from 'Types/app/period';
+import {
+  getDashboardDefaultPeriod,
+  getSerializedDashboardPeriod,
+} from './dashboardPeriod';
+
+describe('dashboard period config helpers', () => {
+  it('falls back to the default dashboard period when config is missing', () => {
+    const period = getDashboardDefaultPeriod({});
+
+    expect(period.rangeName).toBe(LAST_24_HOURS);
+  });
+
+  it('serializes a preset period without dropping start and end', () => {
+    const period = Period({ rangeName: LAST_24_HOURS });
+
+    expect(getSerializedDashboardPeriod(period)).toEqual({
+      rangeName: LAST_24_HOURS,
+      start: period.start,
+      end: period.end,
+    });
+  });
+
+  it('preserves custom ranges for dashboard defaults', () => {
+    const period = Period({
+      rangeName: CUSTOM_RANGE,
+      start: 1700000000000,
+      end: 1700086400000,
+    });
+
+    const defaultPeriod = getDashboardDefaultPeriod({ defaultPeriod: period });
+
+    expect(defaultPeriod.rangeName).toBe(CUSTOM_RANGE);
+    expect(defaultPeriod.start).toBe(1700000000000);
+    expect(defaultPeriod.end).toBe(1700086400000);
+  });
+});

--- a/frontend/app/mstore/types/dashboard.ts
+++ b/frontend/app/mstore/types/dashboard.ts
@@ -61,6 +61,7 @@ export default class Dashboard {
       this.name = data.name || this.name;
       this.description = data.description || this.description;
       this.isPublic = data.isPublic;
+      this.config = data.config || this.config;
     });
   }
 
@@ -71,6 +72,7 @@ export default class Dashboard {
       isPublic: this.isPublic,
       metrics: this.metrics,
       description: this.description,
+      config: this.config,
     };
   }
 
@@ -80,6 +82,7 @@ export default class Dashboard {
       this.name = json.name;
       this.description = json.description;
       this.isPublic = json.isPublic;
+      this.config = json.config || {};
       this.key = json.dashboardId;
       this.createdAt = DateTime.fromMillis(new Date(json.createdAt).getTime());
       this.owner = json.ownerName;

--- a/frontend/app/mstore/types/dashboardPeriod.ts
+++ b/frontend/app/mstore/types/dashboardPeriod.ts
@@ -1,0 +1,14 @@
+import Period, { LAST_24_HOURS } from 'Types/app/period';
+
+export const getSerializedDashboardPeriod = (period: any) => ({
+  rangeName: period?.rangeName || LAST_24_HOURS,
+  start: period?.start,
+  end: period?.end,
+});
+
+export const getDashboardDefaultPeriod = (config: any) =>
+  Period(
+    config?.defaultPeriod?.rangeName
+      ? getSerializedDashboardPeriod(config.defaultPeriod)
+      : getSerializedDashboardPeriod({ rangeName: LAST_24_HOURS }),
+  );

--- a/openreplay-dashboard-default-period-debtest.md
+++ b/openreplay-dashboard-default-period-debtest.md
@@ -1,0 +1,50 @@
+# DebTest: OpenReplay Dashboard Default Time Range
+
+## Change Summary
+- Adds persisted dashboard-level `config.defaultPeriod`
+- Saves the default time range from the existing dashboard edit modal
+- Hydrates `dashboardStore.period` from the saved dashboard default on load/select
+- Splits this from the original issue's series-limit work; this PR is time-range only
+
+## Change Tier
+- Tier 2
+- Reason: cross-layer product change touching frontend state, API schemas, backend persistence, and DB schema
+
+## Real User Problem
+- Dashboard users cannot save a preferred default time range, so every open falls back to generic store defaults instead of the dashboard's intended reporting window.
+
+## Failure Modes Reviewed
+- Older clients updating dashboards without the new `config` field could wipe persisted defaults
+- Python and Go API paths could serialize different JSON shapes into the same `dashboards.config` column
+- Dashboard load could still reset to the generic last-24-hours default instead of the saved dashboard period
+- Custom ranges could lose `start/end` when serialized through the new config helper
+- Aggregated Go dashboard query could fail after selecting `d.config` without grouping it
+- New frontend test could accidentally depend on the full MobX store graph instead of the isolated helper seam
+
+## Verification Run
+- `python3 -m py_compile api/schemas/schemas.py api/chalicelib/core/metrics/dashboards.py`
+- `gofmt -w backend/pkg/analytics/dashboards/model.go backend/pkg/analytics/dashboards/dashboards.go`
+- `go test ./pkg/analytics/dashboards/...`
+- `./node_modules/.bin/jest --runInBand app/mstore/types/dashboard.test.ts`
+- `git diff --check`
+
+## Results
+- Python syntax: pass
+- Go formatting: pass
+- Go dashboard package compile/test slice: pass
+- Targeted frontend Jest helper test: pass
+- Diff whitespace / patch hygiene: pass
+
+## Known Non-Blocking Gaps
+- Full-repo `tsc --noEmit` is not a useful signal here because the repository already has a large unrelated TypeScript error floor.
+- No DB-backed integration test was run for the new `dashboards.config` migration path.
+- No end-to-end browser/UI test was run for editing and reopening a dashboard.
+
+## Review Findings Fixed During DebTest
+- Preserved backward compatibility for update requests that omit `config`, so older clients do not erase an existing saved default.
+- Normalized Python-side config writes with `by_alias=True` so Python and Go store the same camelCase JSON shape.
+- Added the missing `GROUP BY d.config` in the aggregated Go dashboard query.
+- Isolated the new frontend helper into `dashboardPeriod.ts` so the test runs without importing the entire store graph.
+
+## Merge Readiness
+- Ready for PR as a bounded time-range-only change.

--- a/scripts/schema/db/init_dbs/postgresql/1.27.0/1.27.0.sql
+++ b/scripts/schema/db/init_dbs/postgresql/1.27.0/1.27.0.sql
@@ -1,0 +1,29 @@
+\set previous_version 'v1.26.0'
+\set next_version 'v1.27.0'
+SELECT openreplay_version()                       AS current_version,
+       openreplay_version() = :'previous_version' AS valid_previous,
+       openreplay_version() = :'next_version'     AS is_next
+\gset
+
+\if :valid_previous
+\echo valid previous DB version :'previous_version', starting DB upgrade to :'next_version'
+BEGIN;
+SELECT format($fn_def$
+CREATE OR REPLACE FUNCTION openreplay_version()
+    RETURNS text AS
+$$
+SELECT '%1$s'
+$$ LANGUAGE sql IMMUTABLE;
+$fn_def$, :'next_version')
+\gexec
+
+ALTER TABLE public.dashboards
+    ADD COLUMN IF NOT EXISTS config jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMIT;
+
+\elif :is_next
+\echo new version detected :'next_version', nothing to do
+\else
+\warn skipping DB upgrade of :'next_version', expected previous version :'previous_version', found :'current_version'
+\endif

--- a/scripts/schema/db/init_dbs/postgresql/init_schema.sql
+++ b/scripts/schema/db/init_dbs/postgresql/init_schema.sql
@@ -1,4 +1,4 @@
-\set or_version 'v1.25.0'
+\set or_version 'v1.27.0'
 SET client_min_messages TO NOTICE;
 \set ON_ERROR_STOP true
 SELECT EXISTS (SELECT 1
@@ -826,6 +826,7 @@ CREATE TABLE public.dashboards
     description  text      NOT NULL DEFAULT '',
     is_public    boolean   NOT NULL DEFAULT TRUE,
     is_pinned    boolean   NOT NULL DEFAULT FALSE,
+    config       jsonb     NOT NULL DEFAULT '{}'::jsonb,
     created_at   timestamp NOT NULL DEFAULT timezone('utc'::text, now()),
     deleted_at   timestamp NULL     DEFAULT NULL
 );

--- a/scripts/schema/db/rollback_dbs/postgresql/1.27.0/1.27.0.sql
+++ b/scripts/schema/db/rollback_dbs/postgresql/1.27.0/1.27.0.sql
@@ -1,0 +1,29 @@
+\set previous_version 'v1.27.0'
+\set next_version 'v1.26.0'
+SELECT openreplay_version()                       AS current_version,
+       openreplay_version() = :'previous_version' AS valid_previous,
+       openreplay_version() = :'next_version'     AS is_next
+\gset
+
+\if :valid_previous
+\echo valid previous DB version :'previous_version', starting DB downgrade to :'next_version'
+BEGIN;
+SELECT format($fn_def$
+CREATE OR REPLACE FUNCTION openreplay_version()
+    RETURNS text AS
+$$
+SELECT '%1$s'
+$$ LANGUAGE sql IMMUTABLE;
+$fn_def$, :'next_version')
+\gexec
+
+ALTER TABLE public.dashboards
+    DROP COLUMN IF EXISTS config;
+
+COMMIT;
+
+\elif :is_next
+\echo new version detected :'next_version', nothing to do
+\else
+\warn skipping DB downgrade of :'next_version', expected previous version :'previous_version', found :'current_version'
+\endif


### PR DESCRIPTION
## Summary
- persist dashboard-level `config.defaultPeriod` across frontend, API, backend, and schema
- let users save the dashboard default time range from the existing edit modal
- hydrate the dashboard page period from the saved default on load/select

## Scope
- time range only for issue #4139
- deliberately excludes series limit so the change stays bounded and reviewable

## QA
- `python3 -m py_compile api/schemas/schemas.py api/chalicelib/core/metrics/dashboards.py`
- `gofmt -w backend/pkg/analytics/dashboards/model.go backend/pkg/analytics/dashboards/dashboards.go`
- `go test ./pkg/analytics/dashboards/...`
- `./node_modules/.bin/jest --runInBand app/mstore/types/dashboard.test.ts`
- `git diff --check`

## Notes
- preserves backward compatibility for older update clients that omit `config`, so existing saved defaults are not overwritten
- Python writes dashboard config using alias/camelCase to match the Go service JSON shape