### PR TITLE
Updated patch build from main a4fa839891d0c9bbcdedcc0bd315618f1e03b18e

### DIFF
--- a/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.10
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.26.6"
+AppVersion: "v1.26.7"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the frontend Helm chart AppVersion from v1.26.6 to v1.26.7 to publish the latest patch build and trigger the tag update job.

<sup>Written for commit f48475dc5bdeb2286d745a731275758f6d65ac5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

