### PR TITLE
dev

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -5,24 +5,24 @@ name = "pypi"
 
 [packages]
 urllib3 = "==2.6.3"
-requests = "==2.32.5"
-boto3 = "==1.42.50"
-pyjwt = "==2.11.0"
-psycopg2-binary = "==2.9.11"
-clickhouse-connect = "==0.11.0"
+requests = "==2.33.1"
+boto3 = "==1.42.94"
+pyjwt = "==2.12.1"
+psycopg2-binary = "==2.9.12"
+clickhouse-connect = "==0.15.1"
 elasticsearch = "==9.3.0"
 jira = "==3.10.5"
-cachetools = "==7.0.1"
-fastapi = "==0.129.0"
+cachetools = "==7.0.6"
+fastapi = "==0.136.0"
 python-decouple = "==3.8"
 apscheduler = "==3.11.2"
-redis = "==7.2.0"
-psycopg = {extras = ["binary", "pool"], version = "==3.3.2"}
-uvicorn = {extras = ["standard"], version = "==0.41.0"}
-pydantic = {extras = ["email"], version = "==2.12.5"}
+redis = "==7.4.0"
+psycopg = {extras = ["binary", "pool"], version = "==3.3.3"}
+uvicorn = {extras = ["standard"], version = "==0.46.0"}
+pydantic = {extras = ["email"], version = "==2.13.3"}
 
 [dev-packages]
 
 [requires]
 python_version = "3.13"
-python_full_version = "3.13.11"
+python_full_version = "3.13.13"

--- a/api/requirements-alerts.txt
+++ b/api/requirements-alerts.txt
@@ -1,16 +1,16 @@
 urllib3==2.6.3
-requests==2.32.5
-boto3==1.42.50
-pyjwt==2.11.0
-psycopg2-binary==2.9.11
-psycopg[pool,binary]==3.3.2
-clickhouse-connect==0.11.0
+requests==2.33.1
+boto3==1.42.94
+pyjwt==2.12.1
+psycopg2-binary==2.9.12
+psycopg[pool,binary]==3.3.3
+clickhouse-connect==0.15.1
 elasticsearch==9.3.0
 jira==3.10.5
-cachetools==7.0.1
+cachetools==7.0.6
 
-fastapi==0.129.0
-uvicorn[standard]==0.41.0
+fastapi==0.136.0
+uvicorn[standard]==0.46.0
 python-decouple==3.8
-pydantic[email]==2.12.5
+pydantic[email]==2.13.3
 apscheduler==3.11.2

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,18 +1,18 @@
 urllib3==2.6.3
-requests==2.32.5
-boto3==1.42.50
-pyjwt==2.11.0
-psycopg2-binary==2.9.11
-psycopg[pool,binary]==3.3.2
-clickhouse-connect==0.11.0
+requests==2.33.1
+boto3==1.42.94
+pyjwt==2.12.1
+psycopg2-binary==2.9.12
+psycopg[pool,binary]==3.3.3
+clickhouse-connect==0.15.1
 elasticsearch==9.3.0
 jira==3.10.5
-cachetools==7.0.1
+cachetools==7.0.6
 
-fastapi==0.129.0
-uvicorn[standard]==0.41.0
+fastapi==0.136.0
+uvicorn[standard]==0.46.0
 python-decouple==3.8
-pydantic[email]==2.12.5
+pydantic[email]==2.13.3
 apscheduler==3.11.2
 
-redis==7.2.0
+redis==7.4.0

--- a/ee/api/Pipfile
+++ b/ee/api/Pipfile
@@ -5,32 +5,32 @@ name = "pypi"
 
 [packages]
 urllib3 = "==2.6.3"
