### PR TITLE
Block OR downgrade

### DIFF
--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -530,6 +530,21 @@ function upgrade() {
 
     or_version="$(yq eval '.fromVersion' /var/lib/openreplay/vars.yaml)"
 
+    # Reconcile vars.yaml fromVersion against the in-cluster openreplay-version ConfigMap.
+    # If they disagree, bail out. Cluster ConfigMap (written by post-upgrade hook) is source of truth;
+    # proceeding with a stale fromVersion would clone the wrong tag and silently skip migrations.
+    cluster_version="$(kubectl get configmap -n "${APP_NS}" openreplay-version -o jsonpath='{.data.version}' 2>/dev/null || true)"
+    stripped_or_version="${or_version//\"/}"
+    if [[ -n "$cluster_version" && "$cluster_version" != "$stripped_or_version" ]]; then
+        log err "Version drift detected.
+          vars.yaml fromVersion : ${BWHITE}${stripped_or_version}${RED}
+          cluster ConfigMap     : ${BWHITE}${cluster_version}${RED}
+
+          Fix ${BWHITE}${OR_DIR}/vars.yaml${RED} so fromVersion matches the cluster, then rerun.
+            ${BWHITE}sudo yq -i '.fromVersion = "${cluster_version}"' ${OR_DIR}/vars.yaml${RED}
+        "
+    fi
+
     # If release upgrade, then check for version specific instructions
     [[ $RELEASE_UPGRADE -eq 1 ]] && version_specific_checks "$or_version"
     # Unless it's upgrade release, always checkout same tag.

--- a/scripts/helmcharts/openreplay/templates/configmap.yaml
+++ b/scripts/helmcharts/openreplay/templates/configmap.yaml
@@ -1,3 +1,22 @@
+{{/*
+  Downgrade guard.
+  If the cluster has an openreplay-version ConfigMap with a version strictly
+  newer than .Chart.AppVersion, abort the helm operation immediately.
+  This catches the case where someone runs `helm upgrade` directly with an
+  older chart (bypassing openreplay-cli), which would otherwise deploy older
+  images and silently rewind the installation.
+
+  Override with --set allowDowngrade=true if this is intentional.
+*/}}
+{{- $existing := lookup "v1" "ConfigMap" .Release.Namespace "openreplay-version" }}
+{{- $existingVersion := "" }}
+{{- if $existing }}
+  {{- $existingVersion = index $existing.data "version" | default "" }}
+{{- end }}
+{{- $newVersion := .Chart.AppVersion }}
+{{- if and $existingVersion (not .Values.allowDowngrade) (semverCompare (printf ">%s" (trimPrefix "v" $newVersion)) (trimPrefix "v" $existingVersion)) }}
+  {{- fail (printf "\n\n  [DOWNGRADE BLOCKED]\n  Installed version (ConfigMap openreplay-version) : %s\n  Chart.AppVersion being applied                   : %s\n\n  Applying an older chart would roll back images and corrupt migration state.\n  If this is intentional, rerun with --set allowDowngrade=true.\n" $existingVersion $newVersion) }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,7 +26,8 @@ metadata:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-weight": "-6" # Higher precidence, so the first the config map will get created.
 data:
-  version: {{ .Chart.AppVersion }}
+  version: {{ $newVersion }}
+  chartAppVersion: {{ .Chart.AppVersion }}  # actual chart deployed, for audit
 ---
 # If some jobs or crons are doing db operations, or using credentias,
 # it should fetch them from this secret.

--- a/scripts/helmcharts/openreplay/templates/configmap.yaml
+++ b/scripts/helmcharts/openreplay/templates/configmap.yaml
@@ -26,8 +26,8 @@ metadata:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-weight": "-6" # Higher precidence, so the first the config map will get created.
 data:
-  version: {{ $newVersion }}
-  chartAppVersion: {{ .Chart.AppVersion }}  # actual chart deployed, for audit
+  version: {{ $newVersion | quote }}
+  chartAppVersion: {{ .Chart.AppVersion | quote }}  # actual chart deployed, for audit
 ---
 # If some jobs or crons are doing db operations, or using credentias,
 # it should fetch them from this secret.

--- a/scripts/helmcharts/openreplay/values.yaml
+++ b/scripts/helmcharts/openreplay/values.yaml
@@ -2,6 +2,11 @@ migrationJob:
   podAnnotations:
     linkerd.io/inject: disabled
 
+# Safety guard: the openreplay-version ConfigMap template aborts helm at
+# render time if the cluster already has a newer version than Chart.AppVersion.
+# Set to true to allow intentional rollbacks / downgrades.
+allowDowngrade: false
+
 # Offline migration using pre-built migration image (for air-gapped environments)
 # When enabled, uses bundled schema files instead of cloning from GitHub
 offlineMigration:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Blocks accidental downgrades and version drift to protect migrations. Adds a Helm guard to stop applying older charts and a CLI check that aborts when `vars.yaml` doesn’t match the cluster.

- **Bug Fixes**
  - Helm: Abort if `.Chart.AppVersion` is older than the installed `openreplay-version` (via `lookup` + `fail`; override with `--set allowDowngrade=true`). Quote version fields in the ConfigMap and set `allowDowngrade: false` in `values.yaml`. Also records `chartAppVersion` for audit.
  - CLI: In `upgrade()`, compare `/var/lib/openreplay/vars.yaml` `fromVersion` with the in-cluster `openreplay-version`; abort with a copy-pasteable `yq` command to realign when they differ.

<sup>Written for commit 472d5498924df324d7182e17d4227a299ad8ede5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

