### PR TITLE
feat(mcp-auth): small changes

### DIFF
--- a/ee/mcp_app/lib/api.ts
+++ b/ee/mcp_app/lib/api.ts
@@ -168,7 +168,7 @@ export async function fetchProjects() {
 
     // Store projects in state
     state.projects = data.map((project: any) => ({
-        projectId: String(project.projectId || project.id),
+        projectId: String(project.projectId),
         name: project.name,
     }));
 

--- a/ee/mcp_app/lib/tools.ts
+++ b/ee/mcp_app/lib/tools.ts
@@ -1126,7 +1126,7 @@ export function registerInternalTools(server: McpServer) {
   // Login with email/password
   console.error("[SERVER] Registering login tool...");
   server.registerTool(
-    "login",
+    "login_email_password",
     {
       description: "Authenticate with OpenReplay using email and password. Only use this if the user explicitly provides email and password. Otherwise prefer login_browser.",
       inputSchema: {
@@ -1158,7 +1158,7 @@ export function registerInternalTools(server: McpServer) {
       };
     }
   );
-  console.error("[SERVER] login tool registered");
+  console.error("[SERVER] login_email_password tool registered");
 
   // Login via browser (OAuth-style)
   console.error("[SERVER] Registering login_browser tool...");
@@ -1171,6 +1171,7 @@ export function registerInternalTools(server: McpServer) {
         "Opens a browser tab for the user to approve access, then waits for approval (up to 5 minutes).",
       inputSchema: {
         backendUrl: z.string().optional().describe("OpenReplay backend URL (optional, uses current if already configured)"),
+        frontendUrl: z.string().optional().describe("OpenReplay URL (optional, uses current if already configured)"),
       },
     },
     async (args) => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the email/password auth tool to `login_email_password` and added an optional `frontendUrl` to `login_browser`. Also standardized project IDs to use `project.projectId` only.

- New Features
  - `login_browser` supports an optional `frontendUrl`.

- Migration
  - Replace tool invocations of `login` with `login_email_password`.

<sup>Written for commit e63f7bb9fd1f4b0ccdca0e1c767b8eeac9d66300. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

