### PR TITLE
Add health check to default nginx server

### DIFF
--- a/scripts/helmcharts/openreplay/values.yaml
+++ b/scripts/helmcharts/openreplay/values.yaml
@@ -61,6 +61,9 @@ ingress-nginx:
     image:
       tag: 5.3.1-alpine
     enableSnippets: true
+    # Keep k8s ingress compatible health check for LB
+    healthStatus: true
+    healthStatusURI: /healthz
     ingressClass:
       name: openreplay
       create: true
@@ -79,11 +82,6 @@ ingress-nginx:
           }
         server-tokens: "false"
         server-snippets: |-
-          # Keep k8s ingress compatible health check for LB
-          location /healthz {
-            access_log off;
-            return 200 "ok";
-          }
           # Security headers
           add_header X-XSS-Protection "1; mode=block" always;
           add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
The health check server snippet is added to the server block with the server name of your configured domain. This means health checks must provide the host header which is not possible in all cloud environments for example AWS.

Enabling and configuring the health status URI adds the /healthz endpoint back to the default server and nginx responds with 200.

The location nginx adds has some differences from the server snippet
- Does not turn off the access log
- Returns "healthy" instead of "ok"

```nginx
location /healthz {
  default_type text/plain;
  return 200 "healthy\n";
}
```

This would be a breaking change if a health check also checked for body of "ok".