### PR TITLE
ui: fix cursor animation for mobile touch events

### DIFF
--- a/frontend/app/player/mobile/IOSMessageManager.ts
+++ b/frontend/app/player/mobile/IOSMessageManager.ts
@@ -1,34 +1,31 @@
-import logger from 'App/logger';
-import { TarFile } from 'js-untar';
-import { FrameSnapshot } from 'Player/common/parseFrames';
 import { getResourceFromNetworkRequest } from 'Player';
-
 import type { Store } from 'Player';
-import { IMessageManager } from 'Player/player/Animator';
-
-import TouchManager from 'Player/mobile/managers/TouchManager';
+import { FrameSnapshot } from 'Player/common/parseFrames';
 import IOSPerformanceTrackManager, {
   PerformanceChartPoint,
 } from 'Player/mobile/managers/IOSPerformanceTrackManager';
 import SnapshotManager from 'Player/mobile/managers/SnapshotManager';
+import TouchManager from 'Player/mobile/managers/TouchManager';
+import { IMessageManager } from 'Player/player/Animator';
+import { TarFile } from 'js-untar';
+
+import logger from 'App/logger';
+
+import ListWalker from '../common/ListWalker';
+import Screen, {
+  INITIAL_STATE as SCREEN_INITIAL_STATE,
+  State as ScreenState,
+} from '../web/Screen/Screen';
 import ActivityManager from '../web/managers/ActivityManager';
+import type { SkipInterval } from '../web/managers/ActivityManager';
+import { MType } from '../web/messages';
+import type { Message } from '../web/messages';
 import Lists, {
   InitialLists,
   INITIAL_STATE as LISTS_INITIAL_STATE,
   State as ListsState,
 } from './IOSLists';
-import ListWalker from '../common/ListWalker';
-import { MType } from '../web/messages';
-import type { Message } from '../web/messages';
-
-import Screen, {
-  INITIAL_STATE as SCREEN_INITIAL_STATE,
-  State as ScreenState,
-} from '../web/Screen/Screen';
-
 import { Log } from './types/log';
