### PR TITLE
ui: prevent assist disconnection on reload

### DIFF
--- a/frontend/app/player/web/assist/AssistManager.ts
+++ b/frontend/app/player/web/assist/AssistManager.ts
@@ -169,8 +169,8 @@ export default class AssistManager {
   }
 
   connect(agentToken: string, agentId: number, projectId: number) {
-    const jmr = new JSONRawMessageReader();
-    const reader = new MStreamReader(jmr, this.session.startedAt);
+    let jmr = new JSONRawMessageReader();
+    let reader = new MStreamReader(jmr, this.session.startedAt);
     let waitingForMessages = true;
 
     const now = new Date().getTime();
@@ -264,6 +264,10 @@ export default class AssistManager {
     socket.on('SESSION_RECONNECTED', () => {
       this.clearDisconnectTimeout();
       this.clearInactiveTimeout();
+      jmr = new JSONRawMessageReader();
+      reader = new MStreamReader(jmr, this.session.startedAt);
+      waitingForMessages = true;
+      this.store.update({ currentTab: undefined });
       this.setStatus(ConnectionStatus.Connected);
     });
 

--- a/tracker/tracker-assist/src/Assist.ts
+++ b/tracker/tracker-assist/src/Assist.ts
@@ -440,7 +440,7 @@ export default class Assist {
       };
       if (this.app.active()) {
         this.assistDemandedRestart = true;
-        this.app.stop();
+        this.app.stop(false);
         this.app.clearBuffers();
         this.app.waitStatus(0).then(() => {
           this.app.allowAppStart();
@@ -453,8 +453,10 @@ export default class Assist {
               .then(() => {
                 this.remoteControl?.reconnect([id]);
               })
-              .catch((e) => app.debug.error(e));
-            // TODO: check if it's needed; basically allowing some time for the app to finish everything before starting again
+              .catch((e) => {
+                this.assistDemandedRestart = false;
+                app.debug.error(e);
+              });
           }, 100);
         });
       }
@@ -471,7 +473,7 @@ export default class Assist {
       });
       if (this.app.active()) {
         this.assistDemandedRestart = true;
-        this.app.stop();
+        this.app.stop(false);
         this.app.clearBuffers();
         this.app.waitStatus(0).then(() => {
           this.app.allowAppStart();
@@ -484,7 +486,10 @@ export default class Assist {
               .then(() => {
                 this.remoteControl?.reconnect(Object.keys(this.agents));
               })
-              .catch((e) => app.debug.error(e));
+              .catch((e) => {
+                this.assistDemandedRestart = false;
+                app.debug.error(e);
+              });
           }, 100);
         });
       }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents Assist from disconnecting after a page reload or session reconnect by resetting message readers and refining the restart flow so agents stay connected.

- **Bug Fixes**
  - Re-init `JSONRawMessageReader` and `MStreamReader` on `SESSION_RECONNECTED`, reset `waitingForMessages`, and clear `currentTab`.
  - Use `this.app.stop(false)` during restarts to avoid full teardown; clear buffers and restart cleanly.
  - Reconnect remote control for target agents and reset `assistDemandedRestart` on errors to avoid stuck state.

<sup>Written for commit 61dc5d8dcdb387a175329b39a9a454f1d4714938. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

