### PR TITLE
feat(mcp-auth): browser based auth

### DIFF
--- a/ee/mcp_app/lib/api.ts
+++ b/ee/mcp_app/lib/api.ts
@@ -1,293 +1,319 @@
-import { state } from "./state.js";
-import { resolveCountryValue } from "./countries.js";
+import {state, createPollAbortController} from "./state.js";
+import {resolveCountryValue} from "./countries.js";
 
-function resolveBaseUrl(backendUrl: string): { base: string; isSaas: boolean } {
-  try {
-    const urlObj = new URL(backendUrl);
-    if (urlObj.hostname === 'app.openreplay.com') {
-      urlObj.hostname = 'api.openreplay.com';
-    }
-    const isSaas = urlObj.hostname === 'api.openreplay.com';
-    // Remove trailing slash
-    return { base: urlObj.origin, isSaas };
-  } catch {
-    return { base: backendUrl.replace(/\/$/, ''), isSaas: false };
-  }
-}
+const API_PATH = process.env.API_PATH ?? "/api";
 
 // Helper function to make authenticated API requests
 export async function makeApiRequest(endpoint: string, options: RequestInit = {}) {
-  const { base, isSaas } = resolveBaseUrl(state.backendUrl);
-  const url = isSaas ? `${base}${endpoint.replace(/^\/api/, '').replace(/^\/v2\/api/, '/v2')}` : `${base}${endpoint}`;
-  const headers = {
-    "Accept": "application/json",
-    "Content-Type": "application/json",
-    ...(state.jwt ? { "Authorization": `Bearer ${state.jwt}` } : {}),
-    ...options.headers,
-  };
+    const base = state.backendUrl.replace(/\/$/, '');
+    const resolvedEndpoint = API_PATH + endpoint;
+    const url = `${base}${resolvedEndpoint}`;
+    const headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        ...(state.jwt ? {"Authorization": `Bearer ${state.jwt}`} : {}),
+        ...options.headers,
+    };
 
-  console.error(`[SERVER] Making API request to: ${url}`);
+    console.error(`[SERVER] Making API request to: ${url}`);
 
-  const response = await fetch(url, { ...options, headers });
+    const response = await fetch(url, {...options, headers});
 
