### PR TITLE
UI patches for 1.26

### DIFF
--- a/frontend/app/PrivateRoutes.tsx
+++ b/frontend/app/PrivateRoutes.tsx
@@ -162,6 +162,14 @@ function PrivateRoutes() {
     if (!searchStore.urlParsed && filtersLoaded) {
       const searchParams = new URLSearchParams(location.search);
       const searchId = searchParams.get('sid');
+      const supportedFilters = [
+        'userId',
+        'distinct_id',
+        'userCountry',
+        'userCity',
+        'meta_',
+      ];
+      const parsedFilters = supportedFilters.filter((f) => searchParams.has(f));
 
       if (searchId) {
         searchStore
@@ -183,6 +191,29 @@ function PrivateRoutes() {
               initialFetchDoneRef.current = true;
             }, 500);
           });
+      } else if (parsedFilters.length > 0) {
+        const start = searchParams.get('st_ts');
+        const end = searchParams.get('end_ts');
+        const filters: any[] = [];
+        parsedFilters.forEach((f, i) => {
+          const value = searchParams.get(f) as string;
+          const isMeta = f.startsWith('meta_');
+          const filterName = isMeta ? f.replace('meta_', '') : f;
+          const filter = filterStore.findEvent({ name: filterName });
+          if (filter) {
+            filter.value = [value];
+          }
+          filters.push(filter);
+        });
+        searchStore.edit({
+          filters,
+          startDate: start ? parseInt(start) : undefined,
+          endDate: end ? parseInt(end) : undefined,
+          rangeName: 'CUSTOM_RANGE',
+          rangeValue: 'CUSTOM_RANGE',
+        });
+        searchStore.setUrlParsed();
+        void searchStore.fetchSessions(true);
       } else {
         searchStore.setUrlParsed();
         void searchStore.fetchSessions(true);

--- a/frontend/app/components/Charts/SankeyChart.tsx
+++ b/frontend/app/components/Charts/SankeyChart.tsx
@@ -46,7 +46,7 @@ const nodeToFilter = {
 const subFilters = {
   INPUT: 'label',
   CLICK: 'label',
-  LOCATION: 'url_path',
+  LOCATION: 'urlPath',
   ISSUE: 'issue_type',
   TAG_TRIGGER: 'tag_id',
 };

--- a/frontend/app/components/Dashboard/components/WidgetSessions/WidgetSessions.tsx
+++ b/frontend/app/components/Dashboard/components/WidgetSessions/WidgetSessions.tsx
@@ -147,31 +147,29 @@ function WidgetSessions({ className = '' }) {
   const fetchSessions = useCallback(
     (metricId, flt) => {
       if (!isMounted()) return;
+      const isDrilldown = !!flt.isDrilldown;
       if (
+        !isDrilldown &&
         widget.metricType === FUNNEL &&
-        flt.series[0].filter.filters.length === 0
+        flt.series?.[0]?.filter?.filters?.length === 0
       ) {
         setLoading(false);
         return setData([]);
       }
 
       setLoading(true);
-      const params = { ...flt, filters: [] };
+      const { isDrilldown: _omit, ...rest } = flt;
+      const params = { ...rest, filters: [...(flt.filters || [])] };
       if (widget.metricType === TABLE && widget.metricOf === 'REQUEST') {
         const reqFilter = filterStore.findEvent({ name: FilterKey.REQUEST });
         if (reqFilter) {
           params.filters.push(reqFilter);
         }
       }
-      if (flt.filters?.length && params.series?.[0]?.filter) {
-        if (widget.metricType === FUNNEL) {
-          params.series[0].filter.filters = [...flt.filters];
-        } else {
-          params.series[0].filter.filters = [
-            ...(flt.series[0].filter.filters || []),
-            ...flt.filters,
-          ];
-        }
+      if (isDrilldown) {
+        delete params.series;
+      } else if (!params.series?.length) {
+        params.series = widget.series.map((s) => s.toJson());
       }
 
       widget
@@ -256,9 +254,41 @@ function WidgetSessions({ className = '' }) {
         }
       }
 
+      const hasDrilldown = filter.filters.length > 0;
+      const isFunnel = widget.metricType === FUNNEL;
+
+      let finalFilters = filter.filters;
+      let finalSeries: any[] = seriesJson;
+      let isDrilldownRequest = false;
+
+      if (hasDrilldown) {
+        if (isFunnel && seriesJson.length > 0) {
+          finalSeries = [
+            {
+              ...seriesJson[0],
+              filter: {
+                ...seriesJson[0].filter,
+                filters: filter.filters.map((f) => ({ ...f })),
+                eventsOrder: 'then',
+              },
+            },
+          ];
+          finalFilters = [];
+        } else {
+          const seriesFilters = seriesJson.flatMap(
+            (s) => s.filter?.filters || [],
+          );
+          finalFilters = [...filter.filters, ...seriesFilters];
+          finalSeries = [];
+          isDrilldownRequest = true;
+        }
+      }
+
       debounceSessions(widget.metricId, {
         ...filter,
-        series: seriesJson,
+        filters: finalFilters,
+        series: finalSeries,
+        isDrilldown: isDrilldownRequest,
         metricType: widget.metricType,
         metricOf: widget.metricOf,
         page: metricStore.sessionsPage,

--- a/frontend/app/components/Funnels/FunnelWidget/FunnelWidget.tsx
+++ b/frontend/app/components/Funnels/FunnelWidget/FunnelWidget.tsx
@@ -43,16 +43,16 @@ function FunnelWidget(props: Props) {
   const metricFilters = metric?.series[0]?.filter.filters || [];
 
   const applyDrillDown = (index: number, isComp?: boolean) => {
-    const filter = new Filter().fromData({
+    const filter = {
       filters: metricFilters.slice(0, index + 1),
-    });
+    };
     const periodTimestamps =
       isComp && index > -1
         ? comparisonPeriod.toTimestamps()
         : drillDownPeriod.toTimestamps();
 
     drillDownFilter.merge({
-      filters: filter.toJson().filters,
+      filters: filter.filters,
       startTimestamp: periodTimestamps.startTimestamp,
       endTimestamp: periodTimestamps.endTimestamp,
     });

--- a/frontend/app/components/Session/WebPlayer.tsx
+++ b/frontend/app/components/Session/WebPlayer.tsx
@@ -163,9 +163,9 @@ function WebPlayer(props: any) {
   React.useEffect(() => {
     if (
       messagesProcessed &&
-      (session.events.length > 0 ||
-        session.errors.length > 0 ||
-        session.stackEvents.length > 0 ||
+      (session.events?.length ||
+        session.errors?.length ||
+        session.stackEvents?.length ||
         session.addedEvents)
     ) {
       contextValue.player?.updateLists?.(session);

--- a/frontend/app/components/Session_/Player/Controls/Timeline.tsx
+++ b/frontend/app/components/Session_/Player/Controls/Timeline.tsx
@@ -35,6 +35,7 @@ function Timeline({ isMobile }: { isMobile: boolean }) {
   const highlightEnabled = uiPlayerStore.highlightSelection.enabled;
   const { playing, ready, endTime, devtoolsLoading, domLoading } = store.get();
   const sessionId = sessionStore.current.sessionId;
+  const loadingEvents = !sessionStore.current.addedEvents;
 
   const progressRef = useRef<HTMLDivElement>(null);
   const timelineRef = useRef<HTMLDivElement>(null);
@@ -141,6 +142,7 @@ function Timeline({ isMobile }: { isMobile: boolean }) {
     return Math.max(Math.round(p * targetTime), 0);
   };
 
+  const showLoaderStripes = devtoolsLoading || domLoading || !ready || loadingEvents
   return (
     <div
       className="flex items-center absolute w-full"
@@ -170,9 +172,7 @@ function Timeline({ isMobile }: { isMobile: boolean }) {
         <CustomDragLayer onDrag={onDrag} minX={0} maxX={maxWidth} />
 
         <div className={stl.timeline} ref={timelineRef}>
-          {devtoolsLoading || domLoading || !ready ? (
-            <div className={stl.stripes} />
-          ) : null}
+          {showLoaderStripes ? <div className={stl.stripes} /> : null}
         </div>
 
         {isMobile ? <MobEventsList /> : <WebEventsList />}

--- a/frontend/app/mstore/filterStore.ts
+++ b/frontend/app/mstore/filterStore.ts
@@ -180,7 +180,7 @@ export default class FilterStore {
     );
 
     if (!filter) {
-      console.error('Filter not found');
+      console.error('Filter not found', data);
       return new FilterItem({
         name: data.name,
         isEvent: data.isEvent,

--- a/frontend/app/mstore/searchStore.ts
+++ b/frontend/app/mstore/searchStore.ts
@@ -186,6 +186,8 @@ class SearchStore {
           sort: searchData?.sort || this.instance.sort,
           order: searchData?.order || this.instance.order,
           eventsOrder: searchData?.eventsOrder || this.instance.eventsOrder,
+          rangeName: 'CUSTOM_RANGE',
+          rangeValue: 'CUSTOM_RANGE',
         });
 
         this.currentPage = 1;

--- a/frontend/app/mstore/sessionStore.ts
+++ b/frontend/app/mstore/sessionStore.ts
@@ -251,8 +251,8 @@ export default class SessionStore {
     const nextEntryNum =
       keys.length > 0
         ? Math.max(
-            ...keys.map((key) => this.prefetchedMobUrls[key]?.entryNum || 0),
-          ) + 1
+          ...keys.map((key) => this.prefetchedMobUrls[key]?.entryNum || 0),
+        ) + 1
         : 0;
     this.prefetchedMobUrls[sessionId] = {
       data: fileData,
@@ -354,100 +354,111 @@ export default class SessionStore {
 
   fetchSessionData = async (sessionId: string, isLive = false) => {
     try {
-      const filter = isLive ? searchStoreLive.instance : searchStore.instance;
       const data = await sessionService.getSessionInfo(sessionId, isLive);
-      const eventsData: Record<string, any[]> = {};
-      try {
-        const evData = isLive
-          ? {
-              errors: [],
-              events: [],
-              issues: [],
-              crashes: [],
-              resources: [],
-              stackEvents: [],
-              userEvents: [],
-              userTesting: [],
-              incidents: [],
-            }
-          : await sessionService.getSessionEvents(sessionId);
 
-        Object.assign(eventsData, {
-          ...evData,
-          events: evData.events.map((e) => ({
-            ...e,
-            isHighlighted: searchStore.instance.filters.length
-              ? checkEventWithFilters(e, searchStore.instance.filters)
-              : false,
-          })),
-        });
-      } catch (e) {
-        console.error('Failed to fetch events', e);
-      }
-
-      const {
-        errors = [],
-        events = [],
-        issues = [],
-        crashes = [],
-        resources = [],
-        stackEvents = [],
-        userEvents = [],
-        incidents = [],
-      } = eventsData;
-
-      const filterEvents = filter.filters.filter((f) => f.isEvent) as Record<
-        string,
-        any
-      >[];
-      const matching: number[] = [];
-
-      const visitedEvents: Location[] = [];
-      const tmpMap = new Set();
-
-      events.forEach((event) => {
-        if (event.type === 'LOCATION' && !tmpMap.has(event.url)) {
-          tmpMap.add(event.url);
-          visitedEvents.push(event as Location);
-        }
-      });
-
-      filterEvents.forEach(({ key, operator, value }) => {
-        events.forEach((e, index) => {
-          if (key === e.type) {
-            const val = e.type === 'LOCATION' ? e.url : e.value;
-            if (operator === 'is' && value === val) {
-              matching.push(index);
-            }
-            if (operator === 'contains' && val.includes(value)) {
-              matching.push(index);
-            }
-          }
+      const session = new Session(data);
+      this.current = session;
+      this.addSessionEvents(data, isLive).then((sessionWithEvents) => {
+        runInAction(() => {
+          this.current = sessionWithEvents;
         });
       });
-
-      runInAction(() => {
-        const session = new Session(data);
-        session.addEvents(
-          events ?? [],
-          crashes ?? [],
-          errors ?? [],
-          issues ?? [],
-          resources ?? [],
-          userEvents ?? [],
-          stackEvents ?? [],
-          incidents ?? [],
-        );
-        this.current = session;
-        this.eventsIndex = matching;
-        this.visitedEvents = visitedEvents;
-        this.host = visitedEvents[0]?.host || '';
-        this.prefetched = false;
-      });
+      this.prefetched = false;
     } catch (e) {
       console.error(e);
       this.fetchFailed = true;
     }
+  };
+
+  addSessionEvents = async (sessionData, isLive = false) => {
+    const session = new Session(sessionData);
+    const filter = isLive ? searchStoreLive.instance : searchStore.instance;
+
+    const eventsData: Record<string, any[]> = {};
+    try {
+      const evData = isLive
+        ? {
+            errors: [],
+            events: [],
+            issues: [],
+            crashes: [],
+            resources: [],
+            stackEvents: [],
+            userEvents: [],
+            userTesting: [],
+            incidents: [],
+          }
+        : await sessionService.getSessionEvents(session.sessionId);
+
+      Object.assign(eventsData, {
+        ...evData,
+        events: evData.events.map((e) => ({
+          ...e,
+          isHighlighted: searchStore.instance.filters.length
+            ? checkEventWithFilters(e, searchStore.instance.filters)
+            : false,
+        })),
+      });
+    } catch (e) {
+      console.error('Failed to fetch events', e);
+    }
+
+    const {
+      errors = [],
+      events = [],
+      issues = [],
+      crashes = [],
+      resources = [],
+      stackEvents = [],
+      userEvents = [],
+      incidents = [],
+    } = eventsData;
+
+    const filterEvents = filter.filters.filter((f) => f.isEvent) as Record<
+      string,
+      any
+    >[];
+    const matching: number[] = [];
+
+    const visitedEvents: Location[] = [];
+    const tmpMap = new Set();
+
+    events.forEach((event) => {
+      if (event.type === 'LOCATION' && !tmpMap.has(event.url)) {
+        tmpMap.add(event.url);
+        visitedEvents.push(event as Location);
+      }
+    });
+
+    filterEvents.forEach(({ key, operator, value }) => {
+      events.forEach((e, index) => {
+        if (key === e.type) {
+          const val = e.type === 'LOCATION' ? e.url : e.value;
+          if (operator === 'is' && value === val) {
+            matching.push(index);
+          }
+          if (operator === 'contains' && val.includes(value)) {
+            matching.push(index);
+          }
+        }
+      });
+    });
+
+    const newSess = session.addEvents(
+      events ?? [],
+      crashes ?? [],
+      errors ?? [],
+      issues ?? [],
+      resources ?? [],
+      userEvents ?? [],
+      stackEvents ?? [],
+      incidents ?? [],
+    );
+    this.eventsIndex = matching;
+    this.visitedEvents = visitedEvents;
+    this.host = visitedEvents[0]?.host || '';
+
+    return newSess;
   };
 
   fetchNotes = async (sessionId: string) => {
@@ -494,13 +505,13 @@ export default class SessionStore {
 
     const filteredEvents = query
       ? events.filter(
-          (e) =>
-            searchRe.test(e.url) ||
-            searchRe.test(e.value) ||
-            searchRe.test(e.label) ||
-            searchRe.test(e.type) ||
-            (e.type === 'LOCATION' && searchRe.test('visited')),
-        )
+        (e) =>
+          searchRe.test(e.url) ||
+          searchRe.test(e.value) ||
+          searchRe.test(e.label) ||
+          searchRe.test(e.type) ||
+          (e.type === 'LOCATION' && searchRe.test('visited')),
+      )
       : null;
 
     this.filteredEvents = filteredEvents;

--- a/frontend/app/mstore/types/widget.ts
+++ b/frontend/app/mstore/types/widget.ts
@@ -561,7 +561,15 @@ export default class Widget {
   fetchSessions = async (_: any, filter: any): Promise<any> => {
     const newFilter = this.applyProperties(filter);
     const resp = await metricService.fetchSessions(newFilter);
-    if (!resp.series?.length) {
+    if (resp.sessions) {
+      return [
+        {
+          ...resp,
+          sessions: resp.sessions.map((s: any) => new Session().fromJson(s)),
+          seriesName: 'All',
+        },
+      ];
+    } else if (!resp.series?.length) {
       return null;
     }
     return resp.series.map((cat: { sessions: any[] }) => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds deep-link filter support and fixes drilldown and event-loading flows for a smoother 1.26 UI. Sessions, dashboards, and the player now behave correctly when filters come from the URL or while events are still loading.

- **New Features**
  - Support `userId`, `distinct_id`, `userCountry`, `userCity`, and `meta_*` URL params to prefill filters and a custom date range, then auto-fetch sessions.
  - Drilldowns: send filters-only requests for generic widgets; for funnels, build a single series with the selected steps and “then” order.

- **Bug Fixes**
  - Correct Sankey LOCATION subfilter to `urlPath`.
  - Decouple event loading from session info; show loader stripes until events arrive; guard player updates for missing arrays.
  - Fix funnel drilldown filter creation and series handling in `WidgetSessions`; ensure REQUEST table adds the `REQUEST` filter when needed.

<sup>Written for commit 0fca08bbd55a8d44c5e305e8ae4ef142ddbd8156. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

