### PR TITLE
Restore/lost UI commits

### DIFF
--- a/frontend/app/components/Client/ProfileSettings/ProfileSettings.tsx
+++ b/frontend/app/components/Client/ProfileSettings/ProfileSettings.tsx
@@ -50,7 +50,11 @@ function ProfileSettings() {
       <Section
         title={t('Interface Language')}
         description={t('Select the language in which OpenReplay will appear.')}
-        children={<LanguageSwitcher />}
+        children={
+          <div className="px-5">
+            <LanguageSwitcher />
+          </div>
+        }
       />
 
       <div className="border-b my-10" />

--- a/frontend/app/components/Client/Users/components/UserForm/UserForm.tsx
+++ b/frontend/app/components/Client/Users/components/UserForm/UserForm.tsx
@@ -1,16 +1,26 @@
+import { Button, Tooltip } from 'antd';
 import cn from 'classnames';
-import { useObserver, observer } from 'mobx-react-lite';
+import { observer, useObserver } from 'mobx-react-lite';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useModal } from 'App/components/Modal';
 import { useStore } from 'App/mstore';
-import { confirm, CopyButton, Form, Icon, Input } from 'UI';
-import { Button } from 'antd';
+import { CopyButton, Form, Icon, Input, confirm } from 'UI';
 
 import Select from 'Shared/Select';
-import { useTranslation } from 'react-i18next';
 