-requests = "==2.32.5"
-boto3 = "==1.42.50"
-pyjwt = "==2.11.0"
-psycopg2-binary = "==2.9.11"
-clickhouse-connect = "==0.11.0"
+requests = "==2.33.1"
+boto3 = "==1.42.94"
+pyjwt = "==2.12.1"
+psycopg2-binary = "==2.9.12"
+clickhouse-connect = "==0.15.1"
 elasticsearch = "==9.3.0"
 jira = "==3.10.5"
-cachetools = "==7.0.1"
-fastapi = "==0.129.0"
-gunicorn = "==25.1.0"
+cachetools = "==7.0.6"
+fastapi = "==0.136.0"
+gunicorn = "==25.3.0"
 python-decouple = "==3.8"
 apscheduler = "==3.11.2"
 python3-saml = "==1.16.0"
-python-multipart = "==0.0.22"
-scim2-models = "==0.6.4"
-scim2-server = "==0.1.8"
+python-multipart = "==0.0.26"
+scim2-models = "==0.6.12"
+scim2-server = "==0.1.9"
 scim2-filter-parser = "==0.7.0"
-werkzeug = "==3.1.5"
-redis = "==7.2.0"
+werkzeug = "==3.1.8"
+redis = "==7.4.0"
 azure-storage-blob = "==12.28.0"
-psycopg = {extras = ["binary", "pool"], version = "==3.3.2"}
-uvicorn = {extras = ["standard"], version = "==0.41.0"}
-pydantic = {extras = ["email"], version = "==2.12.5"}
+psycopg = {extras = ["binary", "pool"], version = "==3.3.3"}
+uvicorn = {extras = ["standard"], version = "==0.46.0"}
+pydantic = {extras = ["email"], version = "==2.13.3"}
 
 [dev-packages]
 
 [requires]
 python_version = "3.13"
-python_full_version = "3.13.11"
+python_full_version = "3.13.13"

--- a/ee/api/requirements-alerts.txt
+++ b/ee/api/requirements-alerts.txt
@@ -1,18 +1,18 @@
 urllib3==2.6.3
-requests==2.32.5
-boto3==1.42.50
-pyjwt==2.11.0
-psycopg2-binary==2.9.11
-psycopg[pool,binary]==3.3.2
-clickhouse-connect==0.11.0
+requests==2.33.1
+boto3==1.42.94
+pyjwt==2.12.1
+psycopg2-binary==2.9.12
+psycopg[pool,binary]==3.3.3
+clickhouse-connect==0.15.1
 elasticsearch==9.3.0
 jira==3.10.5
-cachetools==7.0.1
+cachetools==7.0.6
 
-fastapi==0.129.0
-uvicorn[standard]==0.41.0
+fastapi==0.136.0
+uvicorn[standard]==0.46.0
 python-decouple==3.8
-pydantic[email]==2.12.5
+pydantic[email]==2.13.3
 apscheduler==3.11.2
 
 azure-storage-blob==12.28.0

--- a/ee/api/requirements-crons.txt
+++ b/ee/api/requirements-crons.txt
@@ -1,18 +1,18 @@
 urllib3==2.6.3
-requests==2.32.5
-boto3==1.42.50
-pyjwt==2.11.0
-psycopg2-binary==2.9.11
-psycopg[pool,binary]==3.3.2
-clickhouse-connect==0.11.0
+requests==2.33.1
+boto3==1.42.94
+pyjwt==2.12.1
+psycopg2-binary==2.9.12
+psycopg[pool,binary]==3.3.3
+clickhouse-connect==0.15.1
 elasticsearch==9.3.0
 jira==3.10.5
-cachetools==7.0.1
+cachetools==7.0.6
 
-fastapi==0.129.0
+fastapi==0.136.0
 python-decouple==3.8
-pydantic[email]==2.12.5
+pydantic[email]==2.13.3
 apscheduler==3.11.2
 
-redis==7.2.0
+redis==7.4.0
 azure-storage-blob==12.28.0

--- a/ee/api/requirements.txt
+++ b/ee/api/requirements.txt
@@ -1,32 +1,32 @@
 urllib3==2.6.3
