### PR TITLE
Updated patch build from main aa92544be6442c4a184bd0458559dd820e5c5343

### DIFF
--- a/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.10
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.26.8"
+AppVersion: "v1.26.9"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the frontend Helm chart AppVersion from v1.26.8 to v1.26.9. Ensures deployments use the latest patch build.

<sup>Written for commit 2da12217f016eb423d4cfa0375c395cd6f347f47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