-function UserForm() {
+function UserForm({
+  showMakeOwnerButton,
+  canMakeOwner,
+  makeOwnerTooltip,
+  handleMakeOwner,
+}: {
+  showMakeOwnerButton: boolean;
+  canMakeOwner: boolean;
+  makeOwnerTooltip: string | undefined;
+  handleMakeOwner: (e: React.MouseEvent) => void;
+}) {
   const { t } = useTranslation();
   const { hideModal } = useModal();
   const { userStore, roleStore } = useStore();
@@ -120,6 +130,22 @@ function UserForm() {
             </div>
           </label>
         </Form.Field>
+        {user.exists() && showMakeOwnerButton && (
+          <div className="mb-4">
+            <Tooltip title={makeOwnerTooltip}>
+              <div
+                className={cn(
+                  'flex gap-2 items-center w-fit',
+                  canMakeOwner ? 'link cursor-pointer' : 'text-disabled-text',
+                )}
+                onClick={handleMakeOwner}
+              >
+                <Icon name="user-switch" />
+                <span>{t('Make Owner')}</span>
+              </div>
+            </Tooltip>
+          </div>
+        )}
 
         {isEnterprise && (
           <Form.Field>

--- a/frontend/app/components/Client/Users/components/UserList/UserList.tsx
+++ b/frontend/app/components/Client/Users/components/UserList/UserList.tsx
@@ -1,13 +1,16 @@
-import { useStore } from 'App/mstore';
 import { useObserver } from 'mobx-react-lite';
 import React, { useEffect } from 'react';
-import { sliceListPerPage, getRE, filterList } from 'App/utils';
-import { Pagination, NoContent, Loader, Divider } from 'UI';
+import { useTranslation } from 'react-i18next';
+
 import { useModal } from 'App/components/Modal';
+import { useStore } from 'App/mstore';
+import { filterList, sliceListPerPage } from 'App/utils';
+import { Divider, Loader, NoContent, Pagination, confirm } from 'UI';
+
 import AnimatedSVG, { ICONS } from 'Shared/AnimatedSVG/AnimatedSVG';
+
 import UserForm from '../UserForm';
 import UserListItem from '../UserListItem';
-import { useTranslation } from 'react-i18next';
 
 interface Props {
   isOnboarding?: boolean;
@@ -22,7 +25,7 @@ function UserList(props: Props) {
   const searchQuery = useObserver(() => userStore.searchQuery);
   const isOwner = useObserver(() => userStore.account.superAdmin);
   const currentUserId = useObserver(() => userStore.account.id);
-  const { showModal } = useModal();
+  const { showModal, hideModal } = useModal();
 
   const getList = (list: any) =>
     filterList(list, searchQuery, ['email', 'roleName', 'name']);
@@ -39,8 +42,42 @@ function UserList(props: Props) {
   }, []);
 
   const editHandler = (user: any) => {
+    const showMakeOwnerButton = isOwner;
+    const canMakeOwner = user.isJoined && user.userId !== currentUserId;
+    const makeOwnerTooltip = !user.isJoined
+      ? t('User has not accepted the invitation yet')
+      : user.userId === currentUserId
+        ? t('Cannot transfer ownership to yourself')
+        : undefined;
+
+    const handleMakeOwner = async (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (
+        await confirm({
+          header: t('Transfer Ownership'),
+          confirmButton: t('Yes, transfer'),
+          confirmation: t(
+            'There can only be one owner account. By proceeding, the ownership will be transferred to {{name}}. You will lose your owner privileges.',
+            { name: user.name },
+          ),
+        })
+      ) {
+        await userStore.makeOwner(user.userId);
+        await userStore.fetchUsers();
+        hideModal();
+      }
+    };
+
     userStore.initUser(user).then(() => {
-      showModal(<UserForm />, { right: true });
+      showModal(
+        <UserForm
+          showMakeOwnerButton={showMakeOwnerButton}
+          canMakeOwner={canMakeOwner}
+          makeOwnerTooltip={makeOwnerTooltip}
+          handleMakeOwner={handleMakeOwner}
+        />,
+        { right: true },
+      );
     });
   };
 
@@ -82,13 +119,6 @@ function UserList(props: Props) {
                     e.stopPropagation();
                     userStore.copyInviteCode(user.userId);
                   }}
-                  onMakeOwner={
-                    isOwner
-                      ? (userId) => {
-                          userStore.makeOwner(userId);
-                        }
-                      : undefined
-                  }
                   currentUserId={currentUserId}
                   isEnterprise={isEnterprise}
                   isOnboarding={isOnboarding}

--- a/frontend/app/components/Client/Users/components/UserListItem/UserListItem.tsx
+++ b/frontend/app/components/Client/Users/components/UserListItem/UserListItem.tsx
@@ -35,7 +35,6 @@ interface Props {
   generateInvite?: any;
   copyInviteCode?: any;
   isEnterprise?: boolean;
-  onMakeOwner?: (userId: string) => void;
   currentUserId?: string;
 }
 function UserListItem(props: Props) {
@@ -46,34 +45,9 @@ function UserListItem(props: Props) {
     copyInviteCode = () => {},
     isEnterprise = false,
     isOnboarding = false,
-    onMakeOwner,
     currentUserId,
   } = props;
   const { t } = useTranslation();
-
-  const canMakeOwner = user.isJoined && user.userId !== currentUserId;
-
-  const makeOwnerTooltip = !user.isJoined
-    ? t('User has not accepted the invitation yet')
-    : user.userId === currentUserId
-      ? t('Cannot transfer ownership to yourself')
-      : t('Make Owner');
-
-  const handleMakeOwner = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (
-      await confirm({
-        header: t('Transfer Ownership'),
-        confirmButton: t('Yes, transfer'),
-        confirmation: t(
-          'There can only be one owner account. By proceeding, the ownership will be transferred to {{name}}. You will lose your owner privileges.',
-          { name: user.name },
-        ),
-      })
-    ) {
-      onMakeOwner?.(user.userId);
-    }
-  };
 
   return (
     <div
@@ -136,17 +110,6 @@ function UserListItem(props: Props) {
                 icon={<Icon name="link-45deg" />}
                 variant="text"
                 onClick={generateInvite}
-              />
-            </Tooltip>
-          )}
-
-          {!user.isSuperAdmin && onMakeOwner && (
-            <Tooltip title={makeOwnerTooltip}>
-              <Button
-                type="text"
-                icon={<Icon name="user-switch" />}
-                onClick={handleMakeOwner}
-                disabled={!canMakeOwner}
               />
             </Tooltip>
           )}

--- a/frontend/app/components/DataManagement/Tags/index.tsx
+++ b/frontend/app/components/DataManagement/Tags/index.tsx
@@ -119,7 +119,7 @@ function TagsPage() {
       className="flex flex-col rounded-lg border bg-white mx-auto"
       style={{ maxWidth: 1360 }}
     >
-      <div className="flex flex-col gap-2 md:gap-0 md:flex-row md:items-center md:justify-between border-b px-4 py-2">
+      <div className="flex flex-col gap-2 md:gap-0 md:flex-row md:items-center md:justify-between border-b px-4 py-3">
         <div className="font-semibold text-lg capitalize">{t('Features')}</div>
         <div className="flex items-center gap-2">
           {/* <div className="min-w-50 md:w-1/4 md:min-w-75">

--- a/frontend/app/components/shared/SaveSearchModal/SaveSearchModal.tsx
+++ b/frontend/app/components/shared/SaveSearchModal/SaveSearchModal.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
-import { Modal, Button, Input, Checkbox, message } from 'antd';
-import { Trash2, Users } from 'lucide-react';
+import { Button, Checkbox, Input, Modal, message } from 'antd';
 import cn from 'classnames';
-import { useStore } from 'App/mstore';
+import { Trash2, Users } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
+
+import { useStore } from 'App/mstore';
 
 interface Props {
   show: boolean;
@@ -18,17 +19,17 @@ function SaveSearchModal({ show, closeHandler, rename = false }: Props) {
   const userId = userStore.account.id;
   const { savedSearch } = searchStore;
   const loading = searchStore.isSaving;
-
+  const existing = React.useRef(savedSearch.exists()).current;
   const onNameChange = ({ target: { value } }: any) => {
     searchStore.editSavedSearch({ name: value });
   };
 
   const onSave = () => {
     searchStore
-      .save(savedSearch.exists() ? savedSearch.searchId : null, rename)
+      .save(existing ? savedSearch.searchId : null, rename)
       .then(() => {
         message.success(
-          `${savedSearch.exists() ? t('Updated') : t('Saved')} ${t('Successfully')}`,
+          `${existing ? t('Updated') : t('Saved')} ${t('Successfully')}`,
         );
         closeHandler();
       })
@@ -57,7 +58,7 @@ function SaveSearchModal({ show, closeHandler, rename = false }: Props) {
 
   return (
     <Modal
-      title={savedSearch.exists() ? t('Update Segment') : t('Save Segment')}
+      title={existing ? t('Update Segment') : t('Save Segment')}
       open={show}
       onCancel={closeHandler}
       width={480}
@@ -70,11 +71,11 @@ function SaveSearchModal({ show, closeHandler, rename = false }: Props) {
               loading={loading}
               disabled={!savedSearch.name || savedSearch.name.trim() === ''}
             >
-              {savedSearch.exists() ? t('Update') : t('Save')}
+              {existing ? t('Update') : t('Save')}
             </Button>
             <Button onClick={closeHandler}>{t('Cancel')}</Button>
           </div>
-          {savedSearch.exists() && (
+          {existing && (
             <Button
               type="text"
               danger
@@ -103,7 +104,7 @@ function SaveSearchModal({ show, closeHandler, rename = false }: Props) {
         <div
           className={cn('flex items-center gap-2', {
             'opacity-50 pointer-events-none':
-              savedSearch.exists() && savedSearch.userId !== userId,
+              existing && savedSearch.userId !== userId,
           })}
         >
           <Checkbox

--- a/frontend/app/player/common/types.ts
+++ b/frontend/app/player/common/types.ts
@@ -53,6 +53,7 @@ export interface SessionFilesInfo {
   agentInfo?: { email: string; name: string };
   canvasURL?: string[];
   mobileFrames?: string;
+  trackerVersion: string;
 }
 
 export type PlayerMsg = Message & { tabId: string };

--- a/frontend/app/player/web/WebPlayer.ts
+++ b/frontend/app/player/web/WebPlayer.ts
@@ -1,13 +1,14 @@
-import { Log, LogLevel, SessionFilesInfo } from 'App/player';
-
-import type { Store } from 'App/player';
 import { Message } from 'Player/web/messages';
+
+import { Log, LogLevel, SessionFilesInfo } from 'App/player';
+import type { Store } from 'App/player';
+
 import Player from '../player/Player';
-import MessageManager from './MessageManager';
 import MessageLoader from './MessageLoader';
+import MessageManager from './MessageManager';
+import Screen, { ScaleMode } from './Screen/Screen';
 import InspectorController from './addons/InspectorController';
 import TargetMarker from './addons/TargetMarker';
-import Screen, { ScaleMode } from './Screen/Screen';
 
 export default class WebPlayer extends Player {
   static readonly INITIAL_STATE = {
@@ -117,6 +118,18 @@ export default class WebPlayer extends Player {
         }
         console.log(messages);
       },
+      getDebugData: () => ({
+        trackerVersion: session?.trackerVersion,
+        sessionData: session,
+        messageMetadata: this.messageLoader.rawMessages.map((m) => ({
+          tp: m.tp,
+          time: m.time,
+          tabId: m.tabId,
+          tag: m.tag,
+          id: m.id,
+          parentID: m.parentID,
+        })),
+      }),
     });
   }
 

--- a/frontend/app/player/web/WebPlayer.ts
+++ b/frontend/app/player/web/WebPlayer.ts
@@ -138,6 +138,7 @@ export default class WebPlayer extends Player {
 
   reinit(session: SessionFilesInfo) {
     if (this.wpState.get().mobsFetched) return; // already initialized
+    this.wpState.update({ mobsFetched: true });
     this.messageLoader.setSession(session);
     this.messageManager.setSession(session);
     void this.messageLoader.loadFiles();

--- a/tracker/tracker/src/webworker/QueueSender.ts
+++ b/tracker/tracker/src/webworker/QueueSender.ts
@@ -18,6 +18,10 @@ export default class QueueSender {
   // eslint-disable-next-line
   private isCompressing
   private lastBatchNum = 0
+  // Running total of bytes held by in-flight fetches that set keepalive: true.
+  // Browsers cap this at 64 KB per fetch group; exceeding it makes fetch() throw
+  // synchronously, so we track it here and fall back to keepalive: false.
+  private inflightKeepaliveBytes = 0
 
   constructor(
     ingestBaseURL: string,
@@ -93,6 +97,12 @@ export default class QueueSender {
 
   // would be nice to use Beacon API, but it is not available in WebWorker
   private sendBatch(batch: Uint8Array, isCompressed?: boolean, batchNum?: string | number, dataType: DataType = 'player'): void {
+    if (batch.length === 0) {
+      console.error('OpenReplay: refusing to send 0-byte batch.', { batchNum, dataType, isCompressed, batch })
+      this.attemptsCount = 0
+      this.sendNext()
+      return
+    }
     const batchNumStr = batchNum?.toString().replace(/^([^_]+)_([^_]+).*/, '$1_$2_$3')
     this.busy = true
 
@@ -115,14 +125,28 @@ export default class QueueSender {
       return
     }
 
+    const useKeepalive =
+      batch.length < KEEPALIVE_SIZE_LIMIT &&
+      this.inflightKeepaliveBytes + batch.length <= KEEPALIVE_SIZE_LIMIT
+    if (useKeepalive) {
+      this.inflightKeepaliveBytes += batch.length
+    }
+    const releaseKeepalive = () => {
+      if (useKeepalive) {
+        this.inflightKeepaliveBytes -= batch.length
+      }
+    }
+
     fetch(`${this.ingestURL}?batch=${this.pageNo ?? 'noPageNum'}_${batchNumStr ?? 'noBatchNum'}`, {
       // @ts-ignore
       body: batch,
       method: 'POST',
       headers,
-      keepalive: batch.length < KEEPALIVE_SIZE_LIMIT,
+      keepalive: useKeepalive,
     })
       .then((r: Record<string, any>) => {
+        releaseKeepalive()
+        r.body?.cancel().catch(() => {})
         if (r.status === 401) {
           // TODO: continuous session ?
           this.busy = false
@@ -138,6 +162,7 @@ export default class QueueSender {
         this.sendNext()
       })
       .catch((e: Error) => {
+        releaseKeepalive()
         console.warn('OpenReplay:', e)
         this.retry(batch, isCompressed, `${batchNum ?? 'noBatchNum'}_reject:${e.message}`, dataType)
       })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores lost UI updates, improves the user management flow, and adds a new player debug API. Also fixes tracker keepalive handling and several small UI issues for better stability.

- New Features
  - Ownership transfer moved into the user edit modal with tooltip, validation, and confirmation; refreshes users after transfer and hides the modal.
  - Player: added getDebugData() to expose trackerVersion, session data, and message metadata for debugging.

- Bug Fixes
  - Tracker: enforce a keepalive byte budget and guard against 0-byte batches; release budget on settle and cancel response bodies to reduce unload-time fetch errors.
  - WebPlayer: prevent double initialization by setting mobsFetched during reinit; type updated to include trackerVersion.
  - SaveSearchModal: prevent UI from switching between “Save/Update” mid-save by snapshotting existence state.
  - UI polish: align the Language Switcher in settings and adjust Tags header spacing.

<sup>Written for commit 62936166e4c1aa34a79447bdb726f361652eea59. Summary will update on new commits. <a href="https://cubic.dev/pr/openreplay/openreplay/pull/4554?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

