### PR TITLE
Updated patch build from main 608035240420499a3bcf655ab106a058b6c7f4ee

### DIFF
--- a/scripts/helmcharts/openreplay/charts/api/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/api/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.26.2"
+AppVersion: "v1.26.3"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the OpenReplay API Helm chart AppVersion from v1.26.2 to v1.26.3 to publish the latest patch. Merging this PR will trigger the tag update job.

<sup>Written for commit 3608e781b789570df0f303d909fe512cc1534a6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