-
-import type { SkipInterval } from '../web/managers/ActivityManager';
 
 export const performanceWarnings = [
   'thermalState',
@@ -226,7 +223,6 @@ export default class IOSMessageManager implements IMessageManager {
       });
     }
     if (lastAppFocusMessage) {
-      console.log(lastAppFocusMessage);
       Object.assign(stateToUpdate, {
         inBackground: lastAppFocusMessage.value === 1,
       });
@@ -262,7 +258,16 @@ export default class IOSMessageManager implements IMessageManager {
     Object.keys(stateToUpdate).length > 0 && this.state.update(stateToUpdate);
   }
 
-  distributeMessage = (msg: Message & { tabId: string }): void => {
+  distributeMessage = (
+    msg: Message & { tabId: string; timestamp?: number },
+  ): void => {
+    if (msg.tp === 9999) return;
+    // @ts-ignore
+    const fixedTime =
+      msg.time === 0 && msg.timestamp
+        ? msg.timestamp - this.sessionStart
+        : msg.time;
+    msg.time = fixedTime;
     const lastMessageTime = Math.max(msg.time, this.lastMessageTime);
     this.lastMessageTime = lastMessageTime;
     this.state.update({ lastMessageTime });

--- a/frontend/app/player/mobile/managers/TouchManager.ts
+++ b/frontend/app/player/mobile/managers/TouchManager.ts
@@ -1,12 +1,13 @@
-import { MOUSE_TRAIL } from 'App/constants/storageKeys';
 import ListWalker from 'Player/common/ListWalker';
-import MouseTrail, { SwipeEvent } from 'Player/web/addons/MouseTrail';
-import type { IosClickEvent, IosSwipeEvent } from 'Player/web/messages';
-import { MType } from 'Player/web/messages';
 import type Screen from 'Player/web/Screen/Screen';
+import MouseTrail from 'Player/web/addons/MouseTrail';
+import type { MobileClickEvent, MobileSwipeEvent } from 'Player/web/messages';
+import { MType } from 'Player/web/messages';
+
+import { MOUSE_TRAIL } from 'App/constants/storageKeys';
 
 export default class TouchManager extends ListWalker<
-  IosClickEvent | IosSwipeEvent
+  MobileClickEvent | MobileSwipeEvent
 > {
   private touchTrail: MouseTrail | undefined;
 
@@ -48,8 +49,9 @@ export default class TouchManager extends ListWalker<
         //   direction: lastTouch.direction
         // } as SwipeEvent)
       } else {
-        this.screen.cursor.move(lastTouch);
-        this.screen.cursor.mobileClick();
+        this.touchTrail?.addTouch(lastTouch.x, lastTouch.y);
+        // this.screen.cursor.move(lastTouch);
+        // this.screen.cursor.mobileClick();
       }
     }
   }

--- a/frontend/app/player/web/addons/MouseTrail.ts
+++ b/frontend/app/player/web/addons/MouseTrail.ts
@@ -6,6 +6,12 @@ const LINE_DURATION = 3.5;
 const LINE_DURATION_MOBILE = 5;
 const LINE_WIDTH_START = 5;
 
+const TOUCH_PULSE_FRAMES = 60;
+const TOUCH_PULSE_BASE_RADIUS = 8;
+const TOUCH_PULSE_PEAK_RADIUS = 22;
+const TOUCH_PULSE_ALPHA = 0.35;
+const TOUCH_PULSE_Y_OFFSET = TOUCH_PULSE_PEAK_RADIUS;
+
 export type SwipeEvent = {
   x: number;
   y: number;
@@ -22,6 +28,8 @@ export default class MouseTrail {
   private readonly lineDuration: number;
 
   private points: Point[] = [];
+
+  private touchPulses: TouchPulse[] = [];
 
   constructor(
     private readonly canvas: HTMLCanvasElement,
@@ -122,13 +130,47 @@ export default class MouseTrail {
       this.context.stroke();
       this.context.closePath();
     }
+
+    this.drawTouchPulses();
   };
 
   addPoint = (x: number, y: number) => {
     const point = new Point(x, y, 0);
     this.points.push(point);
   };
+
+  addTouch = (x: number, y: number) => {
+    this.touchPulses.push({ x, y: y + TOUCH_PULSE_Y_OFFSET, lifetime: 0 });
+  };
+
+  private drawTouchPulses = () => {
+    const pulses = this.touchPulses;
+    for (let i = pulses.length - 1; i >= 0; i--) {
+      const pulse = pulses[i]!;
+      pulse.lifetime += 1;
+
+      if (pulse.lifetime > TOUCH_PULSE_FRAMES) {
+        pulses.splice(i, 1);
+        continue;
+      }
+
+      const t = pulse.lifetime / TOUCH_PULSE_FRAMES;
+      const wave = Math.sin(Math.PI * t);
+      const radius =
+        TOUCH_PULSE_BASE_RADIUS +
+        (TOUCH_PULSE_PEAK_RADIUS - TOUCH_PULSE_BASE_RADIUS) * wave;
+      const alpha = TOUCH_PULSE_ALPHA * wave;
+
+      this.context.beginPath();
+      this.context.arc(pulse.x, pulse.y, radius, 0, Math.PI * 2);
+      this.context.fillStyle = `rgba(128, 128, 128, ${alpha})`;
+      this.context.fill();
+      this.context.closePath();
+    }
+  };
 }
+
+type TouchPulse = { x: number; y: number; lifetime: number };
 
 type Coords = { x: number; y: number };
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the mobile touch cursor animation by drawing touch pulses on the `MouseTrail` canvas instead of moving/clicking the cursor, and corrects iOS message timing to prevent zero-time events.

- **New Features**
  - Added touch pulse animation to `MouseTrail` (`addTouch`) with smooth fade/expand over 60 frames.
  - `TouchManager` now records taps via `addTouch` and uses `MobileClickEvent | MobileSwipeEvent`.

- **Bug Fixes**
  - Fixed iOS message timing: when `time === 0`, use `timestamp - sessionStart`; ignore messages with `tp === 9999`.
  - Removed stray console log and cleaned imports.

<sup>Written for commit a17ac29f3ee00d07a4e77630e215a72abe42567a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