-requests==2.32.5
-boto3==1.42.50
-pyjwt==2.11.0
-psycopg2-binary==2.9.11
-psycopg[pool,binary]==3.3.2
-clickhouse-connect==0.11.0
+requests==2.33.1
+boto3==1.42.94
+pyjwt==2.12.1
+psycopg2-binary==2.9.12
+psycopg[pool,binary]==3.3.3
+clickhouse-connect==0.15.1
 elasticsearch==9.3.0
 jira==3.10.5
-cachetools==7.0.1
+cachetools==7.0.6
 
-fastapi==0.129.0
-uvicorn[standard]==0.41.0
-gunicorn==25.1.0
+fastapi==0.136.0
+uvicorn[standard]==0.46.0
+gunicorn==25.3.0
 python-decouple==3.8
-pydantic[email]==2.12.5
+pydantic[email]==2.13.3
 apscheduler==3.11.2
 
 # xmlsec and lxml are provided by Nix. Check shell.nix and Dockerfile
 
 python3-saml==1.16.0
-python-multipart==0.0.22
+python-multipart==0.0.26
 
 # SCIM packages for user/group provisioning
-scim2-models==0.6.4
-scim2-server==0.1.8
+scim2-models==0.6.12
+scim2-server==0.1.9
 scim2-filter-parser==0.7.0
-werkzeug==3.1.5
+werkzeug==3.1.8
 
-redis==7.2.0
+redis==7.4.0
 #confluent-kafka==2.1.0
 azure-storage-blob==12.28.0

--- a/ee/scripts/schema/db/init_dbs/postgresql/init_schema.sql
+++ b/ee/scripts/schema/db/init_dbs/postgresql/init_schema.sql
@@ -1,4 +1,4 @@
-\set or_version 'v1.26.0-ee'
+\set or_version 'v1.27.0-ee'
 SET client_min_messages TO NOTICE;
 \set ON_ERROR_STOP true
 SELECT EXISTS (SELECT 1

--- a/scripts/schema/db/init_dbs/postgresql/init_schema.sql
+++ b/scripts/schema/db/init_dbs/postgresql/init_schema.sql
@@ -1,4 +1,4 @@
-\set or_version 'v1.26.0'
+\set or_version 'v1.27.0'
 SET client_min_messages TO NOTICE;
 \set ON_ERROR_STOP true
 SELECT EXISTS (SELECT 1


### PR DESCRIPTION
- **refactor(chalice): upgraded dependencies**
- **refactor(db): changes**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded API and EE dependencies across the stack and bumped the PostgreSQL schema version to v1.27.0. Also aligned the Python runtime to 3.13.13.

- **Dependencies**
  - API stack: `fastapi` 0.129.0 -> 0.136.0, `uvicorn` 0.41.0 -> 0.46.0, `pydantic` 2.12.5 -> 2.13.3
  - DB drivers: `psycopg2-binary` 2.9.11 -> 2.9.12, `psycopg` 3.3.2 -> 3.3.3
  - Clients/utilities: `requests` 2.32.5 -> 2.33.1, `boto3` 1.42.50 -> 1.42.94, `redis` 7.2.0 -> 7.4.0, `cachetools` 7.0.1 -> 7.0.6, `pyjwt` 2.11.0 -> 2.12.1
  - Data connectors: `clickhouse-connect` 0.11.0 -> 0.15.1
  - EE-only: `gunicorn` 25.1.0 -> 25.3.0, `python-multipart` 0.0.22 -> 0.0.26, `scim2-models` 0.6.4 -> 0.6.12, `scim2-server` 0.1.8 -> 0.1.9, `werkzeug` 3.1.5 -> 3.1.8
  - Python: `python_full_version` 3.13.11 -> 3.13.13

<sup>Written for commit f12b3b4087b11944df52459112465f8fb72c1e79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

