### PR TITLE
refactor(chalice): changed routes

### DIFF
--- a/api/routers/core.py
+++ b/api/routers/core.py
@@ -820,13 +820,13 @@ def delete_msteams_integration(webhookId: int, _=Body(None),
     return webhook.delete(tenant_id=context.tenant_id, webhook_id=webhookId)
 
 
-@app.get('/{project_id}/check-recording-status', tags=["sessions"])
-async def check_recording_status(project_id: int):
+@app.get('/{projectId}/check-recording-status', tags=["sessions"])
+async def check_recording_status(projectId: int):
     """
     Check the recording status and sessions count for a given project ID.
 
     Args:
-        project_id (int): The ID of the project to check.
+        projectId (int): The ID of the project to check.
 
     Returns:
         dict: A dictionary containing the recording status and sessions count.
@@ -839,7 +839,7 @@ async def check_recording_status(project_id: int):
                   "sessions_count": int      # The total count of sessions
               }
     """
-    return {"data": sessions.check_recording_status(project_id=project_id)}
+    return {"data": sessions.check_recording_status(project_id=projectId)}
 
 
 @public_app.get('/', tags=["health"])

--- a/ee/api/routers/core_dynamic.py
+++ b/ee/api/routers/core_dynamic.py
@@ -590,38 +590,38 @@ def get_all_notes(projectId: int, data: schemas.SearchNoteSchema = Body(...),
     return {'data': data}
 
 
-@app.post('/{project_id}/feature-flags/search', tags=["feature flags"])
-def search_feature_flags(project_id: int,
+@app.post('/{projectId}/feature-flags/search', tags=["feature flags"])
+def search_feature_flags(projectId: int,
                          data: schemas.SearchFlagsSchema = Body(...),
                          context: schemas.CurrentContext = Depends(OR_context)):
-    return feature_flags.search_feature_flags(project_id=project_id, user_id=context.user_id, data=data)
+    return feature_flags.search_feature_flags(project_id=projectId, user_id=context.user_id, data=data)
 
 
-@app.get('/{project_id}/feature-flags/{feature_flag_id}', tags=["feature flags"])
-def get_feature_flag(project_id: int, feature_flag_id: int):
-    return feature_flags.get_feature_flag(project_id=project_id, feature_flag_id=feature_flag_id)
+@app.get('/{projectId}/feature-flags/{feature_flag_id}', tags=["feature flags"])
+def get_feature_flag(projectId: int, feature_flag_id: int):
+    return feature_flags.get_feature_flag(project_id=projectId, feature_flag_id=feature_flag_id)
 
 
-@app.post('/{project_id}/feature-flags', tags=["feature flags"])
-def add_feature_flag(project_id: int, data: schemas.FeatureFlagSchema = Body(...),
+@app.post('/{projectId}/feature-flags', tags=["feature flags"])
+def add_feature_flag(projectId: int, data: schemas.FeatureFlagSchema = Body(...),
                      context: schemas.CurrentContext = Depends(OR_context)):
-    return feature_flags.create_feature_flag(project_id=project_id, user_id=context.user_id, feature_flag_data=data)
+    return feature_flags.create_feature_flag(project_id=projectId, user_id=context.user_id, feature_flag_data=data)
 
 
-@app.put('/{project_id}/feature-flags/{feature_flag_id}', tags=["feature flags"])
-def update_feature_flag(project_id: int, feature_flag_id: int, data: schemas.FeatureFlagSchema = Body(...),
+@app.put('/{projectId}/feature-flags/{feature_flag_id}', tags=["feature flags"])
+def update_feature_flag(projectId: int, feature_flag_id: int, data: schemas.FeatureFlagSchema = Body(...),
                         context: schemas.CurrentContext = Depends(OR_context)):
-    return feature_flags.update_feature_flag(project_id=project_id, feature_flag_id=feature_flag_id,
+    return feature_flags.update_feature_flag(project_id=projectId, feature_flag_id=feature_flag_id,
                                              user_id=context.user_id, feature_flag=data)
 
 
-@app.delete('/{project_id}/feature-flags/{feature_flag_id}', tags=["feature flags"])
-def delete_feature_flag(project_id: int, feature_flag_id: int, _=Body(None)):
-    return {"data": feature_flags.delete_feature_flag(project_id=project_id, feature_flag_id=feature_flag_id)}
+@app.delete('/{projectId}/feature-flags/{feature_flag_id}', tags=["feature flags"])
+def delete_feature_flag(projectId: int, feature_flag_id: int, _=Body(None)):
+    return {"data": feature_flags.delete_feature_flag(project_id=projectId, feature_flag_id=feature_flag_id)}
 
 
-@app.post('/{project_id}/feature-flags/{feature_flag_id}/status', tags=["feature flags"])
-def update_feature_flag_status(project_id: int, feature_flag_id: int,
+@app.post('/{projectId}/feature-flags/{feature_flag_id}/status', tags=["feature flags"])
+def update_feature_flag_status(projectId: int, feature_flag_id: int,
                                data: schemas.FeatureFlagStatus = Body(...)):
-    return {"data": feature_flags.update_feature_flag_status(project_id=project_id, feature_flag_id=feature_flag_id,
+    return {"data": feature_flags.update_feature_flag_status(project_id=projectId, feature_flag_id=feature_flag_id,
                                                              is_active=data.is_active)}

--- a/ee/api/routers/ee.py
+++ b/ee/api/routers/ee.py
@@ -123,27 +123,27 @@ def delete_record(projectId: int, recordId: int, _=Body(None),
     return {"data": result}
 
 
-@app.get('/{project_id}/assist-stats/avg', tags=["assist-stats"])
+@app.get('/{projectId}/assist-stats/avg', tags=["assist-stats"])
 def get_assist_stats_avg(
-        project_id: int,
+        projectId: int,
         startTimestamp: int = None,
         endTimestamp: int = None,
         userId: str = None
 ):
     return assist_stats.get_averages(
-        project_id=project_id,
+        project_id=projectId,
         start_timestamp=startTimestamp,
         end_timestamp=endTimestamp,
         user_id=userId)
 
 
 @app.get(
-    '/{project_id}/assist-stats/top-members',
+    '/{projectId}/assist-stats/top-members',
     tags=["assist-stats"],
     response_model=schemas.AssistStatsTopMembersResponse
 )
 def get_assist_stats_top_members(
-        project_id: int,
+        projectId: int,
         startTimestamp: int = None,
         endTimestamp: int = None,
         sort: Optional[schemas.AssistStatsSort] = Query(default=schemas.AssistStatsSort.sessions_assisted.value,
@@ -155,7 +155,7 @@ def get_assist_stats_top_members(
         limit: int = 5
 ):
     return assist_stats.get_top_members(
-        project_id=project_id,
+        project_id=projectId,
         start_timestamp=startTimestamp,
         end_timestamp=endTimestamp,
         sort_by=sort,
@@ -167,15 +167,15 @@ def get_assist_stats_top_members(
 
 
 @app.post(
-    '/{project_id}/assist-stats/sessions',
+    '/{projectId}/assist-stats/sessions',
     tags=["assist-stats"],
     response_model=schemas.AssistStatsSessionsResponse
 )
 def get_assist_stats_sessions(
-        project_id: int,
+        projectId: int,
         data: schemas.AssistStatsSessionsRequest = Body(...),
 ):
     return assist_stats.get_sessions(
-        project_id=project_id,
+        project_id=projectId,
         data=data
     )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized the project path parameter to `projectId` (camelCase) across core and EE API routes for consistency and clearer OpenAPI docs. No behavior change to endpoints.

- **Refactors**
  - Renamed `/{project_id}/...` to `/{projectId}/...` for:
    - Sessions: `check-recording-status`
    - Feature flags: search, CRUD, status
    - Assist stats: avg, top-members, sessions
  - Updated handler arguments and service calls to use `projectId`.

- **Migration**
  - Regenerate OpenAPI/SDKs; path param is now named `projectId`.
  - Update any code referencing `project_id` in typed clients or request builders to `projectId`. URLs do not change.

<sup>Written for commit bf958dfae988777b67c9ac2bcb3985bee95c8de3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

