### PR TITLE
fix(api): handle prefix in auth middleware

### DIFF
--- a/backend/pkg/server/auth/auth.go
+++ b/backend/pkg/server/auth/auth.go
@@ -25,7 +25,7 @@ type authImpl struct {
 	publicEndpoints map[string]struct{} // with PublicKeyPermission
 }
 
-func NewAuth(log logger.Logger, jwtSecret string, users user.Users, tenants tenant.Tenants, projects projects.Projects, extensionSecret *string, keys keys.Keys, handlers []api.Handlers) (api.RouterMiddleware, error) {
+func NewAuth(log logger.Logger, jwtSecret string, users user.Users, tenants tenant.Tenants, projects projects.Projects, extensionSecret *string, keys keys.Keys, prefix string, handlers []api.Handlers) (api.RouterMiddleware, error) {
 	res := &authImpl{
 		log:             log,
 		secret:          jwtSecret,
@@ -35,11 +35,11 @@ func NewAuth(log logger.Logger, jwtSecret string, users user.Users, tenants tena
 		extensionSecret: defaultString(extensionSecret),
 		keys:            keys,
 	}
-	res.parsePublicEndpoints(handlers)
+	res.parsePublicEndpoints(prefix, handlers)
 	return res, nil
 }
 
-func (a *authImpl) parsePublicEndpoints(handlers []api.Handlers) {
+func (a *authImpl) parsePublicEndpoints(prefix string, handlers []api.Handlers) {
 	if len(handlers) == 0 {
 		return
 	}
@@ -49,6 +49,9 @@ func (a *authImpl) parsePublicEndpoints(handlers []api.Handlers) {
 			for _, perm := range handler.Permissions {
 				if perm == api.PublicKeyPermission {
 					a.publicEndpoints[handler.Path] = struct{}{}
+					if prefix != "" {
+						a.publicEndpoints[prefix+handler.Path] = struct{}{}
+					}
 					continue
 				}
 			}

--- a/backend/pkg/server/middleware/builder.go
+++ b/backend/pkg/server/middleware/builder.go
@@ -46,7 +46,7 @@ func NewMiddlewareBuilder(
 ) (api.MiddlewareBuilder, error) {
 	healthCheck := NewHealthCheck()
 	corsCheck := NewCors(http.UseAccessControlHeaders)
-	authenticator, err := auth.NewAuth(log, jwtSecret, user.New(pgPool), tenants, projects, extensionSecret, keys, handlers)
+	authenticator, err := auth.NewAuth(log, jwtSecret, user.New(pgPool), tenants, projects, extensionSecret, keys, prefix, handlers)
 	if err != nil {
 		return nil, fmt.Errorf("error creating auth middleware: %s", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the auth middleware to respect the API route prefix when checking public endpoints. Prefixed public routes now work without auth and no longer return 401.

- **Bug Fixes**
  - `auth.NewAuth` accepts a `prefix` and registers both raw and prefixed paths in `publicEndpoints`.
  - Middleware builder now passes the router `prefix` to `auth.NewAuth`.

<sup>Written for commit 9642b2809a8bbfb1946f302b2d8d3f039c99bc23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

