### PR TITLE
OR 3469 clickhouse delta apply

### DIFF
--- a/scripts/helmcharts/openreplay/files/clickhouse.sh
+++ b/scripts/helmcharts/openreplay/files/clickhouse.sh
@@ -10,22 +10,64 @@ clickhousedir=/opt/openreplay/openreplay/scripts/schema/db/init_dbs/clickhouse
 
 [[ "${CH_USE_TLS}" == "true" ]] && CH_TLS_FLAGS="--secure --accept-invalid-certificate" || CH_TLS_FLAGS=""
 
+ch_client="clickhouse-client -h ${CH_HOST} --port ${CH_PORT} --user ${CH_USERNAME} ${CH_PASSWORD} ${CH_TLS_FLAGS}"
+
+function run_numbered_migration() {
+    local version=$1
+    local version_dir="${clickhousedir}/${version}"
+
+    # Safe-init the state function (no-op if it already exists)
+    $ch_client -q "CREATE FUNCTION IF NOT EXISTS openreplay_migration_state AS() -> -1;"
+
+    # Read current state and determine where to start
+    local state
+    state=$($ch_client -q "SELECT openreplay_migration_state()" | tr -d '[:space:]')
+    local start_from=$((state + 1))
+    echo "Migration state for version $version: state=$state, starting from step $start_from"
+
+    # Execute numbered files in version-sorted order (sort -V handles 10 > 2 correctly)
+    for file in $(ls "${version_dir}"/*.sql | sort -V); do
+        local file_num
+        file_num=$(basename "$file" .sql)
+        if [[ $file_num -lt $start_from ]]; then
+            echo "Skipping $file (step $file_num already done)"
+            continue
+        fi
+        echo "Executing $file (step $file_num)"
+        $ch_client --multiquery < "$file" || { echo "FAILED at $file (step $file_num)"; exit 1; }
+    done
+
+    # Verify migration completed (state should be -1)
+    local final_state
+    final_state=$($ch_client -q "SELECT openreplay_migration_state()" | tr -d '[:space:]')
+    if [[ $final_state -ne -1 ]]; then
+        echo "ERROR: Migration for version $version did not complete. Final state: $final_state"
+        exit 1
+    fi
+    echo "Migration for version $version completed successfully"
+}
+
 function migrate() {
     echo "Starting clickhouse migration"
     IFS=',' read -r -a migration_versions <<< "$1"
     for version in ${migration_versions[*]}; do
         echo "Migrating clickhouse version $version"
-        # For now, we can ignore the clickhouse db inject errors.
-        # TODO: Better error handling in script
-        clickhouse-client -h ${CH_HOST} --port ${CH_PORT} --user ${CH_USERNAME} ${CH_PASSWORD} ${CH_TLS_FLAGS} --multiquery < ${clickhousedir}/${version}/${version}.sql || true
+        if [[ -f "${clickhousedir}/${version}/${version}.sql" ]]; then
+            # Old-style: single file migration (pre-1.23.0)
+            # Keep || true — these files have no throwIf guards and contain non-idempotent DDL
+            $ch_client --multiquery < "${clickhousedir}/${version}/${version}.sql" || true
+        else
+            # New-style: numbered files with resume support (1.23.0+)
+            run_numbered_migration "$version"
+        fi
     done
 }
 
 function init() {
     echo "Initializing clickhouse"
-    for file in `ls ${clickhousedir}/create/*.sql`; do
+    for file in $(ls "${clickhousedir}"/create/*.sql); do
         echo "Injecting $file"
-        clickhouse-client -h ${CH_HOST} --user ${CH_USERNAME} ${CH_PASSWORD} --port ${CH_PORT} ${CH_TLS_FLAGS} --multiquery < $file || true
+        $ch_client --multiquery < "$file" || true
     done
 }
 

--- a/scripts/helmcharts/openreplay/templates/job.yaml
+++ b/scripts/helmcharts/openreplay/templates/job.yaml
@@ -46,8 +46,10 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-  backoffLimit: 0 # Don't restart failing containers
+  backoffLimit: 1 # One retry; resume logic picks up from last successful step
+  activeDeadlineSeconds: {{ .Values.migrationJob.activeDeadlineSeconds | default 3600 }}
   template:
     metadata:
       name: postgresqlMigrate


### PR DESCRIPTION

- **feat(OR-3469): rewrite clickhouse.sh migrate with resume logic**
- **feat(OR-3469): harden migration Job for fail-safe upgrades**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes ClickHouse upgrades fail-safe by adding resumable delta migrations to `clickhouse.sh` and hardening the Helm migration Job. Addresses OR-3469; runs 1.23.0+ numbered files in order and keeps old single-file migrations working.

- **New Features**
  - Resumable numbered migrations via `openreplay_migration_state()` with final verification; files run in correct order with `sort -V`; pre-1.23.0 single-file migrations keep `|| true`.
  - Hardened K8s Job: `"helm.sh/hook-delete-policy": before-hook-creation`, `backoffLimit: 1`, and `activeDeadlineSeconds` (default 3600, configurable via `.Values.migrationJob.activeDeadlineSeconds`).

- **Bug Fixes**
  - Runner uses 1.23.0+ numbered SQL files (not `${version}.sql`); failures exit non-zero and retries resume from the last successful step.
  - Trimmed `clickhouse-client` output for reliable state reads; `init` now uses the same `$ch_client` flags and credentials for consistency.

<sup>Written for commit 3d88493c9a4366f3d5df3bbc068a0f4df4f41e43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

