### PR TITLE
Small imprs

### DIFF
--- a/frontend/app/components/Client/Projects/CaptureLimit.tsx
+++ b/frontend/app/components/Client/Projects/CaptureLimit.tsx
@@ -1,0 +1,3 @@
+export default function CaptureLimit({ project }: { project: any }) {
+  return null;
+}

--- a/frontend/app/components/Client/Projects/ProjectTabContent.tsx
+++ b/frontend/app/components/Client/Projects/ProjectTabContent.tsx
@@ -5,6 +5,7 @@ import ProjectTabTracking from 'Components/Client/Projects/ProjectTabTracking';
 import CustomFields from 'Components/Client/CustomFields';
 import ProjectTags from 'Components/Client/Projects/ProjectTags';
 import ProjectCaptureRate from 'Components/Client/Projects/ProjectCaptureRate';
+import CaptureLimit from 'Components/Client/Projects/CaptureLimit';
 import { Empty } from 'antd';
 
 const ProjectTabContent: React.FC = () => {
@@ -23,7 +24,12 @@ const ProjectTabContent: React.FC = () => {
   const tabContent: Record<string, React.ReactNode> = React.useMemo(
     () => ({
       installation: <ProjectTabTracking project={project} />,
-      captureRate: <ProjectCaptureRate project={project} />,
+      captureRate: (
+        <>
+          <ProjectCaptureRate project={project} />
+          <CaptureLimit project={project} />
+        </>
+      ),
       metadata: <CustomFields />,
       tags: <ProjectTags />,
     }),

--- a/frontend/app/components/Client/Users/components/UserList/UserList.tsx
+++ b/frontend/app/components/Client/Users/components/UserList/UserList.tsx
@@ -20,6 +20,8 @@ function UserList(props: Props) {
   const loading = useObserver(() => userStore.loading);
   const users = useObserver(() => userStore.list);
   const searchQuery = useObserver(() => userStore.searchQuery);
+  const isOwner = useObserver(() => userStore.account.superAdmin);
+  const currentUserId = useObserver(() => userStore.account.id);
   const { showModal } = useModal();
 
   const getList = (list: any) =>
@@ -80,9 +82,14 @@ function UserList(props: Props) {
                     e.stopPropagation();
                     userStore.copyInviteCode(user.userId);
                   }}
-                  onMakeOwner={(userId) => {
-                    userStore.makeOwner(userId);
-                  }}
+                  onMakeOwner={
+                    isOwner
+                      ? (userId) => {
+                          userStore.makeOwner(userId);
+                        }
+                      : undefined
+                  }
+                  currentUserId={currentUserId}
                   isEnterprise={isEnterprise}
                   isOnboarding={isOnboarding}
                 />

--- a/frontend/app/components/Client/Users/components/UserList/UserList.tsx
+++ b/frontend/app/components/Client/Users/components/UserList/UserList.tsx
@@ -80,6 +80,9 @@ function UserList(props: Props) {
                     e.stopPropagation();
                     userStore.copyInviteCode(user.userId);
                   }}
+                  onMakeOwner={(userId) => {
+                    userStore.makeOwner(userId);
+                  }}
                   isEnterprise={isEnterprise}
                   isOnboarding={isOnboarding}
                 />

--- a/frontend/app/components/Client/Users/components/UserListItem/UserListItem.tsx
+++ b/frontend/app/components/Client/Users/components/UserListItem/UserListItem.tsx
@@ -36,6 +36,7 @@ interface Props {
   copyInviteCode?: any;
   isEnterprise?: boolean;
   onMakeOwner?: (userId: string) => void;
+  currentUserId?: string;
 }
 function UserListItem(props: Props) {
   const {
@@ -46,8 +47,17 @@ function UserListItem(props: Props) {
     isEnterprise = false,
     isOnboarding = false,
     onMakeOwner,
+    currentUserId,
   } = props;
   const { t } = useTranslation();
+
+  const canMakeOwner = user.isJoined && user.userId !== currentUserId;
+
+  const makeOwnerTooltip = !user.isJoined
+    ? t('User has not accepted the invitation yet')
+    : user.userId === currentUserId
+      ? t('Cannot transfer ownership to yourself')
+      : t('Make Owner');
 
   const handleMakeOwner = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -131,11 +141,12 @@ function UserListItem(props: Props) {
           )}
 
           {!user.isSuperAdmin && onMakeOwner && (
-            <Tooltip title={t('Make Owner')}>
+            <Tooltip title={makeOwnerTooltip}>
               <Button
                 type="text"
                 icon={<Icon name="user-switch" />}
                 onClick={handleMakeOwner}
+                disabled={!canMakeOwner}
               />
             </Tooltip>
           )}

--- a/frontend/app/components/Client/Users/components/UserListItem/UserListItem.tsx
+++ b/frontend/app/components/Client/Users/components/UserListItem/UserListItem.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import React from 'react';
-import { Tooltip, Icon } from 'UI';
+import { Tooltip, Icon, confirm } from 'UI';
 import { Button } from 'antd';
 import { checkForRecent } from 'App/date';
 import cn from 'classnames';
@@ -35,6 +35,7 @@ interface Props {
   generateInvite?: any;
   copyInviteCode?: any;
   isEnterprise?: boolean;
+  onMakeOwner?: (userId: string) => void;
 }
 function UserListItem(props: Props) {
   const {
@@ -44,8 +45,25 @@ function UserListItem(props: Props) {
     copyInviteCode = () => {},
     isEnterprise = false,
     isOnboarding = false,
+    onMakeOwner,
   } = props;
   const { t } = useTranslation();
+
+  const handleMakeOwner = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (
+      await confirm({
+        header: t('Transfer Ownership'),
+        confirmButton: t('Yes, transfer'),
+        confirmation: t(
+          'There can only be one owner account. By proceeding, the ownership will be transferred to {{name}}. You will lose your owner privileges.',
+          { name: user.name },
+        ),
+      })
+    ) {
+      onMakeOwner?.(user.userId);
+    }
+  };
 
   return (
     <div
@@ -91,28 +109,36 @@ function UserListItem(props: Props) {
           },
         )}
       >
-        <div className="grid grid-cols-2 gap-3 items-center justify-end">
-          <div>
-            {!user.isJoined && user.invitationLink && !user.isExpiredInvite && (
-              <Tooltip title={t('Copy Invite Code')} hideOnClick>
-                <Button
-                  type="text"
-                  icon={<Icon name="link-45deg" />}
-                  onClick={copyInviteCode}
-                />
-              </Tooltip>
-            )}
+        <div className="flex gap-2 items-center justify-end">
+          {!user.isJoined && user.invitationLink && !user.isExpiredInvite && (
+            <Tooltip title={t('Copy Invite Code')} hideOnClick>
+              <Button
+                type="text"
+                icon={<Icon name="link-45deg" />}
+                onClick={copyInviteCode}
+              />
+            </Tooltip>
+          )}
 
-            {!user.isJoined && user.isExpiredInvite && (
-              <Tooltip title={t('Generate Invite')} hideOnClick>
-                <Button
-                  icon={<Icon name="link-45deg" />}
-                  variant="text"
-                  onClick={generateInvite}
-                />
-              </Tooltip>
-            )}
-          </div>
+          {!user.isJoined && user.isExpiredInvite && (
+            <Tooltip title={t('Generate Invite')} hideOnClick>
+              <Button
+                icon={<Icon name="link-45deg" />}
+                variant="text"
+                onClick={generateInvite}
+              />
+            </Tooltip>
+          )}
+
+          {!user.isSuperAdmin && onMakeOwner && (
+            <Tooltip title={t('Make Owner')}>
+              <Button
+                type="text"
+                icon={<Icon name="user-switch" />}
+                onClick={handleMakeOwner}
+              />
+            </Tooltip>
+          )}
           <Button variant="text" icon={<Icon name="pencil" />} />
         </div>
       </div>

--- a/frontend/app/mstore/userStore.ts
+++ b/frontend/app/mstore/userStore.ts
@@ -269,6 +269,24 @@ class UserStore {
     });
   };
 
+  makeOwner = async (userId: string) => {
+    this.saving = true;
+    try {
+      await userService.makeOwner(userId);
+      runInAction(() => {
+        toast.success(this.t('Ownership transferred successfully'));
+      });
+      await this.fetchUsers();
+      await this.fetchUserInfo();
+    } catch (error: any) {
+      toast.error(error.message || this.t('Failed to transfer ownership'));
+    } finally {
+      runInAction(() => {
+        this.saving = false;
+      });
+    }
+  };
+
   copyInviteCode = (userId: string): void => {
     const content = this.list.find((u) => u.userId === userId)?.invitationLink;
     if (content) {

--- a/frontend/app/services/UserService.ts
+++ b/frontend/app/services/UserService.ts
@@ -211,6 +211,13 @@ export default class UserService {
       .then((response: { data: any }) => response.data || {});
   }
 
+  makeOwner(userId: string) {
+    return this.client
+      .put(`/client/members/${userId}/owner`)
+      .then((r) => r.json())
+      .then((response: { data: any }) => response.data || {});
+  }
+
   changeScope(scope: 1 | 2) {
     return this.client
       .post('/account/scope', { scope })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an ownership transfer control in the user list so the current owner can make another member the owner. Also adds a placeholder `CaptureLimit` section under Project > Capture Rate.

- **New Features**
  - User list: added “Make Owner” action (with confirm). Enabled only for joined users and not for yourself; hidden for non-owners.
  - Store/Service: `userStore.makeOwner` calling `UserService.makeOwner` (PUT `/client/members/:userId/owner`), with success/error toasts and user/account refresh.
  - Projects: added `CaptureLimit` under the Capture Rate tab (placeholder, no UI yet).

<sup>Written for commit bf719b4544c0557f75c3dcea24cec7af99b0db1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

