### PR TITLE
fix(chalice): fixed projectKey authorizer

### DIFF
--- a/ee/api/auth/auth_project.py
+++ b/ee/api/auth/auth_project.py
@@ -30,7 +30,6 @@ class ProjectAuthorizer:
         elif self.project_identifier == "projectKey":
             current_project = projects.get_by_project_key(project_key=value)
             if current_project is not None \
-                    and request.state.authorizer_identity == "jwt" \
                     and not projects.is_authorized(project_id=current_project["projectId"],
                                                    tenant_id=current_user.tenant_id,
                                                    user_id=user_id):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix projectKey authorizer to enforce project permission checks for all request identities, not just JWT. This closes a gap that allowed unauthorized access via non-JWT flows.

<sup>Written for commit 8cd07e8330bb4b8fadc15b1ba849ceee36bd7a72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

