### PR TITLE
Updated patch build from main 509f184bfbd21242d20e51f3fc0b2a462e637178

### DIFF
--- a/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.26.5"
+AppVersion: "v1.26.6"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the `chalice` Helm chart AppVersion from v1.26.5 to v1.26.6 to publish the latest patch build. Merging will trigger the tag update job.

<sup>Written for commit 062f3a2ffe1c5fb129341ef44c6085864b324044. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

