### PR TITLE
dev: restore my commits

### DIFF
--- a/api/.trivyignore
+++ b/api/.trivyignore
@@ -1,3 +1,13 @@
 # Accept the risk until
 # python setup tools recently fixed. Not yet available in distros.
 CVE-2023-5363 exp:2023-12-31
+
+# --- 2026-04-24 -----------------------------------------------------------
+# lxml XXE via iterparse() / ETCompatXMLParser() default settings.
+# The chalice image pulls lxml through nixpkgs (shell.nix -> python3Packages.lxml),
+# which currently ships 6.0.2; the fix landed in 6.1.0. Upgrade path is either
+# pinning a newer nixpkgs revision or overriding the package in shell.nix.
+# This CVE is only exploitable if the app parses attacker-controlled XML with
+# default parser settings — audit the SAML assertion parsing paths before
+# assuming it's not reachable in-context.
+CVE-2026-41066

--- a/api/Dockerfile.dockerignore
+++ b/api/Dockerfile.dockerignore
@@ -9,3 +9,21 @@ Dockerfile*
 app_alerts.py
 requirements-alerts.txt
 entrypoint_alerts.sh
+
+# dev / local artifacts — must not ship in the image
+.venv/
+venv/
+env/
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.coverage
+.dev/
+.dev-pids/
+.env
+.idea/
+.vscode/

--- a/api/Dockerfile_alerts.dockerignore
+++ b/api/Dockerfile_alerts.dockerignore
@@ -9,3 +9,21 @@ Dockerfile*
 app.py
 entrypoint.sh
 requirements.txt
+
+# dev / local artifacts — must not ship in the image
+.venv/
+venv/
+env/
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.coverage
+.dev/
+.dev-pids/
+.env
+.idea/
+.vscode/

--- a/backend/pkg/analytics/saved_searches/saved_searches.go
+++ b/backend/pkg/analytics/saved_searches/saved_searches.go
@@ -160,6 +160,10 @@ func (s *savedSearchesImpl) Get(projectID int, searchID string) (*model.SavedSea
 		return nil, fmt.Errorf("unmarshal search data: %w", err)
 	}
 
+	stats := s.getSearchStats(ctx, projectID, &savedSearch.Data)
+	savedSearch.SessionsCount = stats.SessionsCount
+	savedSearch.UsersCount = stats.UsersCount
+
 	return &savedSearch, nil
 }
 

--- a/ee/api/.trivyignore
+++ b/ee/api/.trivyignore
@@ -1,0 +1,12 @@
+# Trivy suppressions scoped to ee/api.
+# One CVE id per line. Keep a "why" + date on every entry and revisit quarterly.
+
+# --- 2026-04-24 -----------------------------------------------------------
+# lxml XXE via iterparse() / ETCompatXMLParser() default settings.
+# The EE chalice image pulls lxml through nixpkgs (shell.nix -> python3Packages.lxml),
+# which currently ships 6.0.2; the fix landed in 6.1.0. Upgrade path is either
+# pinning a newer nixpkgs revision or overriding the package in shell.nix.
+# This CVE is only exploitable if the app parses attacker-controlled XML with
+# default parser settings — audit the SAML assertion parsing paths before
+# assuming it's not reachable in-context.
+CVE-2026-41066

--- a/ee/api/Dockerfile.dockerignore
+++ b/ee/api/Dockerfile.dockerignore
@@ -12,3 +12,21 @@ requirements-crons.txt
 requirements-alerts.txt
 entrypoint_crons.sh
 entrypoint_alerts.sh
+
+# dev / local artifacts — must not ship in the image
+.venv/
+venv/
+env/
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.coverage
+.dev/
+.dev-pids/
+.env
+.idea/
+.vscode/

--- a/ee/api/Dockerfile_alerts.dockerignore
+++ b/ee/api/Dockerfile_alerts.dockerignore
@@ -12,3 +12,21 @@ requirements.txt
 requirements-crons.txt
 entrypoint.sh
 entrypoint_crons.sh
+
+# dev / local artifacts — must not ship in the image
+.venv/
+venv/
+env/
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.coverage
+.dev/
+.dev-pids/
+.env
+.idea/
+.vscode/

--- a/ee/api/Dockerfile_crons.dockerignore
+++ b/ee/api/Dockerfile_crons.dockerignore
@@ -12,3 +12,21 @@ requirements.txt
 requirements-alerts.txt
 entrypoint.sh
 entrypoint_alerts.sh
+
+# dev / local artifacts — must not ship in the image
+.venv/
+venv/
+env/
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.coverage
+.dev/
+.dev-pids/
+.env
+.idea/
+.vscode/


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds sessions and users counts to saved search responses. Also tightens Docker build contexts and temporarily suppresses `lxml` CVE-2026-41066 in `api` and `ee/api`.

- **New Features**
  - Return SessionsCount and UsersCount when fetching a single saved search.

- **Refactors**
  - Expanded Dockerfile*.dockerignore in `api` and `ee/api` to exclude local dev artifacts (venvs, caches, IDE files).
  - Added Trivy suppression for `lxml` CVE-2026-41066; remove after upgrading to 6.1.0+.

<sup>Written for commit f67eb32bc26fc58ced7e453203bc8ecdfb032861. Summary will update on new commits. <a href="https://cubic.dev/pr/openreplay/openreplay/pull/4553?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

