### PR TITLE
feat(ci): add dedicated backend build to patch workflows

### DIFF
--- a/.github/workflows/patch-build-old.yaml
+++ b/.github/workflows/patch-build-old.yaml
@@ -136,14 +136,21 @@ jobs:
         function build_managed() {
           local service=$1
           local version=$2
-          echo building managed
+          echo "Building managed: $service"
           clone_msaas
-          if [[ $service == 'chalice' ]]; then
+          if grep -qx $service /tmp/backend.txt; then
+            # Backend service: use dedicated build script
+            cp "$MSAAS_REPO_FOLDER/hacks/dedicated-backend-build/build_dedicated.sh" \
+               "$MSAAS_REPO_FOLDER/openreplay/backend/build.sh"
+            cd "$MSAAS_REPO_FOLDER/openreplay/backend"
+            IMAGE_TAG=$version DOCKER_RUNTIME="depot" DOCKER_BUILD_ARGS="--push" ARCH=arm64 DOCKER_REPO=$DOCKER_REPO_ARM PUSH_IMAGE=0 bash build.sh nil $service
+          elif [[ $service == 'chalice' ]]; then
             cd $MSAAS_REPO_FOLDER/openreplay/api
+            IMAGE_TAG=$version DOCKER_RUNTIME="depot" DOCKER_BUILD_ARGS="--push" ARCH=arm64 DOCKER_REPO=$DOCKER_REPO_ARM PUSH_IMAGE=0 bash build.sh >> /tmp/arm.txt
           else
             cd $MSAAS_REPO_FOLDER/openreplay/$service
+            IMAGE_TAG=$version DOCKER_RUNTIME="depot" DOCKER_BUILD_ARGS="--push" ARCH=arm64 DOCKER_REPO=$DOCKER_REPO_ARM PUSH_IMAGE=0 bash build.sh >> /tmp/arm.txt
           fi
-          IMAGE_TAG=$version DOCKER_RUNTIME="depot" DOCKER_BUILD_ARGS="--push" ARCH=arm64 DOCKER_REPO=$DOCKER_REPO_ARM PUSH_IMAGE=0 bash build.sh >> /tmp/arm.txt
         }
         # Checking for backend images
         ls backend/cmd >> /tmp/backend.txt
@@ -196,6 +203,10 @@ jobs:
               echo IMAGE_TAG=$version DOCKER_RUNTIME="depot" DOCKER_BUILD_ARGS="--push" ARCH=arm64 DOCKER_REPO=$DOCKER_REPO_ARM PUSH_IMAGE=0 bash ${BUILD_SCRIPT_NAME} $foss_build_args
             fi
           else
+            build_managed $SERVICE $version
+          fi
+          # Build managed/dedicated for backend services
+          if grep -qx $SERVICE /tmp/backend.txt; then
             build_managed $SERVICE $version
           fi
           cd $working_dir

--- a/.github/workflows/patch-build.yaml
+++ b/.github/workflows/patch-build.yaml
@@ -129,7 +129,7 @@ jobs:
             fi
         }
 
-        # Build managed services
+        # Build managed/dedicated services via the msaas repo
         build_managed() {
             local service=$1
             local version=$2
@@ -138,17 +138,23 @@ jobs:
             echo "Building managed service: $service"
             clone_msaas
 
-            if [[ $service == 'chalice' ]]; then
+            if grep -qx "$service" "$BACKEND_SERVICES_FILE"; then
+                # Backend service: use dedicated build script (Kafka queue from ee, no license)
+                cp "$MSAAS_REPO_FOLDER/hacks/dedicated-backend-build/build_dedicated.sh" \
+                   "$MSAAS_REPO_FOLDER/openreplay/backend/build.sh"
+                cd "$MSAAS_REPO_FOLDER/openreplay/backend"
+                local build_cmd="IMAGE_TAG=$version DOCKER_RUNTIME=depot DOCKER_BUILD_ARGS=--push ARCH=$arch DOCKER_REPO=$DOCKER_REPO_ARM PUSH_IMAGE=0 bash build.sh nil $service"
+            elif [[ $service == 'chalice' ]]; then
                 cd "$MSAAS_REPO_FOLDER/openreplay/api"
+                local build_cmd="IMAGE_TAG=$version DOCKER_RUNTIME=depot DOCKER_BUILD_ARGS=--push ARCH=$arch DOCKER_REPO=$DOCKER_REPO_ARM PUSH_IMAGE=0 bash build.sh"
             else
                 cd "$MSAAS_REPO_FOLDER/openreplay/$service"
+                local build_cmd="IMAGE_TAG=$version DOCKER_RUNTIME=depot DOCKER_BUILD_ARGS=--push ARCH=$arch DOCKER_REPO=$DOCKER_REPO_ARM PUSH_IMAGE=0 bash build.sh"
             fi
-
-            local build_cmd="IMAGE_TAG=$version DOCKER_RUNTIME=depot DOCKER_BUILD_ARGS=--push ARCH=$arch DOCKER_REPO=$DOCKER_REPO_ARM PUSH_IMAGE=0 bash build.sh"
 
             echo "Executing: $build_cmd"
             if ! eval "$build_cmd" 2>&1; then
-                echo "Build failed for $service"
+                echo "Managed build failed for $service"
                 exit 1
             fi
         }
@@ -253,10 +259,15 @@ jobs:
                 fi
                 build_service "$service" "${version}-ee" "$ee_build_args" "$build_script"
 
-                # Building managed
+                # Build managed/dedicated images
                 case "$service" in
                 chalice | frontend)
                     build_managed "$service" "$version"
+                    ;;
+                *)
+                    if grep -qx "$service" "$BACKEND_SERVICES_FILE"; then
+                        build_managed "$service" "$version"
+                    fi
                     ;;
                 esac
                 # Update chart and commit


### PR DESCRIPTION
For backend services, after FOSS/EE builds, also build a dedicated
image (tagged ${version}-dedicated) using build_dedicated.sh from
the msaas repo. The script overlays Kafka queue from ee and strips
license checks, producing a drop-in image for dedicated deployments.
