### PR TITLE
[ASSETS] Added some bug fixes and logic improvements

### DIFF
--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -1,14 +1,17 @@
 package cacher
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io"
+	"math/rand"
 	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,6 +22,37 @@ import (
 
 	"github.com/pkg/errors"
 )
+
+const (
+	errChanBuffer  = 512
+	retryBaseDelay = 200 * time.Millisecond
+	retryMaxDelay  = 10 * time.Second
+	retryAfterCap  = 30 * time.Second
+)
+
+func isRetriableStatus(code int) bool {
+	switch code {
+	case 403, 408, 429, 500, 502, 503, 504:
+		return true
+	}
+	return false
+}
+
+func parseRetryAfter(h string) (time.Duration, bool) {
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.Atoi(h); err == nil && seconds >= 0 {
+		return time.Duration(seconds) * time.Second, true
+	}
+	if t, err := http.ParseTime(h); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d, true
+		}
+	}
+	return 0, false
+}
 
 const MAX_CACHE_DEPTH = 5
 
@@ -32,6 +66,8 @@ type cacher struct {
 	sizeLimit      int
 	requestHeaders map[string]string
 	workers        *WorkerPool
+	ctx            context.Context
+	cancel         context.CancelFunc
 }
 
 func (c *cacher) CanCache() bool {
@@ -73,13 +109,13 @@ func NewCacher(cfg *config.Config, store objectstorage.ObjectStorage, metrics me
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
 		tlsConfig = &tls.Config{
-			InsecureSkipVerify: true,
-			Certificates:       []tls.Certificate{cert},
-			RootCAs:            caCertPool,
+			Certificates: []tls.Certificate{cert},
+			RootCAs:      caCertPool,
 		}
 
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	c := &cacher{
 		timeoutMap: newTimeoutMap(),
 		objStorage: store,
@@ -91,13 +127,51 @@ func NewCacher(cfg *config.Config, store objectstorage.ObjectStorage, metrics me
 			},
 		},
 		rewriter:       rewriter,
-		Errors:         make(chan error),
+		Errors:         make(chan error, errChanBuffer),
 		sizeLimit:      cfg.AssetsSizeLimit,
 		requestHeaders: cfg.AssetsRequestHeaders,
 		metrics:        metrics,
+		ctx:            ctx,
+		cancel:         cancel,
 	}
 	c.workers = NewPool(64, c.CacheFile)
 	return c, nil
+}
+
+func (c *cacher) reportErr(err error) {
+	select {
+	case c.Errors <- err:
+	default:
+	}
+}
+
+func backoffDelay(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := retryBaseDelay
+	for i := 1; i < attempt; i++ {
+		d *= 2
+		if d >= retryMaxDelay {
+			d = retryMaxDelay
+			break
+		}
+	}
+	half := d / 2
+	return half + time.Duration(rand.Int63n(int64(half)+1))
+}
+
+func (c *cacher) scheduleRetryAfter(t *Task, delay time.Duration) {
+	time.AfterFunc(delay, func() {
+		if c.ctx.Err() != nil {
+			return
+		}
+		c.workers.AddTask(t)
+	})
+}
+
+func (c *cacher) scheduleRetry(t *Task) {
+	c.scheduleRetryAfter(t, backoffDelay(setRetries()-t.retries))
 }
 
 func (c *cacher) CacheFile(task *Task) {
@@ -107,37 +181,44 @@ func (c *cacher) CacheFile(task *Task) {
 func (c *cacher) cacheURL(t *Task) {
 	t.retries--
 	start := time.Now()
-	req, _ := http.NewRequest("GET", t.requestURL, nil)
+	req, _ := http.NewRequestWithContext(c.ctx, "GET", t.requestURL, nil)
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:98.0) Gecko/20100101 Firefox/98.0")
 	for k, v := range c.requestHeaders {
 		req.Header.Set(k, v)
 	}
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		c.Errors <- errors.Wrap(err, t.urlContext)
+		c.timeoutMap.markFailed(t.cachePath)
+		c.reportErr(errors.Wrap(err, t.urlContext))
 		return
 	}
 	c.metrics.RecordDownloadDuration(float64(time.Now().Sub(start).Milliseconds()), res.StatusCode)
 	defer res.Body.Close()
 	if res.StatusCode >= 400 {
-		printErr := true
-		// Retry 403/503 errors
-		if (res.StatusCode == 403 || res.StatusCode == 503) && t.retries > 0 {
-			c.workers.AddTask(t)
-			printErr = false
+		if isRetriableStatus(res.StatusCode) && t.retries > 0 {
+			delay := backoffDelay(setRetries() - t.retries)
+			if ra, ok := parseRetryAfter(res.Header.Get("Retry-After")); ok {
+				if ra > retryAfterCap {
+					ra = retryAfterCap
+				}
+				delay = ra
+			}
+			c.scheduleRetryAfter(t, delay)
+			return
 		}
-		if printErr {
-			c.Errors <- errors.Wrap(fmt.Errorf("Status code is %v, ", res.StatusCode), t.urlContext)
-		}
+		c.timeoutMap.markFailed(t.cachePath)
+		c.reportErr(errors.Wrap(fmt.Errorf("Status code is %v, ", res.StatusCode), t.urlContext))
 		return
 	}
 	data, err := io.ReadAll(io.LimitReader(res.Body, int64(c.sizeLimit+1)))
 	if err != nil {
-		c.Errors <- errors.Wrap(err, t.urlContext)
+		c.timeoutMap.markFailed(t.cachePath)
+		c.reportErr(errors.Wrap(err, t.urlContext))
 		return
 	}
 	if len(data) > c.sizeLimit {
-		c.Errors <- errors.Wrap(errors.New("Maximum size exceeded"), t.urlContext)
+		c.timeoutMap.markCompleted(t.cachePath)
+		c.reportErr(errors.Wrap(errors.New("Maximum size exceeded"), t.urlContext))
 		return
 	}
 
@@ -149,15 +230,17 @@ func (c *cacher) cacheURL(t *Task) {
 
 	// Skip html file (usually it's a CDN mock for 404 error)
 	if strings.HasPrefix(contentType, "text/html") {
-		c.Errors <- errors.Wrap(fmt.Errorf("context type is text/html, sessID: %d", t.sessionID), t.urlContext)
+		c.timeoutMap.markFailed(t.cachePath)
+		c.reportErr(errors.Wrap(fmt.Errorf("context type is text/html, sessID: %d", t.sessionID), t.urlContext))
 		return
 	}
 
 	isCSS := strings.HasPrefix(contentType, "text/css")
 
 	strData := string(data)
+	var extracted []string
 	if isCSS {
-		strData = c.rewriter.RewriteCSS(t.sessionID, t.requestURL, strData) // TODO: one method for rewrite and return list
+		strData, extracted = c.rewriter.RewriteAndExtractCSS(t.sessionID, t.requestURL, strData)
 	}
 
 	// TODO: implement in streams
@@ -165,36 +248,33 @@ func (c *cacher) cacheURL(t *Task) {
 	err = c.objStorage.Upload(strings.NewReader(strData), t.cachePath, contentType, contentEncoding, objectstorage.NoCompression)
 	if err != nil {
 		c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), true)
-		c.Errors <- errors.Wrap(err, t.urlContext)
+		c.timeoutMap.markFailed(t.cachePath)
+		c.reportErr(errors.Wrap(err, t.urlContext))
 		return
 	}
 	c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), false)
 	c.metrics.IncreaseSavedSessions()
