### PR TITLE
refactor(gapi): return at least 1 event if session is still not processed

### DIFF
--- a/backend/pkg/analytics/search/search.go
+++ b/backend/pkg/analytics/search/search.go
@@ -72,7 +72,7 @@ SELECT DISTINCT ON (session_id)
 	s.user_state,
 	s.screen_width,
 	s.screen_height,
-	s.events_count,
+	greatest(s.events_count,1) AS events_count,
 	viewed_sessions.session_id>0 AS viewed,
 	count(DISTINCT session_id) OVER() AS total_number_of_sessions
 	%s


### PR DESCRIPTION
…ssed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the analytics search returns at least 1 event for sessions that aren’t processed yet, so they don’t show up with 0 events. Implemented by using greatest(s.events_count, 1) in the query.

<sup>Written for commit e1e3c46cb5d914d15e38fef17acb38f8ec25d849. Summary will update on new commits. <a href="https://cubic.dev/pr/openreplay/openreplay/pull/4555?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

