### PR TITLE
feat(mcp-auth): config change

### DIFF
--- a/ee/mcp_app/claude_desktop_config.example.json
+++ b/ee/mcp_app/claude_desktop_config.example.json
@@ -7,7 +7,9 @@
         "/ABSOLUTE/PATH/TO/openreplay-mcp-app/server.ts"
       ],
       "env": {
-        "OPENREPLAY_BACKEND_URL": "https://your-openreplay-instance.com"
+        "OPENREPLAY_BACKEND_URL": "https://your-openreplay-instance.com",
+        "OPENREPLAY_URL": "https://your-openreplay-instance.com",
+        "API_PATH": "/api"
       }
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Claude Desktop MCP app example config to include auth-related env vars. Adds `OPENREPLAY_URL` and `API_PATH` for correct API routing and callback URLs.

- **Migration**
  - Set `OPENREPLAY_URL` to your instance base URL (same as `OPENREPLAY_BACKEND_URL`).
  - Set `API_PATH` to your API prefix (default `/api`).

<sup>Written for commit 33c893a904a6b33082f0257675ce953c06012ae4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

