### PR TITLE
ui: prevent predefined flag from being dropped in filteritem

### DIFF
--- a/frontend/app/components/shared/Filters/FilterValue/ValueAutoComplete.tsx
+++ b/frontend/app/components/shared/Filters/FilterValue/ValueAutoComplete.tsx
@@ -1,34 +1,37 @@
-import React, {
-  useState,
-  useEffect,
-  useCallback,
-  useMemo,
-  useRef,
-  memo,
-} from 'react';
-import { debounceCall } from 'App/utils';
-import { useStore } from 'App/mstore';
-import { observer } from 'mobx-react-lite';
-import { searchService } from 'App/services';
+import { TopValue } from '@/mstore/filterStore';
+import { CloseCircleFilled, RedoOutlined } from '@ant-design/icons';
 import {
   Button,
   Checkbox,
-  Input,
-  Tooltip,
-  Popover,
-  Spin,
-  Typography,
   Divider,
+  Input,
+  Popover,
   Space,
+  Spin,
+  Tooltip,
+  Typography,
 } from 'antd';
-import { RedoOutlined, CloseCircleFilled } from '@ant-design/icons';
 import cn from 'classnames';
+import { observer } from 'mobx-react-lite';
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
-import { TopValue } from '@/mstore/filterStore';
-import { mobileScreen } from 'App/utils/isMobile';
 import { VList } from 'virtua';
-const { Text } = Typography;
+
+import { useStore } from 'App/mstore';
+import { searchService } from 'App/services';
+import { debounceCall } from 'App/utils';
+import { mobileScreen } from 'App/utils/isMobile';
+
 import OutsideClickDetectingDiv from 'Shared//OutsideClickDetectingDiv';
+
+const { Text } = Typography;
 
 interface FilterParams {
   id: string;

--- a/frontend/app/mstore/types/filterItem.ts
+++ b/frontend/app/mstore/types/filterItem.ts
@@ -55,6 +55,8 @@ export default class FilterItem implements IFilter {
   autoOpen?: boolean = false;
   defaultProperty?: boolean = false;
   isConditional?: boolean = false;
+  isPredefined?: boolean = false;
+  possibleValues?: Array<{ value: string; label: string }> = [];
   scope?: string[];
   readonly?: boolean = false;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves predefined filters by keeping `isPredefined` and `possibleValues` on `FilterItem`, preventing these from being lost during state updates. Also cleans up imports in `ValueAutoComplete` with no behavior changes.

- **Bug Fixes**
  - Added `isPredefined` (boolean) and `possibleValues` (array) to `FilterItem` to ensure predefined flags and values persist across edits and saves.

- **Refactors**
  - Reordered and deduplicated imports in `ValueAutoComplete.tsx`; no functional changes.

<sup>Written for commit c0170178c2920ca08ba0ccaa1241fd3ecc040064. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