+	c.timeoutMap.markCompleted(t.cachePath)
 
-	if isCSS {
-		if t.depth > 0 {
-			for _, extractedURL := range assets.ExtractURLsFromCSS(string(data)) {
-				if fullURL, cachable := assets.GetFullCachableURL(t.requestURL, extractedURL); cachable {
-					c.checkTask(&Task{
-						requestURL: fullURL,
-						sessionID:  t.sessionID,
-						depth:      t.depth - 1,
-						urlContext: t.urlContext + "\n  -> " + fullURL,
-						isJS:       false,
-						retries:    setRetries(),
-					})
-				}
-			}
-			if err != nil {
-				c.Errors <- errors.Wrap(err, t.urlContext)
-				return
-			}
-		} else {
-			c.Errors <- errors.Wrap(errors.New("Maximum recursion cache depth exceeded"), t.urlContext)
-			return
+	if !isCSS || len(extracted) == 0 {
+		return
+	}
+	if t.depth == 0 {
+		c.reportErr(errors.Wrap(errors.New("Maximum recursion cache depth exceeded"), t.urlContext))
+		return
+	}
+	for _, extractedURL := range extracted {
+		if fullURL, cachable := assets.GetFullCachableURL(t.requestURL, extractedURL); cachable {
+			c.checkTask(&Task{
+				requestURL: fullURL,
+				sessionID:  t.sessionID,
+				depth:      t.depth - 1,
+				urlContext: t.urlContext + "\n  -> " + fullURL,
+				isJS:       false,
+				retries:    setRetries(),
+			})
 		}
 	}
-	return
 }
 
 func (c *cacher) checkTask(newTask *Task) {
@@ -205,12 +285,12 @@ func (c *cacher) checkTask(newTask *Task) {
 	} else {
 		cachePath = assets.GetCachePathForAssets(newTask.sessionID, newTask.requestURL)
 	}
-	if c.timeoutMap.contains(cachePath) {
+	if !c.timeoutMap.reserve(cachePath) {
 		return
 	}
-	c.timeoutMap.add(cachePath)
 	crTime := c.objStorage.GetCreationTime(cachePath)
 	if crTime != nil && crTime.After(time.Now().Add(-MAX_STORAGE_TIME)) {
+		c.timeoutMap.markCompleted(cachePath)
 		return
 	}
 	// add new file in queue to download
@@ -245,6 +325,7 @@ func (c *cacher) UpdateTimeouts() {
 }
 
 func (c *cacher) Stop() {
+	c.cancel()
 	c.workers.Stop()
 }
 

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -170,10 +170,6 @@ func (c *cacher) scheduleRetryAfter(t *Task, delay time.Duration) {
 	})
 }
 
-func (c *cacher) scheduleRetry(t *Task) {
-	c.scheduleRetryAfter(t, backoffDelay(setRetries()-t.retries))
-}
-
 func (c *cacher) CacheFile(task *Task) {
 	c.cacheURL(task)
 }

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -88,7 +88,7 @@ func NewCacher(cfg *config.Config, store objectstorage.ObjectStorage, metrics me
 	}
 
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
 	}
 
 	if cfg.ClientCertFilePath != "" && cfg.ClientKeyFilePath != "" && cfg.CaCertFilePath != "" {

--- a/backend/internal/assets/cacher/timeoutMap.go
+++ b/backend/internal/assets/cacher/timeoutMap.go
@@ -7,39 +7,59 @@ import (
 
 const MAX_STORAGE_TIME = 24 * time.Hour
 
-// If problem with cache contention (>=4 core) look at sync.Map
+const inFlightStaleAfter = 1 * time.Hour
 
 type timeoutMap struct {
-	mx sync.RWMutex
-	m  map[string]time.Time
+	mx        sync.Mutex
+	completed map[string]time.Time
+	inFlight  map[string]time.Time
 }
 
 func newTimeoutMap() *timeoutMap {
 	return &timeoutMap{
-		m: make(map[string]time.Time),
+		completed: make(map[string]time.Time),
+		inFlight:  make(map[string]time.Time),
 	}
 }
 
-func (tm *timeoutMap) add(key string) {
+func (tm *timeoutMap) reserve(key string) bool {
 	tm.mx.Lock()
 	defer tm.mx.Unlock()
-	tm.m[key] = time.Now()
+	if _, ok := tm.inFlight[key]; ok {
+		return false
+	}
+	if _, ok := tm.completed[key]; ok {
+		return false
+	}
+	tm.inFlight[key] = time.Now()
+	return true
 }
 
-func (tm *timeoutMap) contains(key string) bool {
-	tm.mx.RLock()
-	defer tm.mx.RUnlock()
-	_, ok := tm.m[key]
-	return ok
+func (tm *timeoutMap) markCompleted(key string) {
+	tm.mx.Lock()
+	defer tm.mx.Unlock()
+	delete(tm.inFlight, key)
+	tm.completed[key] = time.Now()
+}
+
+func (tm *timeoutMap) markFailed(key string) {
+	tm.mx.Lock()
+	defer tm.mx.Unlock()
+	delete(tm.inFlight, key)
 }
 
 func (tm *timeoutMap) deleteOutdated() {
 	now := time.Now()
 	tm.mx.Lock()
 	defer tm.mx.Unlock()
-	for key, t := range tm.m {
+	for key, t := range tm.completed {
 		if now.Sub(t) > MAX_STORAGE_TIME {
-			delete(tm.m, key)
+			delete(tm.completed, key)
+		}
+	}
+	for key, t := range tm.inFlight {
+		if now.Sub(t) > inFlightStaleAfter {
+			delete(tm.inFlight, key)
 		}
 	}
 }

--- a/backend/internal/config/assets/config.go
+++ b/backend/internal/config/assets/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	ClientKeyFilePath    string            `env:"CLIENT_KEY_FILE_PATH"`
 	CaCertFilePath       string            `env:"CA_CERT_FILE_PATH"`
 	ClientCertFilePath   string            `env:"CLIENT_CERT_FILE_PATH"`
+	InsecureSkipVerify   bool              `env:"ASSETS_INSECURE_SKIP_VERIFY,default=false"`
 }
 
 func New(log logger.Logger) *Config {

--- a/backend/internal/sink/assetscache/assets.go
+++ b/backend/internal/sink/assetscache/assets.go
@@ -172,10 +172,15 @@ func (e *AssetsCache) sendAssetForCache(sessionID uint64, baseURL string, relati
 	}
 }
 
-func (e *AssetsCache) sendAssetsForCacheFromCSS(sessionID uint64, baseURL string, css string) {
-	for _, u := range assets.ExtractURLsFromCSS(css) { // TODO: in one shot with rewriting
+func (e *AssetsCache) processCSS(sessionID uint64, baseURL string, css string) string {
+	if !e.cfg.CacheAssets {
+		return assets.ResolveCSS(baseURL, css)
+	}
+	rewritten, extracted := e.rewriter.RewriteAndExtractCSS(sessionID, baseURL, css)
+	for _, u := range extracted {
 		e.sendAssetForCache(sessionID, baseURL, u)
 	}
+	return rewritten
 }
 
 func (e *AssetsCache) handleURL(sessionID uint64, baseURL string, urlVal string) string {
@@ -204,10 +209,7 @@ func (e *AssetsCache) handleCSS(sessionID uint64, baseURL string, css string) st
 	if err != nil {
 		ctx := context.WithValue(context.Background(), "sessionID", sessionID)
 		e.log.Error(ctx, "can't parse url: %s, err: %s", baseURL, err)
-		if e.cfg.CacheAssets {
-			e.sendAssetsForCacheFromCSS(sessionID, baseURL, css)
-		}
-		return e.getRewrittenCSS(sessionID, baseURL, css)
+		return e.processCSS(sessionID, baseURL, css)
 	}
 	// Calculate hash sum of url + css
 	io.WriteString(h, justUrl)
@@ -223,13 +225,9 @@ func (e *AssetsCache) handleCSS(sessionID uint64, baseURL string, css string) st
 			return cachedAsset.msg
 		}
 	}
-	// Send asset to download in assets service
-	if e.cfg.CacheAssets {
-		e.sendAssetsForCacheFromCSS(sessionID, baseURL, css)
-	}
-	// Rewrite asset
+	// Process: rewrite CSS and dispatch referenced assets in one pass.
 	start := time.Now()
-	res := e.getRewrittenCSS(sessionID, baseURL, css)
+	res := e.processCSS(sessionID, baseURL, css)
 	duration := time.Now().Sub(start).Milliseconds()
 	e.metrics.RecordAssetSize(float64(len(res)))
 	e.metrics.RecordProcessAssetDuration(float64(duration))
@@ -245,12 +243,4 @@ func (e *AssetsCache) handleCSS(sessionID uint64, baseURL string, css string) st
 	}
 	// Return rewritten asset
 	return res
-}
-
-func (e *AssetsCache) getRewrittenCSS(sessionID uint64, url, css string) string {
-	if e.cfg.CacheAssets {
-		return e.rewriter.RewriteCSS(sessionID, url, css)
-	} else {
-		return assets.ResolveCSS(url, css)
-	}
 }

--- a/backend/pkg/url/assets/css.go
+++ b/backend/pkg/url/assets/css.go
@@ -38,19 +38,6 @@ func unquote(str string) (string, string) {
 	return str, ""
 }
 
-func ExtractURLsFromCSS(css string) []string {
-	indexes := cssUrlsIndex(css)
-	urls := make([]string, len(indexes))
-	for _, idx := range indexes {
-
-		f := idx[0]
-		t := idx[1]
-		rawurl, _ := unquote(css[f:t])
-		urls = append(urls, rawurl)
-	}
-	return urls
-}
-
 func rewriteLinks(css string, rewrite func(rawurl string) string) string {
 	for _, idx := range cssUrlsIndex(css) {
 		f := idx[0]
@@ -74,6 +61,15 @@ func (r *Rewriter) RewriteCSS(sessionID uint64, baseurl string, css string) stri
 		return r.RewriteURL(sessionID, baseurl, rawurl)
 	})
 	return rewritePseudoclasses(css)
+}
+
+func (r *Rewriter) RewriteAndExtractCSS(sessionID uint64, baseurl string, css string) (string, []string) {
+	var urls []string
+	css = rewriteLinks(css, func(rawurl string) string {
+		urls = append(urls, rawurl)
+		return r.RewriteURL(sessionID, baseurl, rawurl)
+	})
+	return rewritePseudoclasses(css), urls
 }
 
 func rewritePseudoclasses(css string) string {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves asset caching reliability and CSS handling. Adds robust retry/backoff, prevents duplicate downloads, rewrites/extracts CSS in one pass, and makes TLS verification configurable.

- **Bug Fixes**
  - Added exponential backoff with jitter for retriable HTTP errors (403/408/429/5xx) and support for `Retry-After` (capped at 30s) in `cacher`.
  - TLS: uses provided client certs and `RootCAs`; `InsecureSkipVerify` is now configurable via `ASSETS_INSECURE_SKIP_VERIFY` (defaults to false).
  - Deduplicated in-flight downloads with a new `timeoutMap` (separate `inFlight`/`completed`, stale cleanup after 1h).
  - Buffered, non-blocking error channel to avoid stalls; request context is cancelled on `Stop`.

- **Refactors**
  - Introduced `RewriteAndExtractCSS` to rewrite links and collect URLs in one pass, used in both `cacher` and `assetscache`.
  - Consolidated CSS handling via `processCSS`; dispatches assets only when `CacheAssets` is enabled, otherwise resolves URLs.
  - Removed dead code (`ExtractURLsFromCSS`, `getRewrittenCSS`); reduced duplicate parsing and simplified recursion/depth handling.

<sup>Written for commit 1bf5c6471918b9223c1e73067f6326d91665386d. Summary will update on new commits. <a href="https://cubic.dev/pr/openreplay/openreplay/pull/4559?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

