### PR TITLE
feat(api): api key rotation

### DIFF
--- a/api/chalicelib/core/tenants.py
+++ b/api/chalicelib/core/tenants.py
@@ -43,6 +43,7 @@ def generate_new_api_key(tenant_id):
     with pg_client.PostgresClient() as cur:
         query = cur.mogrify(f"""UPDATE public.tenants
                                 SET api_key=generate_api_key(20)
+                                WHERE tenant_id = %(tenant_id)s
                                 RETURNING api_key;""",
                             {"tenant_id": tenant_id})
         cur.execute(query=query)

--- a/api/routers/core.py
+++ b/api/routers/core.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Union, Optional
 
 from decouple import config
@@ -22,6 +23,8 @@ from or_dependencies import OR_context, OR_role
 from routers.base import get_routers
 
 public_app, app, app_apikey = get_routers()
+
+logger = logging.getLogger(__name__)
 
 
 @app.get('/{projectId}/autocomplete', tags=["autocomplete"])
@@ -626,8 +629,9 @@ def delete_project(projectId: int, _=Body(None), context: schemas.CurrentContext
     return projects.delete(tenant_id=context.tenant_id, user_id=context.user_id, project_id=projectId)
 
 
-@app.get('/client/new_api_key', tags=['client'])
+@app.post('/client/new_api_key', tags=['client'], dependencies=[OR_role("owner", "admin")])
 def generate_new_tenant_token(context: schemas.CurrentContext = Depends(OR_context)):
+    logger.info(f"tenant api_key rotated tenant_id={context.tenant_id} user_id={context.user_id}")
     return {
         'data': tenants.generate_new_api_key(context.tenant_id)
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a secure API key rotation endpoint and fixes tenant scoping in the update query. Rotation now uses POST with owner/admin protection and logs each rotation.

- **Migration**
  - Use POST /client/new_api_key (was GET).
  - Requires `owner` or `admin` role; ensure requests include an authenticated context.

<sup>Written for commit 6da15f54f85276406e38350cb2b08e4342db8cb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