-  if (!response.ok) {
-    const error = await response.text();
-    console.error(`[SERVER] API request failed: ${response.status} ${response.statusText}`);
+    if (!response.ok) {
+        const error = await response.text();
+        console.error(`[SERVER] API request failed: ${response.status} ${response.statusText}`);
 
-    // Check if it's an auth error
-    if (response.status === 401 || response.status === 403) {
-      throw new Error(`AUTH_ERROR: ${response.status} ${response.statusText}`);
+        // Check if it's an auth error
+        if (response.status === 401 || response.status === 403) {
+            throw new Error(`AUTH_ERROR: ${response.status} ${response.statusText}`);
+        }
+
+        throw new Error(`API request failed: ${response.status} ${response.statusText} - ${error}`);
     }
 
-    throw new Error(`API request failed: ${response.status} ${response.statusText} - ${error}`);
-  }
-
-  return response.json();
+    return response.json();
 }
 
 // --- Filter helpers ---
 
 // Fetch filter definitions for a project
 export async function fetchFilters(siteId: string) {
-  console.error(`[SERVER] Fetching filters for site ${siteId}...`);
+    console.error(`[SERVER] Fetching filters for site ${siteId}...`);
 
-  if (!state.jwt) {
-    throw new Error("AUTH_ERROR: Not authenticated");
-  }
+    if (!state.jwt) {
+        throw new Error("AUTH_ERROR: Not authenticated");
+    }
 
-  const { data } = await makeApiRequest(`/api/pa/${siteId}/filters`);
-  state.projectFilters[siteId] = data;
-  console.error(`[SERVER] Cached filters for site ${siteId}`);
-  return data;
+    const {data} = await makeApiRequest(`/pa/${siteId}/filters`);
+    state.projectFilters[siteId] = data;
+    console.error(`[SERVER] Cached filters for site ${siteId}`);
+    return data;
 }
 
 // Get filters from cache or fetch them
 export async function getOrFetchFilters(siteId: string) {
-  if (state.projectFilters[siteId]) {
-    return state.projectFilters[siteId];
-  }
-  try {
-    return await fetchFilters(siteId);
-  } catch (err) {
-    console.error(`[SERVER] Failed to fetch filters for site ${siteId}:`, err);
-    return null;
-  }
+    if (state.projectFilters[siteId]) {
+        return state.projectFilters[siteId];
+    }
+    try {
+        return await fetchFilters(siteId);
+    } catch (err) {
+        console.error(`[SERVER] Failed to fetch filters for site ${siteId}:`, err);
+        return null;
+    }
 }
 
 // Resolve simplified model filters into full API filter objects
 export async function resolveFilters(
-  siteId: string,
-  modelFilters: Array<{ name: string; value: string[]; operator?: string }>,
+    siteId: string,
+    modelFilters: Array<{ name: string; value: string[]; operator?: string }>,
 ): Promise<any[]> {
-  const filterDefs = await getOrFetchFilters(siteId);
-  if (!filterDefs) return [];
+    const filterDefs = await getOrFetchFilters(siteId);
+    if (!filterDefs) return [];
 
-  // Flatten all filter definitions from categorized response
-  const allDefs: any[] = [];
-  for (const category of Object.values(filterDefs) as any[]) {
-    if (category?.list) {
-      allDefs.push(...category.list);
-    }
-  }
-
-  return modelFilters.map((mf) => {
-    const def = allDefs.find((d: any) => d.name === mf.name);
-
-    // Resolve country values if applicable
-    let resolvedValues = mf.value;
-    if (mf.name === "userCountry") {
-      resolvedValues = mf.value.map(resolveCountryValue);
+    // Flatten all filter definitions from categorized response
+    const allDefs: any[] = [];
+    for (const category of Object.values(filterDefs) as any[]) {
+        if (category?.list) {
+            allDefs.push(...category.list);
+        }
     }
 
-    return {
-      value: resolvedValues,
-      operator: mf.operator || "is",
-      dataType: def?.dataType || "string",
-      propertyOrder: "and",
-      filters: [],
-      isEvent: def?.isEvent ?? false,
-      name: mf.name,
-      autoCaptured: def?.autoCaptured ?? true,
-    };
-  });
+    return modelFilters.map((mf) => {
+        const def = allDefs.find((d: any) => d.name === mf.name);
+
+        // Resolve country values if applicable
+        let resolvedValues = mf.value;
+        if (mf.name === "userCountry") {
+            resolvedValues = mf.value.map(resolveCountryValue);
+        }
+
+        return {
+            value: resolvedValues,
+            operator: mf.operator || "is",
+            dataType: def?.dataType || "string",
+            propertyOrder: "and",
+            filters: [],
+            isEvent: def?.isEvent ?? false,
+            name: mf.name,
+            autoCaptured: def?.autoCaptured ?? true,
+        };
+    });
 }
 
 // --- Data fetching ---
 
 // Fetch recent sessions from OpenReplay
 export async function fetchRecentSessions(siteId: string = "5", limit: number = 10, filters: any[] = []) {
-  console.error(`[SERVER] Fetching recent sessions for site ${siteId}...`);
+    console.error(`[SERVER] Fetching recent sessions for site ${siteId}...`);
 
-  if (!state.jwt) {
-    throw new Error("AUTH_ERROR: Not authenticated");
-  }
+    if (!state.jwt) {
+        throw new Error("AUTH_ERROR: Not authenticated");
+    }
 
-  const now = Date.now();
-  const yesterday = now - 24 * 60 * 60 * 1000;
+    const now = Date.now();
+    const yesterday = now - 24 * 60 * 60 * 1000;
 
-  const searchPayload = {
-    filters: filters,
-    rangeValue: "LAST_24_HOURS",
-    startDate: yesterday,
-    endDate: now,
-    sort: "startTs",
-    order: "desc",
-    viewed: false,
-    eventsOrder: "then",
-    limit,
-    startTimestamp: Math.floor(yesterday / 1000) * 1000,
-    endTimestamp: Math.floor(now / 1000) * 1000,
-    page: 1,
-  };
+    const searchPayload = {
+        filters: filters,
+        rangeValue: "LAST_24_HOURS",
+        startDate: yesterday,
+        endDate: now,
+        sort: "startTs",
+        order: "desc",
+        viewed: false,
+        eventsOrder: "then",
+        limit,
+        startTimestamp: Math.floor(yesterday / 1000) * 1000,
+        endTimestamp: Math.floor(now / 1000) * 1000,
+        page: 1,
+    };
 
-  const { data } = await makeApiRequest(`/v2/api/${siteId}/sessions/search`, {
-    method: "POST",
-    body: JSON.stringify(searchPayload),
-  });
+    const {data} = await makeApiRequest(`/v2/api/${siteId}/sessions/search`, {
+        method: "POST",
+        body: JSON.stringify(searchPayload),
+    });
 
-  console.error(`[SERVER] Found ${data.sessions?.length || 0} sessions`);
+    console.error(`[SERVER] Found ${data.sessions?.length || 0} sessions`);
 
-  if (!data.sessions || data.sessions.length === 0) {
-    console.error('Used params', siteId, searchPayload, "\n data", data);
-    throw new Error("No sessions found in the last 24 hours");
-  }
+    if (!data.sessions || data.sessions.length === 0) {
+        console.error('Used params', siteId, searchPayload, "\n data", data);
+        throw new Error("No sessions found in the last 24 hours");
+    }
 
-  // Construct player URLs for each session
-  const baseUrl = state.backendUrl.replace("/api", "").replace("//api.", "//app.");
-  const jwt = state.jwt!; // Already checked above
+    // Construct player URLs for each session
+    const baseUrl = state.backendUrl.replace("/api", "").replace("//api.", "//app.");
+    const jwt = state.jwt!; // Already checked above
 
-  const sessions = data.sessions.map((session: any) => ({
-    ...session,
-    replayUrl: `${baseUrl}/${siteId}/session/${session.sessionId}?jwt=${encodeURIComponent(jwt)}`,
-  }));
+    const sessions = data.sessions.map((session: any) => ({
+        ...session,
+        replayUrl: `${baseUrl}/${siteId}/session/${session.sessionId}?jwt=${encodeURIComponent(jwt)}`,
+    }));
 
-  console.error(`[SERVER] Returning ${sessions.length} sessions`);
+    console.error(`[SERVER] Returning ${sessions.length} sessions`);
 
-  return sessions;
+    return sessions;
 }
 
 // Fetch projects from OpenReplay
 export async function fetchProjects() {
-  console.error("[SERVER] Fetching projects...");
+    console.error("[SERVER] Fetching projects...");
 
-  if (!state.jwt) {
-    throw new Error("AUTH_ERROR: Not authenticated");
-  }
+    if (!state.jwt) {
+        throw new Error("AUTH_ERROR: Not authenticated");
+    }
 
-  const { data } = await makeApiRequest("/api/projects");
-  console.error(`[SERVER] Found ${data.length || 0} projects`);
+    const {data} = await makeApiRequest("/projects");
+    console.error(`[SERVER] Found ${data.length || 0} projects`);
 
-  // Store projects in state
-  state.projects = data.map((project: any) => ({
-    projectId: String(project.projectId || project.id),
-    name: project.name,
-  }));
+    // Store projects in state
+    state.projects = data.map((project: any) => ({
+        projectId: String(project.projectId || project.id),
+        name: project.name,
+    }));
 
-  return state.projects;
+    return state.projects;
 }
 
 // Fetch sessions timeseries chart data
 export async function fetchSessionsTimeseries(
-  siteId: string,
-  startTimestamp: number,
-  endTimestamp: number,
-  density: number = 24,
-  filters: any[] = [],
+    siteId: string,
+    startTimestamp: number,
+    endTimestamp: number,
+    density: number = 24,
+    filters: any[] = [],
 ) {
-  console.error(`[SERVER] Fetching sessions timeseries for site ${siteId} (${startTimestamp} - ${endTimestamp}, density: ${density})...`);
+    console.error(`[SERVER] Fetching sessions timeseries for site ${siteId} (${startTimestamp} - ${endTimestamp}, density: ${density})...`);
 
-  if (!state.jwt) {
-    throw new Error("AUTH_ERROR: Not authenticated");
-  }
+    if (!state.jwt) {
+        throw new Error("AUTH_ERROR: Not authenticated");
+    }
 
-  const payload = {
-    startTimestamp,
-    endTimestamp,
-    density,
-    metricOf: "sessionCount",
-    metricType: "timeseries",
-    metricFormat: "sessionCount",
-    viewType: "lineChart",
-    name: "Sessions Over Time",
-    series: [
-      {
-        seriesId: null,
-        name: "Sessions",
-        filter: {
-          filters: filters,
-          excludes: [],
-          eventsOrder: "then",
-          startTimestamp: 0,
-          endTimestamp: 0,
-          page: 1,
-          limit: 10,
-        },
-      },
-    ],
-    page: 1,
-    limit: 20,
-    sortOrder: "desc",
-  };
+    const payload = {
+        startTimestamp,
+        endTimestamp,
+        density,
+        metricOf: "sessionCount",
+        metricType: "timeseries",
+        metricFormat: "sessionCount",
+        viewType: "lineChart",
+        name: "Sessions Over Time",
+        series: [
+            {
+                seriesId: null,
+                name: "Sessions",
+                filter: {
+                    filters: filters,
+                    excludes: [],
+                    eventsOrder: "then",
+                    startTimestamp: 0,
+                    endTimestamp: 0,
+                    page: 1,
+                    limit: 10,
+                },
+            },
+        ],
+        page: 1,
+        limit: 20,
+        sortOrder: "desc",
+    };
 
-  const { data } = await makeApiRequest(`/v2/api/${siteId}/cards/try`, {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+    const {data} = await makeApiRequest(`/v2/api/${siteId}/cards/try`, {
+        method: "POST",
+        body: JSON.stringify(payload),
+    });
 
-  console.error(`[SERVER] Got ${data?.length || 0} timeseries data points`);
-  return data;
+    console.error(`[SERVER] Got ${data?.length || 0} timeseries data points`);
+    return data;
 }
 
 // Fetch path analysis (user journey / sankey) data
 export async function fetchPathAnalysis(
-  siteId: string,
-  startTimestamp: number,
-  endTimestamp: number,
-  startPoint?: string,
-  filters: any[] = [],
+    siteId: string,
+    startTimestamp: number,
+    endTimestamp: number,
+    startPoint?: string,
+    filters: any[] = [],
 ) {
-  console.error(`[SERVER] Fetching path analysis for site ${siteId} (start point: ${startPoint || "auto"})...`);
+    console.error(`[SERVER] Fetching path analysis for site ${siteId} (start point: ${startPoint || "auto"})...`);
 
-  if (!state.jwt) {
-    throw new Error("AUTH_ERROR: Not authenticated");
-  }
+    if (!state.jwt) {
+        throw new Error("AUTH_ERROR: Not authenticated");
+    }
 
-  const payload = {
-    startTimestamp,
-    endTimestamp,
-    density: 5,
-    metricOf: "sessionCount",
-    metricValue: [],
-    metricType: "pathAnalysis",
-    metricFormat: "sessionCount",
-    viewType: "lineChart",
-    name: "User Journey",
-    series: [
-      {
-        name: "Series 1",
-        filter: {
-          filters: filters,
-          excludes: [],
-          eventsOrder: "then",
-          startTimestamp: 0,
-          endTimestamp: 0,
-          page: 1,
-          limit: 10,
-        },
-      },
-    ],
-    page: 1,
-    rows: 5,
-    stepsBefore: 0,
-    stepsAfter: 5,
-    columns: 4,
-    limit: 20,
-    sortOrder: "desc",
-    hideExcess: true,
-    startType: "start",
-    startPoint: [
-      {
-        value: startPoint ? [startPoint] : [],
+    const payload = {
+        startTimestamp,
+        endTimestamp,
+        density: 5,
+        metricOf: "sessionCount",
+        metricValue: [],
+        metricType: "pathAnalysis",
+        metricFormat: "sessionCount",
+        viewType: "lineChart",
+        name: "User Journey",
+        series: [
+            {
+                name: "Series 1",
+                filter: {
+                    filters: filters,
+                    excludes: [],
+                    eventsOrder: "then",
+                    startTimestamp: 0,
+                    endTimestamp: 0,
+                    page: 1,
+                    limit: 10,
+                },
+            },
+        ],
+        page: 1,
+        rows: 5,
+        stepsBefore: 0,
+        stepsAfter: 5,
+        columns: 4,
+        limit: 20,
+        sortOrder: "desc",
+        hideExcess: true,
+        startType: "start",
+        startPoint: [
+            {
+                value: startPoint ? [startPoint] : [],
+                operator: "is",
+                dataType: "string",
+                propertyOrder: "and",
+                filters: [],
+                isEvent: true,
+                name: "LOCATION",
+                autoCaptured: true,
+            },
+        ],
+        excludes: [],
+    };
+
+    const {data} = await makeApiRequest(`/v2/api/${siteId}/cards/try`, {
+        method: "POST",
+        body: JSON.stringify(payload),
+    });
+
+    console.error(`[SERVER] Got path analysis: ${data?.nodes?.length || 0} nodes, ${data?.links?.length || 0} links`);
+    return data;
+}
+
+// Fetch Web Vitals data
+export async function fetchWebVitals(
+    siteId: string,
+    startTimestamp: number,
+    endTimestamp: number,
+    filters: any[] = [],
+) {
+    console.error(`[SERVER] Fetching web vitals for site ${siteId}...`);
+
+    if (!state.jwt) {
+        throw new Error("AUTH_ERROR: Not authenticated");
+    }
+
+    // LOCATION event filter is required by the web vitals endpoint
+    const locationFilter = {
+        value: [],
         operator: "is",
         dataType: "string",
         propertyOrder: "and",
@@ -295,356 +321,336 @@ export async function fetchPathAnalysis(
         isEvent: true,
         name: "LOCATION",
         autoCaptured: true,
-      },
-    ],
-    excludes: [],
-  };
+    };
 
-  const { data } = await makeApiRequest(`/v2/api/${siteId}/cards/try`, {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+    const payload = {
+        startTimestamp,
+        endTimestamp,
+        density: 24,
+        metricOf: "webVitalUrl",
+        metricValue: [],
+        metricType: "webVital",
+        metricFormat: "sessionCount",
+        viewType: "chart",
+        name: "Web Vitals",
+        series: [
+            {
+                name: "Series 1",
+                filter: {
+                    filters: [locationFilter, ...filters],
+                    excludes: [],
+                    eventsOrder: "then",
+                    startTimestamp: 0,
+                    endTimestamp: 0,
+                    page: 1,
+                    limit: 10,
+                },
+            },
+        ],
+        page: 1,
+        limit: 20,
+        sortOrder: "desc",
+    };
 
-  console.error(`[SERVER] Got path analysis: ${data?.nodes?.length || 0} nodes, ${data?.links?.length || 0} links`);
-  return data;
-}
+    const {data} = await makeApiRequest(`/v2/api/${siteId}/cards/try`, {
+        method: "POST",
+        body: JSON.stringify(payload),
+    });
 
-// Fetch Web Vitals data
-export async function fetchWebVitals(
-  siteId: string,
-  startTimestamp: number,
-  endTimestamp: number,
-  filters: any[] = [],
-) {
-  console.error(`[SERVER] Fetching web vitals for site ${siteId}...`);
-
-  if (!state.jwt) {
-    throw new Error("AUTH_ERROR: Not authenticated");
-  }
-
-  // LOCATION event filter is required by the web vitals endpoint
-  const locationFilter = {
-    value: [],
-    operator: "is",
-    dataType: "string",
-    propertyOrder: "and",
-    filters: [],
-    isEvent: true,
-    name: "LOCATION",
-    autoCaptured: true,
-  };
-
-  const payload = {
-    startTimestamp,
-    endTimestamp,
-    density: 24,
-    metricOf: "webVitalUrl",
-    metricValue: [],
-    metricType: "webVital",
-    metricFormat: "sessionCount",
-    viewType: "chart",
-    name: "Web Vitals",
-    series: [
-      {
-        name: "Series 1",
-        filter: {
-          filters: [locationFilter, ...filters],
-          excludes: [],
-          eventsOrder: "then",
-          startTimestamp: 0,
-          endTimestamp: 0,
-          page: 1,
-          limit: 10,
-        },
-      },
-    ],
-    page: 1,
-    limit: 20,
-    sortOrder: "desc",
-  };
-
-  const { data } = await makeApiRequest(`/v2/api/${siteId}/cards/try`, {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
-
-  console.error(`[SERVER] Got web vitals data: ${Object.keys(data || {}).join(", ")}`);
-  return data;
+    console.error(`[SERVER] Got web vitals data: ${Object.keys(data || {}).join(", ")}`);
+    return data;
 }
 
 // Fetch table data (top pages, top browsers, top countries, top requests, etc.)
 export async function fetchTableData(
-  siteId: string,
-  startTimestamp: number,
-  endTimestamp: number,
-  metricOf: string,
-  limit: number = 20,
-  filters: any[] = [],
+    siteId: string,
+    startTimestamp: number,
+    endTimestamp: number,
+    metricOf: string,
+    limit: number = 20,
+    filters: any[] = [],
 ) {
-  console.error(`[SERVER] Fetching table data for site ${siteId}, metricOf=${metricOf}...`);
+    console.error(`[SERVER] Fetching table data for site ${siteId}, metricOf=${metricOf}...`);
 
-  if (!state.jwt) {
-    throw new Error("AUTH_ERROR: Not authenticated");
-  }
+    if (!state.jwt) {
+        throw new Error("AUTH_ERROR: Not authenticated");
+    }
 
-  const payload = {
-    startTimestamp,
-    endTimestamp,
-    density: 24,
-    metricOf,
-    metricValue: [],
-    metricType: "table",
-    metricFormat: "sessionCount",
-    viewType: "table",
-    name: `Top ${metricOf}`,
-    series: [
-      {
-        name: "Series 1",
-        filter: {
-          filters: filters,
-          excludes: [],
-          eventsOrder: "and",
-          startTimestamp: 0,
-          endTimestamp: 0,
-          page: 1,
-          limit: 10,
-        },
-      },
-    ],
-    page: 1,
-    rows: 5,
-    limit,
-    sortOrder: "desc",
-  };
+    const payload = {
+        startTimestamp,
+        endTimestamp,
+        density: 24,
+        metricOf,
+        metricValue: [],
+        metricType: "table",
+        metricFormat: "sessionCount",
+        viewType: "table",
+        name: `Top ${metricOf}`,
+        series: [
+            {
+                name: "Series 1",
+                filter: {
+                    filters: filters,
+                    excludes: [],
+                    eventsOrder: "and",
+                    startTimestamp: 0,
+                    endTimestamp: 0,
+                    page: 1,
+                    limit: 10,
+                },
+            },
+        ],
+        page: 1,
+        rows: 5,
+        limit,
+        sortOrder: "desc",
+    };
 
-  const { data } = await makeApiRequest(`/v2/api/${siteId}/cards/try`, {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+    const {data} = await makeApiRequest(`/v2/api/${siteId}/cards/try`, {
+        method: "POST",
+        body: JSON.stringify(payload),
+    });
 
-  console.error(`[SERVER] Got table data: ${data?.values?.length || 0} values, total=${data?.total || 0}`);
-  return data;
+    console.error(`[SERVER] Got table data: ${data?.values?.length || 0} values, total=${data?.total || 0}`);
+    return data;
 }
 
 // Fetch funnel data (step-by-step conversion)
 export async function fetchFunnel(
-  siteId: string,
-  startTimestamp: number,
-  endTimestamp: number,
-  steps: string[],
-  filters: any[] = [],
+    siteId: string,
+    startTimestamp: number,
+    endTimestamp: number,
+    steps: string[],
+    filters: any[] = [],
 ) {
-  console.error(`[SERVER] Fetching funnel for site ${siteId}, steps: ${steps.join(' -> ')}...`);
+    console.error(`[SERVER] Fetching funnel for site ${siteId}, steps: ${steps.join(' -> ')}...`);
 
-  if (!state.jwt) {
-    throw new Error("AUTH_ERROR: Not authenticated");
-  }
+    if (!state.jwt) {
+        throw new Error("AUTH_ERROR: Not authenticated");
+    }
 
-  // Each step becomes a LOCATION event filter
-  const stepFilters = steps.map(step => ({
-    value: step ? [step] : [],
-    operator: "is",
-    dataType: "string",
-    propertyOrder: "and",
-    filters: [],
-    isEvent: true,
-    name: "LOCATION",
-    autoCaptured: true,
-  }));
+    // Each step becomes a LOCATION event filter
+    const stepFilters = steps.map(step => ({
+        value: step ? [step] : [],
+        operator: "is",
+        dataType: "string",
+        propertyOrder: "and",
+        filters: [],
+        isEvent: true,
+        name: "LOCATION",
+        autoCaptured: true,
+    }));
 
-  const payload = {
-    startTimestamp,
-    endTimestamp,
-    density: 24,
-    metricOf: "sessionCount",
-    metricValue: [],
-    metricType: "funnel",
-    metricFormat: "sessionCount",
-    viewType: "chart",
-    name: "Funnel Analysis",
-    series: [
-      {
-        name: "Series 1",
-        filter: {
-          filters: [...stepFilters, ...filters],
-          excludes: [],
-          eventsOrder: "then",
-          startTimestamp: 0,
-          endTimestamp: 0,
-          page: 1,
-          limit: 10,
-        },
-      },
-    ],
-    page: 1,
-    limit: 20,
-    sortOrder: "desc",
-  };
+    const payload = {
+        startTimestamp,
+        endTimestamp,
+        density: 24,
+        metricOf: "sessionCount",
+        metricValue: [],
+        metricType: "funnel",
+        metricFormat: "sessionCount",
+        viewType: "chart",
+        name: "Funnel Analysis",
+        series: [
+            {
+                name: "Series 1",
+                filter: {
+                    filters: [...stepFilters, ...filters],
+                    excludes: [],
+                    eventsOrder: "then",
+                    startTimestamp: 0,
+                    endTimestamp: 0,
+                    page: 1,
+                    limit: 10,
+                },
+            },
+        ],
+        page: 1,
+        limit: 20,
+        sortOrder: "desc",
+    };
 
-  const { data } = await makeApiRequest(`/v2/api/${siteId}/cards/try`, {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+    const {data} = await makeApiRequest(`/v2/api/${siteId}/cards/try`, {
+        method: "POST",
+        body: JSON.stringify(payload),
+    });
 
-  console.error(`[SERVER] Got funnel data: ${data?.stages?.length || 0} stages`);
-  return data;
+    console.error(`[SERVER] Got funnel data: ${data?.stages?.length || 0} stages`);
+    return data;
 }
 
 // Fetch session replay metadata
 export async function fetchSessionReplay(siteId: string, sessionId: string) {
-  console.error(`[SERVER] Fetching session replay for ${sessionId} in site ${siteId}...`);
+    console.error(`[SERVER] Fetching session replay for ${sessionId} in site ${siteId}...`);
 
-  if (!state.jwt) {
-    throw new Error("AUTH_ERROR: Not authenticated");
-  }
+    if (!state.jwt) {
+        throw new Error("AUTH_ERROR: Not authenticated");
+    }
 
-  const { data } = await makeApiRequest(`/v2/api/${siteId}/sessions/${sessionId}/replay`);
-  return data;
+    const {data} = await makeApiRequest(`/v2/api/${siteId}/sessions/${sessionId}/replay`);
+    return data;
 }
 
 // Fetch session events (errors, events, incidents, issues, userEvents)
 export async function fetchSessionEvents(siteId: string, sessionId: string) {
-  console.error(`[SERVER] Fetching session events for ${sessionId} in site ${siteId}...`);
+    console.error(`[SERVER] Fetching session events for ${sessionId} in site ${siteId}...`);
 
-  if (!state.jwt) {
-    throw new Error("AUTH_ERROR: Not authenticated");
-  }
+    if (!state.jwt) {
+        throw new Error("AUTH_ERROR: Not authenticated");
+    }
 
-  const { data } = await makeApiRequest(`/v2/api/${siteId}/sessions/${sessionId}/events`);
-  return data;
+    const {data} = await makeApiRequest(`/v2/api/${siteId}/sessions/${sessionId}/events`);
+    return data;
 }
 
 // Fetch recent events (data management / analytics)
 export async function fetchEvents(
-  siteId: string,
-  startTimestamp: number,
-  endTimestamp: number,
-  limit: number = 50,
-  page: number = 1,
-  filters: any[] = [],
+    siteId: string,
+    startTimestamp: number,
+    endTimestamp: number,
+    limit: number = 50,
+    page: number = 1,
+    filters: any[] = [],
 ) {
-  console.error(`[SERVER] Fetching events for site ${siteId}...`);
+    console.error(`[SERVER] Fetching events for site ${siteId}...`);
 
-  if (!state.jwt) {
-    throw new Error("AUTH_ERROR: Not authenticated");
-  }
+    if (!state.jwt) {
+        throw new Error("AUTH_ERROR: Not authenticated");
+    }
 
-  const payload = {
-    sortOrder: "desc",
-    sortBy: "created_at",
-    limit,
-    startTimestamp,
-    endTimestamp,
-    columns: ["$city", "$os", "$auto_captured", "$user_id"],
-    page,
-    filters,
-  };
+    const payload = {
+        sortOrder: "desc",
+        sortBy: "created_at",
+        limit,
+        startTimestamp,
+        endTimestamp,
+        columns: ["$city", "$os", "$auto_captured", "$user_id"],
+        page,
+        filters,
+    };
 
-  const { data } = await makeApiRequest(`/api/${siteId}/events`, {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+    const {data} = await makeApiRequest(`/${siteId}/events`, {
+        method: "POST",
+        body: JSON.stringify(payload),
+    });
 
-  console.error(`[SERVER] Got ${data?.events?.length || 0} events (total: ${data?.total || 0})`);
-  return data;
+    console.error(`[SERVER] Got ${data?.events?.length || 0} events (total: ${data?.total || 0})`);
+    return data;
 }
 
 // Fetch users (data management / analytics)
 export async function fetchUsers(
-  siteId: string,
-  startTimestamp: number,
-  endTimestamp: number,
-  limit: number = 50,
-  page: number = 1,
-  query: string = "",
-  filters: any[] = [],
+    siteId: string,
+    startTimestamp: number,
+    endTimestamp: number,
+    limit: number = 50,
+    page: number = 1,
+    query: string = "",
+    filters: any[] = [],
 ) {
-  console.error(`[SERVER] Fetching users for site ${siteId}...`);
+    console.error(`[SERVER] Fetching users for site ${siteId}...`);
 
-  if (!state.jwt) {
-    throw new Error("AUTH_ERROR: Not authenticated");
-  }
+    if (!state.jwt) {
+        throw new Error("AUTH_ERROR: Not authenticated");
+    }
 
-  const payload = {
-    sortOrder: "desc",
-    sortBy: "$created_at",
-    limit,
-    startTimestamp,
-    endTimestamp,
-    columns: ["$avatar", "$email", "$state", "$city", "$country", "$created_at", "$name", "$last_seen"],
-    page,
-    filters,
-    query,
-  };
+    const payload = {
+        sortOrder: "desc",
+        sortBy: "$created_at",
+        limit,
+        startTimestamp,
+        endTimestamp,
+        columns: ["$avatar", "$email", "$state", "$city", "$country", "$created_at", "$name", "$last_seen"],
+        page,
+        filters,
+        query,
+    };
 
-  const { data } = await makeApiRequest(`/api/${siteId}/users`, {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+    const {data} = await makeApiRequest(`/${siteId}/users`, {
+        method: "POST",
+        body: JSON.stringify(payload),
+    });
 
-  console.error(`[SERVER] Got ${data?.users?.length || 0} users (total: ${data?.total || 0})`);
-  return data;
+    console.error(`[SERVER] Got ${data?.users?.length || 0} users (total: ${data?.total || 0})`);
+    return data;
 }
 
 // Fetch event properties (custom properties tracked for a given event)
 export async function fetchEventProperties(siteId: string) {
-  console.error(`[SERVER] Fetching event properties for site ${siteId}...`);
+    console.error(`[SERVER] Fetching event properties for site ${siteId}...`);
 
-  if (!state.jwt) {
-    throw new Error("AUTH_ERROR: Not authenticated");
-  }
+    if (!state.jwt) {
+        throw new Error("AUTH_ERROR: Not authenticated");
+    }
 
-  const { data } = await makeApiRequest(`/api/pa/${siteId}/filters`);
+    const {data} = await makeApiRequest(`/pa/${siteId}/filters`);
 
-  // Extract event-type filters (custom events and their properties)
-  const events = (data || []).filter((f: any) => f.isEvent);
-  const attributes = (data || []).filter((f: any) => !f.isEvent);
+    // Extract event-type filters (custom events and their properties)
+    const events = (data || []).filter((f: any) => f.isEvent);
+    const attributes = (data || []).filter((f: any) => !f.isEvent);
 
-  console.error(`[SERVER] Got ${events.length} events, ${attributes.length} attributes`);
-  return { events, attributes };
+    console.error(`[SERVER] Got ${events.length} events, ${attributes.length} attributes`);
+    return {events, attributes};
 }
 
 // Poll the backend for browser-based auth approval
 export async function pollForAuth(
-  backendUrl: string,
-  authCode: string,
-  clientId: string,
-  timeoutMs: number = 300_000,
-  intervalMs: number = 3_000,
+    backendUrl: string,
+    authCode: string,
+    clientId: string,
+    timeoutMs: number = 300_000,
+    intervalMs: number = 3_000,
 ): Promise<string | null> {
-  const deadline = Date.now() + timeoutMs;
+    const abortController = createPollAbortController();
+    const deadline = Date.now() + timeoutMs;
+    const statusUrl = `${backendUrl}/v1/mcp/auth-status?state=${authCode}&client_id=${clientId}`;
 
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(`${backendUrl}/v1/mcp/auth-status?state=${authCode}&client_id=${clientId}`);
+    while (Date.now() < deadline) {
+        if (abortController.signal.aborted) {
+            console.error("[SERVER] Browser auth polling aborted");
+            return null;
+        }
 
-      if (!res.ok) {
-        const errorData = await res.json().catch(() => null);
-        console.error(`[SERVER] auth-status returned ${res.status}:`, errorData?.error || res.statusText);
-        return null;
-      }
+        try {
+            const res = await fetch(statusUrl, {signal: abortController.signal});
 
-      const data = await res.json();
+            if (!res.ok) {
+                const errorData = await res.json().catch(() => null);
+                console.error(`[SERVER] auth-status returned ${res.status}:`, errorData?.error || res.statusText);
+                // Keep polling — the user may not have approved yet
+            } else {
+                const data = await res.json();
 
-      if (data.jwt) {
-        console.error("[SERVER] Browser auth approved");
-        return data.jwt;
-      }
-    } catch (err) {
-      console.error("[SERVER] Poll request failed, retrying...", err);
+                if (data.jwt) {
+                    console.error("[SERVER] Browser auth approved");
+                    return data.jwt;
+                }
+            }
+        } catch (err: any) {
+            if (err?.name === "AbortError") {
+                console.error("[SERVER] Browser auth polling aborted");
+                return null;
+            }
+            console.error("[SERVER] Poll request failed, retrying...", err);
+        }
+
+        await new Promise((r) => {
+            const timer = setTimeout(r, intervalMs);
+            abortController.signal.addEventListener("abort", () => {
+                clearTimeout(timer);
+                r(undefined);
+            }, {once: true});
+        });
     }
 
-    await new Promise((r) => setTimeout(r, intervalMs));
-  }
-
-  console.error("[SERVER] Browser auth timed out");
-  return null;
+    console.error("[SERVER] Browser auth timed out");
+    return null;
 }
 
 // Helper function to resolve project name to ID
 export function getProjectIdByName(projectName: string): string | null {
-  const project = state.projects.find(
-    (p) => p.name.toLowerCase() === projectName.toLowerCase()
-  );
-  return project ? project.projectId : null;
+    const project = state.projects.find(
+        (p) => p.name.toLowerCase() === projectName.toLowerCase()
+    );
+    return project ? project.projectId : null;
 }

--- a/ee/mcp_app/lib/schemas.ts
+++ b/ee/mcp_app/lib/schemas.ts
@@ -1,95 +1,92 @@
-import { z } from "zod";
+import {z} from "zod";
 
 export const ConfigureBackendSchema = z.object({
-  backendUrl: z.string().describe("OpenReplay backend API URL"),
+    backendUrl: z.string().describe("OpenReplay backend API URL"),
 });
 
 export const LoginSchema = z.object({
-  email: z.string().describe("Email address"),
-  password: z.string().describe("Password"),
-});
-
-export const LoginJwtSchema = z.object({
-  jwt: z.string().describe("JWT token for authentication"),
+    email: z.string().describe("Email address"),
+    password: z.string().describe("Password"),
 });
 
 export const LoginBrowserSchema = z.object({
-  backendUrl: z.string().optional().describe("OpenReplay backend URL (optional, uses current if already configured)"),
+    backendUrl: z.string().optional().describe("OpenReplay backend URL (optional, uses current if already configured)"),
+    frontendUrl: z.string().optional().describe("OpenReplay frontend URL (optional, uses current if already configured)"),
 });
 
 export const FetchChartDataSchema = z.object({
-  endpoint: z.string().describe("API endpoint to fetch chart data from"),
-  params: z.looseRecord(z.string(), z.any()).optional().describe("Query parameters"),
-  siteId: z.string().optional().describe("Site ID (project ID)"),
+    endpoint: z.string().describe("API endpoint to fetch chart data from"),
+    params: z.looseRecord(z.string(), z.any()).optional().describe("Query parameters"),
+    siteId: z.string().optional().describe("Site ID (project ID)"),
 });
 
 export const GetSessionReplaySchema = z.object({
-  sessionId: z.string().describe("Session ID to get replay URL for"),
-  siteId: z.string().optional().describe("Site ID (project ID)"),
+    sessionId: z.string().describe("Session ID to get replay URL for"),
+    siteId: z.string().optional().describe("Site ID (project ID)"),
 });
 
 export const GetProjectIdSchema = z.object({
-  projectName: z.string().describe("Project name to look up"),
+    projectName: z.string().describe("Project name to look up"),
 });
 
 export const FilterItemSchema = z.object({
-  name: z.string().describe("Filter name (e.g. 'userCountry', 'userBrowser', 'userOs', 'userDevice')"),
-  value: z.array(z.string()).describe("Filter values. For countries use full name like 'France'."),
-  operator: z.string().optional().default("is").describe("Operator: 'is', 'isNot', 'contains', etc."),
+    name: z.string().describe("Filter name (e.g. 'userCountry', 'userBrowser', 'userOs', 'userDevice')"),
+    value: z.array(z.string()).describe("Filter values. For countries use full name like 'France'."),
+    operator: z.string().optional().default("is").describe("Operator: 'is', 'isNot', 'contains', etc."),
 });
 
 export const ViewSessionsChartSchema = z.object({
-  startDate: z.string().describe("Start date as an ISO 8601 string (e.g. '2025-02-10' or '2025-02-10T00:00:00'). Convert relative references like 'last week' or 'past 3 days' to actual dates."),
-  endDate: z.string().describe("End date as an ISO 8601 string. Defaults to now if the user says 'until now' or doesn't specify an end."),
-  siteId: z.string().optional().describe("Site ID (project ID)"),
-  projectName: z.string().optional().describe("Project name to look up"),
-  filters: z.array(FilterItemSchema).optional().describe("Filters to apply."),
+    startDate: z.string().describe("Start date as an ISO 8601 string (e.g. '2025-02-10' or '2025-02-10T00:00:00'). Convert relative references like 'last week' or 'past 3 days' to actual dates."),
+    endDate: z.string().describe("End date as an ISO 8601 string. Defaults to now if the user says 'until now' or doesn't specify an end."),
+    siteId: z.string().optional().describe("Site ID (project ID)"),
+    projectName: z.string().optional().describe("Project name to look up"),
+    filters: z.array(FilterItemSchema).optional().describe("Filters to apply."),
 });
 
 export const ViewUserJourneySchema = z.object({
-  startDate: z.string().describe("Start date as ISO 8601 string. Convert relative references to actual dates."),
-  endDate: z.string().describe("End date as ISO 8601 string. Use today's date if not specified."),
-  siteId: z.string().optional().describe("Site ID (project ID)"),
-  projectName: z.string().optional().describe("Project name to look up"),
-  startPoint: z.string().optional().describe("URL path to start the journey from (e.g. '/articles/first'). Leave empty for general/most popular paths."),
-  filters: z.array(FilterItemSchema).optional().describe("Filters to apply."),
+    startDate: z.string().describe("Start date as ISO 8601 string. Convert relative references to actual dates."),
+    endDate: z.string().describe("End date as ISO 8601 string. Use today's date if not specified."),
+    siteId: z.string().optional().describe("Site ID (project ID)"),
+    projectName: z.string().optional().describe("Project name to look up"),
+    startPoint: z.string().optional().describe("URL path to start the journey from (e.g. '/articles/first'). Leave empty for general/most popular paths."),
+    filters: z.array(FilterItemSchema).optional().describe("Filters to apply."),
 });
 
 export const GetSessionDetailsSchema = z.object({
-  sessionId: z.string().describe("Session ID to get detailed information for"),
-  siteId: z.string().optional().describe("Site ID (project ID)"),
-  projectName: z.string().optional().describe("Project name to look up"),
+    sessionId: z.string().describe("Session ID to get detailed information for"),
+    siteId: z.string().optional().describe("Site ID (project ID)"),
+    projectName: z.string().optional().describe("Project name to look up"),
 });
 
 export const ViewWebVitalsSchema = z.object({
-  startDate: z.string().describe("Start date as ISO 8601 string. Convert relative references to actual dates."),
-  endDate: z.string().describe("End date as ISO 8601 string. Use today's date if not specified."),
-  siteId: z.string().optional().describe("Site ID (project ID)"),
-  projectName: z.string().optional().describe("Project name to look up"),
-  filters: z.array(FilterItemSchema).optional().describe("Filters to apply."),
+    startDate: z.string().describe("Start date as ISO 8601 string. Convert relative references to actual dates."),
+    endDate: z.string().describe("End date as ISO 8601 string. Use today's date if not specified."),
+    siteId: z.string().optional().describe("Site ID (project ID)"),
+    projectName: z.string().optional().describe("Project name to look up"),
+    filters: z.array(FilterItemSchema).optional().describe("Filters to apply."),
 });
 
 export const ViewTableChartSchema = z.object({
-  startDate: z.string().describe("Start date as ISO 8601 string. Convert relative references to actual dates."),
-  endDate: z.string().describe("End date as ISO 8601 string. Use today's date if not specified."),
-  metricOf: z.string().describe("What to rank/count. Values: 'LOCATION' (top pages), 'REQUEST' (top network requests), 'userBrowser' (top browsers), 'userCountry' (top countries), 'userOs' (top operating systems), 'userDevice' (top devices)."),
-  siteId: z.string().optional().describe("Site ID (project ID)"),
-  projectName: z.string().optional().describe("Project name to look up"),
-  limit: z.number().optional().default(20).describe("Max number of items to return (default 20)"),
-  filters: z.array(FilterItemSchema).optional().describe("Filters to apply."),
+    startDate: z.string().describe("Start date as ISO 8601 string. Convert relative references to actual dates."),
+    endDate: z.string().describe("End date as ISO 8601 string. Use today's date if not specified."),
+    metricOf: z.string().describe("What to rank/count. Values: 'LOCATION' (top pages), 'REQUEST' (top network requests), 'userBrowser' (top browsers), 'userCountry' (top countries), 'userOs' (top operating systems), 'userDevice' (top devices)."),
+    siteId: z.string().optional().describe("Site ID (project ID)"),
+    projectName: z.string().optional().describe("Project name to look up"),
+    limit: z.number().optional().default(20).describe("Max number of items to return (default 20)"),
+    filters: z.array(FilterItemSchema).optional().describe("Filters to apply."),
 });
 
 export const ViewFunnelSchema = z.object({
-  startDate: z.string().describe("Start date as ISO 8601 string. Convert relative references to actual dates."),
-  endDate: z.string().describe("End date as ISO 8601 string. Use today's date if not specified."),
-  steps: z.array(z.string()).min(2).describe("Ordered list of URL paths defining the funnel steps, e.g. ['/pricing', '/checkout', '/confirm']. Minimum 2 steps required."),
-  siteId: z.string().optional().describe("Site ID (project ID)"),
-  projectName: z.string().optional().describe("Project name to look up"),
-  filters: z.array(FilterItemSchema).optional().describe("Filters to apply."),
+    startDate: z.string().describe("Start date as ISO 8601 string. Convert relative references to actual dates."),
+    endDate: z.string().describe("End date as ISO 8601 string. Use today's date if not specified."),
+    steps: z.array(z.string()).min(2).describe("Ordered list of URL paths defining the funnel steps, e.g. ['/pricing', '/checkout', '/confirm']. Minimum 2 steps required."),
+    siteId: z.string().optional().describe("Site ID (project ID)"),
+    projectName: z.string().optional().describe("Project name to look up"),
+    filters: z.array(FilterItemSchema).optional().describe("Filters to apply."),
 });
 
 export const ViewSessionReplaySchema = z.object({
-  sessionId: z.string().describe("Session ID to replay. Pick from earlier fetch_sessions/view_recent_sessions results."),
-  siteId: z.string().optional().describe("Site ID (project ID). Use the siteId from the earlier session list if available."),
-  projectName: z.string().optional().describe("Project name to look up. Will be resolved to project ID automatically."),
+    sessionId: z.string().describe("Session ID to replay. Pick from earlier fetch_sessions/view_recent_sessions results."),
+    siteId: z.string().optional().describe("Site ID (project ID). Use the siteId from the earlier session list if available."),
+    projectName: z.string().optional().describe("Project name to look up. Will be resolved to project ID automatically."),
 });

--- a/ee/mcp_app/lib/state.ts
+++ b/ee/mcp_app/lib/state.ts
@@ -16,10 +16,30 @@ export interface Project {
 // Messages are stored here after parsing and fetched by the UI via _get_replay_data
 export const replayStore = new Map<string, any[]>();
 
+// Abort controller for cancelling in-flight polls on shutdown
+export let pollAbortController: AbortController | null = null;
+
+export function createPollAbortController(): AbortController {
+  // Abort any existing poll before starting a new one
+  if (pollAbortController) {
+    pollAbortController.abort();
+  }
+  pollAbortController = new AbortController();
+  return pollAbortController;
+}
+
+export function abortAllPolls() {
+  if (pollAbortController) {
+    pollAbortController.abort();
+    pollAbortController = null;
+  }
+}
+
 // In-memory state for configuration and authentication
 export const state = {
   clientId: null as string | null,
   backendUrl: process.env.OPENREPLAY_BACKEND_URL || "https://foss.openreplay.com",
+  frontendUrl: process.env.OPENREPLAY_URL || process.env.OPENREPLAY_BACKEND_URL || "https://foss.openreplay.com",
   jwt: null as string | null,
   userData: null as any,
   projects: [] as Project[],
@@ -35,6 +55,7 @@ export async function loadPersistedState() {
     if (config.jwt) {
       state.jwt = config.jwt;
       state.backendUrl = config.backendUrl || state.backendUrl;
+      state.frontendUrl = config.frontendUrl || state.frontendUrl;
       state.userData = config.userData || null;
       console.error("[SERVER] Loaded persisted authentication from disk");
     }
@@ -61,6 +82,7 @@ export async function savePersistedState() {
         clientId: state.clientId,
         jwt: state.jwt,
         backendUrl: state.backendUrl,
+        frontendUrl: state.frontendUrl,
         userData: state.userData,
       }, null, 2)
     );

--- a/ee/mcp_app/lib/tools.ts
+++ b/ee/mcp_app/lib/tools.ts
@@ -7,7 +7,6 @@ import { makeApiRequest, fetchRecentSessions, fetchProjects, getProjectIdByName,
 import {
   ConfigureBackendSchema,
   LoginSchema,
-  LoginJwtSchema,
   LoginBrowserSchema,
   FetchChartDataSchema,
   GetSessionReplaySchema,
@@ -1129,7 +1128,7 @@ export function registerInternalTools(server: McpServer) {
   server.registerTool(
     "login",
     {
-      description: "Authenticate with OpenReplay using email and password",
+      description: "Authenticate with OpenReplay using email and password. Only use this if the user explicitly provides email and password. Otherwise prefer login_browser.",
       inputSchema: {
         email: z.string().describe("Email address"),
         password: z.string().describe("Password"),
@@ -1161,46 +1160,15 @@ export function registerInternalTools(server: McpServer) {
   );
   console.error("[SERVER] login tool registered");
 
-  // Login with JWT
-  console.error("[SERVER] Registering login_jwt tool...");
-  server.registerTool(
-    "login_jwt",
-    {
-      description: "Authenticate with OpenReplay using a JWT token (for testing)",
-      inputSchema: {
-        jwt: z.string().describe("JWT token for authentication"),
-      },
-    },
-    async (args) => {
-      console.error("[SERVER] login_jwt called");
-      const parsed = LoginJwtSchema.parse(args);
-      state.jwt = parsed.jwt;
-      state.userData = { authenticated: true };
-
-      // Persist token to disk
-      await savePersistedState();
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: "Successfully authenticated with JWT token",
-          },
-        ],
-      };
-    }
-  );
-  console.error("[SERVER] login_jwt tool registered");
-
   // Login via browser (OAuth-style)
   console.error("[SERVER] Registering login_browser tool...");
   server.registerTool(
     "login_browser",
     {
       description:
-        "Authenticate by opening a URL in the user's browser. " +
-        "Use this when the user wants to log in without pasting a JWT. " +
-        "Returns a URL the user must open. The tool then waits for approval (up to 5 minutes).",
+        "PREFERRED login method. Authenticate by opening a URL in the user's browser. " +
+        "Always use this tool when the user needs to log in, unless they explicitly ask for email/password login. " +
+        "Opens a browser tab for the user to approve access, then waits for approval (up to 5 minutes).",
       inputSchema: {
         backendUrl: z.string().optional().describe("OpenReplay backend URL (optional, uses current if already configured)"),
       },
@@ -1208,15 +1176,26 @@ export function registerInternalTools(server: McpServer) {
     async (args) => {
       const parsed = LoginBrowserSchema.parse(args);
       const backendUrl = parsed.backendUrl || state.backendUrl;
+      const frontendUrl = parsed.frontendUrl || state.frontendUrl;
 
       if (parsed.backendUrl) {
         state.backendUrl = parsed.backendUrl;
       }
 
+      if (parsed.frontendUrl) {
+        state.frontendUrl = parsed.frontendUrl;
+      }
+
       const authCode = generateAuthCode();
-      const authorizeUrl = `${backendUrl}/mcp/authorize?state=${authCode}&client_id=${state.clientId}&app_name=${encodeURIComponent("OpenReplay MCP")}`;
+      const authorizeUrl = `${frontendUrl}/mcp/authorize?state=${authCode}&client_id=${state.clientId}&app_name=${encodeURIComponent("OpenReplay MCP")}`;
 
       console.error(`[SERVER] login_browser: opening browser at ${authorizeUrl}`);
+
+      // Send the URL as a log notification so the model can show it immediately
+      server.server.sendLoggingMessage({
+        level: "info",
+        data: `Browser login started. If the browser didn't open automatically, visit this URL:\n${authorizeUrl}`,
+      });
 
       // Open the URL in the user's default browser
       const openCmd = process.platform === "darwin"
@@ -1230,14 +1209,18 @@ export function registerInternalTools(server: McpServer) {
       const jwt = await pollForAuth(backendUrl, authCode, state.clientId!);
 
       if (!jwt) {
+        // Generate a fresh auth code so the user can try manually
+        const retryAuthCode = generateAuthCode();
+        const retryUrl = `${frontendUrl}/mcp/authorize?state=${retryAuthCode}&client_id=${state.clientId}&app_name=${encodeURIComponent("OpenReplay MCP")}`;
+
         return {
           content: [
             {
               type: "text",
               text: JSON.stringify({
                 type: "error",
-                error: "Browser login timed out or was denied. Please try again.",
-                authorizeUrl,
+                error: "Browser login timed out or was denied. You can try again by opening this URL manually:",
+                authorizeUrl: retryUrl,
               }),
             },
           ],
@@ -1256,6 +1239,7 @@ export function registerInternalTools(server: McpServer) {
             text: JSON.stringify({
               type: "auth_success",
               message: "Successfully authenticated via browser.",
+              authorizeUrl,
             }),
           },
         ],

--- a/ee/mcp_app/server.ts
+++ b/ee/mcp_app/server.ts
@@ -5,7 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { loadPersistedState } from "./lib/state.js";
+import { loadPersistedState, abortAllPolls } from "./lib/state.js";
 import { registerUITools, registerInternalTools } from "./lib/tools.js";
 
 const __dirname = import.meta.dirname ?? path.dirname(fileURLToPath(import.meta.url));
@@ -81,6 +81,20 @@ async function main() {
   console.error(`[SERVER] Resource: ${resourceUri}`);
   console.error("[SERVER] ==========================================");
 }
+
+// Abort any in-flight polls and exit on shutdown
+// Claude Desktop doesn't send SIGINT/SIGTERM — it just closes stdin
+function shutdown() {
+  console.error("[SERVER] Shutting down, aborting polls...");
+  abortAllPolls();
+  process.exit(0);
+}
+
+process.stdin.on("end", shutdown);
+process.stdin.on("close", shutdown);
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+process.on("exit", () => abortAllPolls());
 
 main().catch((error) => {
   console.error("Fatal error:", error);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds browser-based login for MCP: opens a browser, waits for approval with safe cancellation, and persists a new `frontendUrl`. Also standardizes API base path via an `API_PATH` prefix.

- **New Features**
  - `login_browser` is now the preferred auth flow. Opens `<frontendUrl>/mcp/authorize`, logs the URL, waits up to 5 minutes, and returns success or a retry URL.
  - Abortable auth polling with clean shutdown hooks to stop in-flight polls.
  - New `frontendUrl` in state, persisted to disk and configurable via `OPENREPLAY_URL` or tool input.
  - Clear guidance: use `login` only when the user explicitly provides email/password.

- **Migration**
  - Removed the `login_jwt` tool and schema. Update any scripts/tests that called it.
  - API requests now prepend `API_PATH` (defaults to `/api`). Adjust env if your backend uses a different path.
  - Removed legacy SaaS hostname remapping. Set explicit `OPENREPLAY_BACKEND_URL` (API) and `OPENREPLAY_URL` (frontend) as needed.

<sup>Written for commit ebdd9136bbd1dade66cfb59143c7cdde28914292. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

