### PR TITLE
feat(api): sessions filter to support screen_width and height

### DIFF
--- a/backend/pkg/analytics/charts/metric_table.go
+++ b/backend/pkg/analytics/charts/metric_table.go
@@ -561,6 +561,8 @@ var sessionProperties = map[string]string{
 	"utm_source":           "utm_source",
 	"utm_medium":           "utm_medium",
 	"utm_campaign":         "utm_campaign",
+	"screen_width":         "screen_width",
+	"screen_height":        "screen_height",
 	//	IOS
 	"user_os_ios":           "user_os",
 	"user_device_ios":       "user_device",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for `screen_width` and `screen_height` in session filters to enable segmentation and reporting by viewport size.

<sup>Written for commit 3984c3ed6536c83cf0030836641c10910b953934. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

