### PR TITLE
feat(api): filters catelog in v2

### DIFF
--- a/backend/pkg/analytics/filters_catalog/aggregator.go
+++ b/backend/pkg/analytics/filters_catalog/aggregator.go
@@ -1,0 +1,41 @@
+package filters_catalog
+
+import (
+	"context"
+	"fmt"
+
+	"openreplay/backend/pkg/analytics/filters_catalog/model"
+)
+
+func (s *filtersCatalogImpl) GetAllFilters(ctx context.Context, projectID uint32, userID uint64, platform string) (*model.AllFiltersResponse, error) {
+	events, err := s.getEventsCatalog(ctx, projectID, platform)
+	if err != nil {
+		return nil, fmt.Errorf("events catalog: %w", err)
+	}
+	properties, err := s.getPropertiesCatalog(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("properties catalog: %w", err)
+	}
+	metadata, err := s.getMetadataFilters(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("metadata catalog: %w", err)
+	}
+	segments, err := s.getSegmentsFilters(ctx, projectID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("segments catalog: %w", err)
+	}
+	features, err := s.getFeaturesFilters(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("features catalog: %w", err)
+	}
+	return &model.AllFiltersResponse{
+		Events:   events,
+		Event:    properties,
+		Session:  GetSessionsFilters(),
+		User:     GetUsersFilters(),
+		Users:    GetUsersIdentifiedFilters(),
+		Metadata: metadata,
+		Segments: segments,
+		Features: features,
+	}, nil
+}

--- a/backend/pkg/analytics/filters_catalog/api/handlers.go
+++ b/backend/pkg/analytics/filters_catalog/api/handlers.go
@@ -1,25 +1,32 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	filters_catalog "openreplay/backend/pkg/analytics/filters_catalog"
+	"openreplay/backend/pkg/assist/proxy"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/projects"
 	"openreplay/backend/pkg/server/api"
 )
 
+var errAutocompleteFailed = errors.New("failed to fetch autocomplete suggestions")
+
 type handlersImpl struct {
 	log      logger.Logger
 	service  filters_catalog.FiltersCatalog
 	projects projects.Projects
+	assist   proxy.Assist
 	handlers []*api.Description
 }
 
-func NewHandlers(log logger.Logger, req api.RequestHandler, service filters_catalog.FiltersCatalog, p projects.Projects) (api.Handlers, error) {
-	h := &handlersImpl{log: log, service: service, projects: p}
+func NewHandlers(log logger.Logger, req api.RequestHandler, service filters_catalog.FiltersCatalog, p projects.Projects, assist proxy.Assist) (api.Handlers, error) {
+	h := &handlersImpl{log: log, service: service, projects: p, assist: assist}
 	h.handlers = []*api.Description{
 		{"/{project}/filters", "GET", req.Handle(h.getAllFilters), []string{api.DATA_MANAGEMENT}, api.DoNotTrack},
+		{"/{project}/events/autocomplete", "GET", req.Handle(h.autocompleteEvents), []string{api.DATA_MANAGEMENT}, api.DoNotTrack},
+		{"/{project}/properties/autocomplete", "GET", req.Handle(h.autocompleteProperties), []string{api.DATA_MANAGEMENT}, api.DoNotTrack},
 	}
 	return h, nil
 }
@@ -59,4 +66,75 @@ func (h *handlersImpl) getAllFilters(r *api.RequestContext) (any, int, error) {
 		return nil, http.StatusInternalServerError, err
 	}
 	return resp, 0, nil
+}
+
+// @Summary Events autocomplete
+// @Description Suggests event names matching the optional `q` query.
+// @Tags Analytics - Filters
+// @Param project path uint true "Project ID"
+// @Param q query string false "Search query"
+// @Router /{project}/events/autocomplete [get]
+func (h *handlersImpl) autocompleteEvents(r *api.RequestContext) (any, int, error) {
+	projID, err := r.GetProjectID()
+	if err != nil {
+		h.log.Error(r.Request.Context(), "failed to get project ID: %v", err)
+		return nil, http.StatusBadRequest, err
+	}
+
+	q := r.Request.URL.Query().Get("q")
+	rows, err := h.service.SearchEventsAutocomplete(r.Request.Context(), projID, q)
+	if err != nil {
+		h.log.Error(r.Request.Context(), "events autocomplete for project %d: %v", projID, err)
+		return nil, http.StatusInternalServerError, errAutocompleteFailed
+	}
+	return rows, 0, nil
+}
+
+// @Summary Properties autocomplete
+// @Description Suggests property values. With live=true, values are fetched
+//
+//	from the assist service; otherwise from the analytics tables based on source.
+//
+// @Tags Analytics - Filters
+// @Param project path uint true "Project ID"
+// @Param propertyName query string true "Property name"
+// @Param eventName query string false "Event name"
+// @Param userId query string false "User ID"
+// @Param source query string false "Scope source (session/event/user/metadata)"
+// @Param q query string false "Search query"
+// @Param ac query bool false "Auto captured"
+// @Param live query bool false "Fetch live values from assist"
+// @Router /{project}/properties/autocomplete [get]
+func (h *handlersImpl) autocompleteProperties(r *api.RequestContext) (any, int, error) {
+	projID, err := r.GetProjectID()
+	if err != nil {
+		h.log.Error(r.Request.Context(), "failed to get project ID: %v", err)
+		return nil, http.StatusBadRequest, err
+	}
+
+	qv := r.Request.URL.Query()
+	propertyName := qv.Get("propertyName")
+	if propertyName == "" {
+		return nil, http.StatusBadRequest, errors.New("propertyName is required")
+	}
+
+	if qv.Get("live") == "true" {
+		res, err := h.assist.Autocomplete(projID, qv.Get("q"), propertyName)
+		if err != nil {
+			h.log.Error(r.Request.Context(), "live properties autocomplete for project %d: %v", projID, err)
+			return []map[string]interface{}{}, 0, nil
+		}
+		return res, 0, nil
+	}
+
+	rows, err := h.service.SearchPropertiesAutocomplete(
+		r.Request.Context(), projID,
+		propertyName, qv.Get("eventName"), qv.Get("userId"), qv.Get("source"), qv.Get("q"),
+		qv.Get("ac") == "true",
+	)
+	if err != nil {
+		h.log.Error(r.Request.Context(), "properties autocomplete for project %d: %v", projID, err)
+		return nil, http.StatusInternalServerError, errAutocompleteFailed
+	}
+	return rows, 0, nil
 }

--- a/backend/pkg/analytics/filters_catalog/api/handlers.go
+++ b/backend/pkg/analytics/filters_catalog/api/handlers.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"net/http"
+
+	filters_catalog "openreplay/backend/pkg/analytics/filters_catalog"
+	"openreplay/backend/pkg/logger"
+	"openreplay/backend/pkg/projects"
+	"openreplay/backend/pkg/server/api"
+)
+
+type handlersImpl struct {
+	log      logger.Logger
+	service  filters_catalog.FiltersCatalog
+	projects projects.Projects
+	handlers []*api.Description
+}
+
+func NewHandlers(log logger.Logger, req api.RequestHandler, service filters_catalog.FiltersCatalog, p projects.Projects) (api.Handlers, error) {
+	h := &handlersImpl{log: log, service: service, projects: p}
+	h.handlers = []*api.Description{
+		{"/{project}/filters", "GET", req.Handle(h.getAllFilters), []string{api.DATA_MANAGEMENT}, api.DoNotTrack},
+	}
+	return h, nil
+}
+
+func (h *handlersImpl) GetAll() []*api.Description { return h.handlers }
+
+// @Summary Get filters catalog
+// @Description Returns the union of session/user/event/segment/feature filter
+//
+//	definitions used to populate the analytics filter UI.
+//
+// @Tags Analytics - Filters
+// @Param project path uint true "Project ID"
+// @Success 200 {object} model.AllFiltersResponse
+// @Router /{project}/filters [get]
+func (h *handlersImpl) getAllFilters(r *api.RequestContext) (any, int, error) {
+	projID, err := r.GetProjectID()
+	if err != nil {
+		h.log.Error(r.Request.Context(), "failed to get project ID: %v", err)
+		return nil, http.StatusBadRequest, err
+	}
+
+	user := api.GetUser(r.Request)
+	var userID uint64
+	if user != nil {
+		userID = user.ID
+	}
+
+	platform := "web"
+	if proj, err := h.projects.GetProject(projID); err == nil && proj != nil && proj.Platform != "" {
+		platform = proj.Platform
+	}
+
+	resp, err := h.service.GetAllFilters(r.Request.Context(), projID, userID, platform)
+	if err != nil {
+		h.log.Error(r.Request.Context(), "filters catalog for project %d: %v", projID, err)
+		return nil, http.StatusInternalServerError, err
+	}
+	return resp, 0, nil
+}

--- a/backend/pkg/analytics/filters_catalog/autocomplete.go
+++ b/backend/pkg/analytics/filters_catalog/autocomplete.go
@@ -1,0 +1,242 @@
+package filters_catalog
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"openreplay/backend/pkg/analytics/filters_catalog/model"
+)
+
+const autocompleteCacheTTL = 180 * time.Second
+
+var multiSpaceRe = regexp.MustCompile(` +`)
+
+func stringToSQLLike(value string) string {
+	value = multiSpaceRe.ReplaceAllString(value, " ")
+	value = strings.ReplaceAll(value, "*", "%")
+	if strings.HasPrefix(value, "^") {
+		value = value[1:]
+	} else if !strings.HasPrefix(value, "%") {
+		value = "%" + value
+	}
+	if strings.HasSuffix(value, "$") {
+		value = value[:len(value)-1]
+	} else if !strings.HasSuffix(value, "%") {
+		value = value + "%"
+	}
+	return value
+}
+
+func scanAutocompleteRows(rows driver.Rows) ([]model.AutocompleteRow, error) {
+	defer rows.Close()
+	out := make([]model.AutocompleteRow, 0)
+	for rows.Next() {
+		var r model.AutocompleteRow
+		if err := rows.Scan(&r.Value, &r.RowPercentage); err != nil {
+			return nil, fmt.Errorf("scan autocomplete row: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *filtersCatalogImpl) SearchEventsAutocomplete(ctx context.Context, projectID uint32, q string) ([]model.AutocompleteRow, error) {
+	cacheKey := fmt.Sprintf("events|%d|%s", projectID, q)
+	if rows, ok := s.acCache.get(cacheKey); ok {
+		return rows, nil
+	}
+
+	constraints := []string{"project_id = ?"}
+	args := []any{projectID}
+	if q != "" {
+		constraints = append(constraints, "value ILIKE ?")
+		args = append(args, stringToSQLLike(q))
+	}
+	query := fmt.Sprintf(`
+SELECT value,
+       truncate(row_count * 100 / SUM(row_count) OVER (), 2) AS row_percentage
+FROM (SELECT value,
+             sumMerge(data_count) OVER () AS row_count
+      FROM product_analytics.autocomplete_events_grouped
+      WHERE %s
+      ORDER BY row_count DESC
+      LIMIT 20) AS raw`, strings.Join(constraints, " AND "))
+
+	rows, err := s.ch.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("ch query autocomplete events: %w", err)
+	}
+	result, err := scanAutocompleteRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	s.acCache.set(cacheKey, result)
+	return result, nil
+}
+
+func (s *filtersCatalogImpl) SearchPropertiesAutocomplete(ctx context.Context, projectID uint32, propertyName, eventName, userID, source, q string, autoCaptured bool) ([]model.AutocompleteRow, error) {
+	scope := resolveAutocompleteScope(source, propertyName)
+
+	if autoCaptured {
+		propertyName = keyToSnakeCase(propertyName)
+	}
+
+	_, usersSimple := UsersSimpleProperties[propertyName]
+	_, eventsSimple := EventsSimpleProperties[propertyName]
+	switch {
+	case scope == "sessions",
+		scope == "users" && usersSimple,
+		scope == "events" && eventsSimple:
+		return s.searchSimpleProperty(ctx, projectID, propertyName, scope, q)
+	case scope == "users":
+		return s.searchUsersProperties(ctx, projectID, propertyName, userID, q)
+	default:
+		return s.searchEventsProperties(ctx, projectID, propertyName, eventName, q)
+	}
+}
+
+func resolveAutocompleteScope(source, propertyName string) string {
+	switch source {
+	case "session", "sessions", "metadata", "metadatas":
+		return "sessions"
+	case "user", "users":
+		if !strings.HasPrefix(propertyName, "$") {
+			return "sessions"
+		}
+		return "users"
+	case "event", "events":
+		return "events"
+	}
+	return ""
+}
+
+func (s *filtersCatalogImpl) searchSimpleProperty(ctx context.Context, projectID uint32, name, source, q string) ([]model.AutocompleteRow, error) {
+	cacheKey := fmt.Sprintf("simple|%d|%s|%s|%s", projectID, name, source, q)
+	if rows, ok := s.acCache.get(cacheKey); ok {
+		return rows, nil
+	}
+
+	constraints := []string{
+		"project_id = ?",
+		"_timestamp >= now()-INTERVAL 1 MONTH",
+		"name = ?",
+		"source = ?",
+	}
+	args := []any{projectID, name, source}
+	if q != "" {
+		constraints = append(constraints, "value ILIKE ?")
+		args = append(args, stringToSQLLike(q))
+	}
+	query := fmt.Sprintf(`
+SELECT value, truncate(100 * row_count / sum(row_count) OVER (), 2) AS row_percentage
+FROM (SELECT value, sumMerge(data_count) AS row_count
+      FROM product_analytics.autocomplete_simple
+      WHERE %s
+      GROUP BY 1) AS raw
+ORDER BY row_count DESC
+LIMIT 20`, strings.Join(constraints, " AND "))
+
+	rows, err := s.ch.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("ch query autocomplete simple: %w", err)
+	}
+	result, err := scanAutocompleteRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	s.acCache.set(cacheKey, result)
+	return result, nil
+}
+
+func (s *filtersCatalogImpl) searchUsersProperties(ctx context.Context, projectID uint32, propertyName, userID, q string) ([]model.AutocompleteRow, error) {
+	constraints := []string{"project_id = ?", "property_name = ?"}
+	args := []any{projectID, propertyName}
+	if userID != "" {
+		constraints = append(constraints, "user_id = ?")
+		args = append(args, userID)
+	}
+	if q != "" {
+		constraints = append(constraints, "value ILIKE ?")
+		args = append(args, stringToSQLLike(q))
+	}
+	query := fmt.Sprintf(`
+SELECT value,
+       truncate(row_count * 100 / sum(row_count) OVER (), 2) AS row_percentage
+FROM (SELECT value,
+             sumMerge(data_count) AS row_count
+      FROM product_analytics.autocomplete_user_properties_grouped
+      WHERE %s
+      GROUP BY 1
+      ORDER BY row_count DESC
+      LIMIT 20) AS raw`, strings.Join(constraints, " AND "))
+
+	rows, err := s.ch.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("ch query autocomplete user properties: %w", err)
+	}
+	return scanAutocompleteRows(rows)
+}
+
+func (s *filtersCatalogImpl) searchEventsProperties(ctx context.Context, projectID uint32, propertyName, eventName, q string) ([]model.AutocompleteRow, error) {
+	constraints := []string{"project_id = ?", "property_name = ?"}
+	args := []any{projectID, propertyName}
+	if eventName != "" {
+		constraints = append(constraints, "event_name = ?")
+		args = append(args, eventName)
+	}
+	if q != "" {
+		constraints = append(constraints, "value ILIKE ?")
+		args = append(args, stringToSQLLike(q))
+	}
+	query := fmt.Sprintf(`
+SELECT value,
+       truncate(row_count * 100 / sum(row_count) OVER (), 2) AS row_percentage
+FROM (SELECT value,
+             sumMerge(data_count) AS row_count
+      FROM product_analytics.autocomplete_event_properties_grouped
+      WHERE %s
+      GROUP BY 1
+      ORDER BY row_count DESC
+      LIMIT 20) AS raw`, strings.Join(constraints, " AND "))
+
+	rows, err := s.ch.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("ch query autocomplete event properties: %w", err)
+	}
+	out, err := scanAutocompleteRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	if eventName == "ISSUE" && propertyName == "issue_type" {
+		for i := range out {
+			out[i].Name = issueTypeName(out[i].Value)
+		}
+	}
+	return out, nil
+}
+
+func issueTypeName(value string) string {
+	for _, it := range IssueTypes {
+		if it.Type == value {
+			return it.Name
+		}
+	}
+	return keyToTitleCase(value)
+}
+
+func keyToTitleCase(name string) string {
+	parts := strings.Split(keyToSnakeCase(name), "_")
+	words := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		words = append(words, strings.ToUpper(p[:1])+strings.ToLower(p[1:]))
+	}
+	return strings.Join(words, " ")
+}

--- a/backend/pkg/analytics/filters_catalog/autocomplete_cache.go
+++ b/backend/pkg/analytics/filters_catalog/autocomplete_cache.go
@@ -1,0 +1,55 @@
+package filters_catalog
+
+import (
+	"sync"
+	"time"
+
+	"openreplay/backend/pkg/analytics/filters_catalog/model"
+)
+
+type autocompleteCache struct {
+	mu  sync.RWMutex
+	ttl time.Duration
+	m   map[string]cachedRows
+}
+
+type cachedRows struct {
+	rows    []model.AutocompleteRow
+	expires time.Time
+}
+
+func newAutocompleteCache(ttl time.Duration) *autocompleteCache {
+	c := &autocompleteCache{ttl: ttl, m: make(map[string]cachedRows)}
+	go c.cleaner()
+	return c
+}
+
+func (c *autocompleteCache) get(key string) ([]model.AutocompleteRow, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.m[key]
+	if !ok || time.Now().After(e.expires) {
+		return nil, false
+	}
+	return e.rows, true
+}
+
+func (c *autocompleteCache) set(key string, rows []model.AutocompleteRow) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[key] = cachedRows{rows: rows, expires: time.Now().Add(c.ttl)}
+}
+
+func (c *autocompleteCache) cleaner() {
+	for {
+		time.Sleep(c.ttl)
+		now := time.Now()
+		c.mu.Lock()
+		for k, e := range c.m {
+			if now.After(e.expires) {
+				delete(c.m, k)
+			}
+		}
+		c.mu.Unlock()
+	}
+}

--- a/backend/pkg/analytics/filters_catalog/autocomplete_static.go
+++ b/backend/pkg/analytics/filters_catalog/autocomplete_static.go
@@ -1,0 +1,37 @@
+package filters_catalog
+
+var EventsSimpleProperties = map[string]struct{}{
+	"$user_id":          {},
+	"$sdk_edition":      {},
+	"$sdk_version":      {},
+	"$current_url":      {},
+	"$current_path":     {},
+	"$initial_referrer": {},
+	"$referring_domain": {},
+	"$country":          {},
+	"$state":            {},
+	"$city":             {},
+	"$or_api_endpoint":  {},
+}
+
+var UsersSimpleProperties = map[string]struct{}{
+	"$user_id":             {},
+	"$email":               {},
+	"$name":                {},
+	"$first_name":          {},
+	"$last_name":           {},
+	"$phone":               {},
+	"$sdk_edition":         {},
+	"$sdk_version":         {},
+	"$current_url":         {},
+	"$current_path":        {},
+	"$initial_referrer":    {},
+	"$referring_domain":    {},
+	"initial_utm_source":   {},
+	"initial_utm_medium":   {},
+	"initial_utm_campaign": {},
+	"$country":             {},
+	"$state":               {},
+	"$city":                {},
+	"$or_api_endpoint":     {},
+}

--- a/backend/pkg/analytics/filters_catalog/autocomplete_test.go
+++ b/backend/pkg/analytics/filters_catalog/autocomplete_test.go
@@ -1,0 +1,72 @@
+package filters_catalog
+
+import "testing"
+
+func TestStringToSQLLike(t *testing.T) {
+	cases := map[string]string{
+		"abc":   "%abc%",
+		"^abc":  "abc%",
+		"abc$":  "%abc",
+		"^abc$": "abc",
+		"a*c":   "%a%c%",
+		"a  b":  "%a b%",
+		"%abc":  "%abc%",
+		"abc%":  "%abc%",
+		"%abc%": "%abc%",
+	}
+	for in, want := range cases {
+		if got := stringToSQLLike(in); got != want {
+			t.Errorf("stringToSQLLike(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResolveAutocompleteScope(t *testing.T) {
+	cases := []struct {
+		source, property, want string
+	}{
+		{"session", "anything", "sessions"},
+		{"sessions", "anything", "sessions"},
+		{"metadata", "anything", "sessions"},
+		{"metadatas", "anything", "sessions"},
+		{"event", "anything", "events"},
+		{"events", "anything", "events"},
+		{"user", "$user_id", "users"},
+		{"users", "$email", "users"},
+		{"user", "plain", "sessions"},
+		{"users", "plain", "sessions"},
+		{"", "anything", ""},
+		{"unknown", "anything", ""},
+	}
+	for _, c := range cases {
+		if got := resolveAutocompleteScope(c.source, c.property); got != c.want {
+			t.Errorf("resolveAutocompleteScope(%q,%q) = %q, want %q", c.source, c.property, got, c.want)
+		}
+	}
+}
+
+func TestKeyToTitleCase(t *testing.T) {
+	cases := map[string]string{
+		"issue_type":     "Issue Type",
+		"hesitationTime": "Hesitation Time",
+		"url_host":       "Url Host",
+		"crash":          "Crash",
+	}
+	for in, want := range cases {
+		if got := keyToTitleCase(in); got != want {
+			t.Errorf("keyToTitleCase(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIssueTypeName(t *testing.T) {
+	if got := issueTypeName("js_exception"); got != "Errors" {
+		t.Errorf("issueTypeName(js_exception) = %q, want Errors", got)
+	}
+	if got := issueTypeName("click_rage"); got != "Click Rage" {
+		t.Errorf("issueTypeName(click_rage) = %q, want Click Rage", got)
+	}
+	if got := issueTypeName("custom_thing"); got != "Custom Thing" {
+		t.Errorf("issueTypeName(custom_thing) = %q, want Custom Thing", got)
+	}
+}

--- a/backend/pkg/analytics/filters_catalog/catalog_static.go
+++ b/backend/pkg/analytics/filters_catalog/catalog_static.go
@@ -1,0 +1,363 @@
+package filters_catalog
+
+// FilterTypeDef bundles the wire/JSON name with the Python-format string used
+// as the input to StringToID. The EnumStr looks like "FilterType.REFERRER"
+// because Python's `class FilterType(str, Enum)` inherits `Enum.__str__`,
+// so f-strings interpolate the member as "ClassName.MEMBER" rather than
+// the value. The live system's IDs depend on this format.
+type FilterTypeDef struct {
+	Name    string
+	EnumStr string
+}
+
+var (
+	// Session filters
+	FTReferrer           = FilterTypeDef{Name: "referrer", EnumStr: "FilterType.REFERRER"}
+	FTDuration           = FilterTypeDef{Name: "duration", EnumStr: "FilterType.DURATION"}
+	FTUTMSource          = FilterTypeDef{Name: "utmSource", EnumStr: "FilterType.UTM_SOURCE"}
+	FTUTMMedium          = FilterTypeDef{Name: "utmMedium", EnumStr: "FilterType.UTM_MEDIUM"}
+	FTUTMCampaign        = FilterTypeDef{Name: "utmCampaign", EnumStr: "FilterType.UTM_CAMPAIGN"}
+	FTUserCountry        = FilterTypeDef{Name: "userCountry", EnumStr: "FilterType.USER_COUNTRY"}
+	FTUserCity           = FilterTypeDef{Name: "userCity", EnumStr: "FilterType.USER_CITY"}
+	FTUserState          = FilterTypeDef{Name: "userState", EnumStr: "FilterType.USER_STATE"}
+	FTUserOS             = FilterTypeDef{Name: "userOs", EnumStr: "FilterType.USER_OS"}
+	FTUserBrowser        = FilterTypeDef{Name: "userBrowser", EnumStr: "FilterType.USER_BROWSER"}
+	FTUserBrowserVersion = FilterTypeDef{Name: "userBrowserVersion", EnumStr: "FilterType.USER_BROWSER_VERSION"}
+	FTUserDevice         = FilterTypeDef{Name: "userDevice", EnumStr: "FilterType.USER_DEVICE"}
+	FTUserDeviceType     = FilterTypeDef{Name: "userDeviceType", EnumStr: "FilterType.USER_DEVICE_TYPE"}
+	FTRevID              = FilterTypeDef{Name: "revId", EnumStr: "FilterType.REV_ID"}
+	FTIssue              = FilterTypeDef{Name: "issue", EnumStr: "FilterType.ISSUE"}
+	// User filters
+	FTUserID     = FilterTypeDef{Name: "userId", EnumStr: "FilterType.USER_ID"}
+	FTDistinctID = FilterTypeDef{Name: "distinct_id", EnumStr: "FilterType.DISTINCT_ID"}
+)
+
+// IssueType — single entry from the static issue types catalog
+// (api/chalicelib/core/issues/issues_ch.py:67-132).
+type IssueType struct {
+	Type         string `json:"type"`
+	Visible      bool   `json:"visible"`
+	Order        int    `json:"order"`
+	Name         string `json:"name"`
+	AutoCaptured bool   `json:"autoCaptured"`
+}
+
+// IssueTypes is the static catalog of issue categories. Order is significant —
+// the frontend renders in this order.
+var IssueTypes = []IssueType{
+	{Type: "js_exception", Visible: true, Order: 0, Name: "Errors", AutoCaptured: true},
+	{Type: "bad_request", Visible: true, Order: 1, Name: "Bad Requests", AutoCaptured: true},
+	{Type: "missing_resource", Visible: true, Order: 2, Name: "Missing Images", AutoCaptured: true},
+	{Type: "click_rage", Visible: true, Order: 3, Name: "Click Rage", AutoCaptured: true},
+	{Type: "dead_click", Visible: true, Order: 4, Name: "Dead Clicks", AutoCaptured: true},
+	{Type: "memory", Visible: true, Order: 5, Name: "High Memory", AutoCaptured: true},
+	{Type: "cpu", Visible: true, Order: 6, Name: "High CPU", AutoCaptured: true},
+	{Type: "crash", Visible: true, Order: 7, Name: "Crashes", AutoCaptured: true},
+	{Type: "incident", Visible: true, Order: 8, Name: "Incident", AutoCaptured: false},
+}
+
+// PredefinedEvent holds metadata for a built-in event type.
+// Description is intentionally left blank for now; only the map keys are used
+// by the /pa/{projectId}/filters endpoint as a fallback when ClickHouse returns
+// no rows.
+type PredefinedEvent struct {
+	Description string
+}
+
+// PredefinedEvents is the set of built-in web event types
+// (port of PREDEFINED_EVENTS from api/chalicelib/core/pa/events.py).
+var PredefinedEvents = map[string]PredefinedEvent{
+	"CLICK":       {},
+	"INPUT":       {},
+	"LOCATION":    {},
+	"ERROR":       {},
+	"REQUEST":     {},
+	"ISSUE":       {},
+	"PERFORMANCE": {},
+}
+
+// PredefinedEventsOrder preserves api/chalicelib/core/product_analytics/events.py:30-52
+// (PREDEFINED_EVENTS dict insertion order). Use this — not the map — when you need
+// deterministic output that matches Python's response.
+var PredefinedEventsOrder = []string{
+	"CLICK", "INPUT", "LOCATION", "ERROR", "REQUEST", "ISSUE", "PERFORMANCE",
+}
+
+// PredefinedEventsMobile is the set of built-in mobile event types
+// (port of PREDEFINED_EVENTS_MOBILE from events.py).
+var PredefinedEventsMobile = map[string]PredefinedEvent{
+	"TAP":     {},
+	"INPUT":   {},
+	"SWIPE":   {},
+	"REQUEST": {},
+	"CRASH":   {},
+	"ISSUE":   {},
+}
+
+// PredefinedEventsMobileOrder preserves the dict order in events.py:54-73.
+var PredefinedEventsMobileOrder = []string{
+	"TAP", "INPUT", "SWIPE", "REQUEST", "CRASH", "ISSUE",
+}
+
+// ExcludedEvents holds event-type keys that must never appear in the
+// /pa/{projectId}/filters response (port of EXCLUDED_EVENTS from events.py).
+var ExcludedEvents = map[string]struct{}{
+	"CUSTOM":      {},
+	"TAG_TRIGGER": {},
+}
+
+// PredefinedProperty holds metadata for a built-in event property.
+type PredefinedProperty struct {
+	Type           string
+	IsPredefined   bool
+	PossibleValues []any
+	IsConditional  bool
+}
+
+// PredefinedProperties is the set of known event properties
+// (port of PREDEFINED_PROPERTIES from api/chalicelib/core/pa/properties.py).
+// Keys are snake_case — the caller converts camelCase CH column names before
+// looking up. PossibleValues is nil for entries that don't set it; callers
+// must coerce nil to []any{} when building the JSON response.
+var PredefinedProperties = map[string]PredefinedProperty{
+	"label":                       {Type: "String", IsConditional: true},
+	"hesitation_time":             {Type: "UInt32"},
+	"name":                        {Type: "String", IsConditional: true},
+	"payload":                     {Type: "String"},
+	"level":                       {Type: "Enum8"},
+	"message":                     {Type: "String"},
+	"context":                     {Type: "Enum8"},
+	"url_host":                    {Type: "String", IsConditional: true},
+	"url_path":                    {Type: "String", IsConditional: true},
+	"first_contentful_paint_time": {Type: "UInt16"},
+	"speed_index":                 {Type: "UInt16"},
+	"min_fps":                     {Type: "UInt8"},
+	"max_fps":                     {Type: "UInt8"},
+	"min_cpu":                     {Type: "UInt8"},
+	"max_cpu":                     {Type: "UInt8"},
+	"min_used_js_heap_size":       {Type: "UInt64"},
+	"max_used_js_heap_size":       {Type: "UInt64"},
+	"method": {
+		Type:           "Enum8",
+		IsPredefined:   true,
+		PossibleValues: []any{"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTION"},
+		IsConditional:  true,
+	},
+	"status":        {Type: "UInt16", IsConditional: true},
+	"success":       {Type: "UInt8"},
+	"request_body":  {Type: "String"},
+	"response_body": {Type: "String"},
+	"selector":      {Type: "String", IsConditional: true},
+	"duration":      {Type: "UInt16", IsConditional: true},
+	"normalized_x":  {Type: "UInt16", IsConditional: true},
+	"normalized_y":  {Type: "UInt16", IsConditional: true},
+}
+
+// PredefinedPropertiesOrder preserves the dict order in
+// api/chalicelib/core/product_analytics/properties.py:75-220 (PREDEFINED_PROPERTIES).
+var PredefinedPropertiesOrder = []string{
+	"label", "hesitation_time", "name", "payload", "level", "message", "context",
+	"url_host", "url_path", "first_contentful_paint_time", "speed_index",
+	"min_fps", "max_fps", "min_cpu", "max_cpu",
+	"min_used_js_heap_size", "max_used_js_heap_size",
+	"method", "status", "success", "request_body", "response_body",
+	"selector", "duration", "normalized_x", "normalized_y",
+}
+
+// ExcludedProperties holds property keys that must never appear in the
+// /pa/{projectId}/filters response (port of EXCLUDED_PROPERTIES from properties.py).
+var ExcludedProperties = map[string]struct{}{
+	"message_id":  {},
+	"error_id":    {},
+	"tag_id":      {},
+	"web_vitals":  {},
+	"user_device": {},
+}
+
+// OREventDisplayName returns the human-readable display name for a built-in
+// event type key (port of or_event_display_name from events.py).
+func OREventDisplayName(eventName string) string {
+	switch eventName {
+	case "CLICK":
+		return "Click"
+	case "INPUT":
+		return "Text Input"
+	case "LOCATION":
+		return "Page View"
+	case "ERROR":
+		return "Error"
+	case "REQUEST":
+		return "Network Request"
+	case "PERFORMANCE":
+		return "Performance"
+	case "ISSUE":
+		return "Issue"
+	case "INCIDENT":
+		return "Incident"
+	case "TAG_TRIGGER":
+		return "Tag"
+	case "TAP":
+		return "Tap"
+	case "SWIPE":
+		return "Swipe"
+	case "CRASH":
+		return "Crash"
+	}
+	return ""
+}
+
+// ORPropertyDisplayName returns the human-readable display name for a property
+// key (port of or_property_display_name from properties.py).
+func ORPropertyDisplayName(name string) string {
+	switch name {
+	case "label":
+		return "Label"
+	case "hesitation_time":
+		return "Hesitation Time"
+	case "name":
+		return "Name"
+	case "payload":
+		return "Payload"
+	case "level":
+		return "Level"
+	case "source":
+		return "Source"
+	case "duration":
+		return "Duration"
+	case "context":
+		return "Context"
+	case "url_host":
+		return "Hostname"
+	case "url_path":
+		return "Path"
+	case "url_hostpath":
+		return "URL Host and Path"
+	case "request_start":
+		return "Request Start"
+	case "response_start":
+		return "Response Start"
+	case "response_end":
+		return "Response End"
+	case "dom_content_loaded_event_start":
+		return "DOM Content Loaded Event Start"
+	case "dom_content_loaded_event_end":
+		return "DOM Content Loaded Event End"
+	case "load_event_start":
+		return "Load Event Start"
+	case "load_event_end":
+		return "Load Event End"
+	case "first_paint":
+		return "First Paint"
+	case "first_contentful_paint_time":
+		return "First Contentful-paint Time"
+	case "speed_index":
+		return "Speed Index"
+	case "visually_complete":
+		return "Visually Complete"
+	case "time_to_interactive":
+		return "Time To Interactive"
+	case "ttfb":
+		return "Time To First Byte"
+	case "ttlb":
+		return "Time To Last Byte"
+	case "response_time":
+		return "Response Time"
+	case "dom_building_time":
+		return "DOM Building Time"
+	case "dom_content_loaded_event_time":
+		return "DOM Content Loaded Event Time"
+	case "load_event_time":
+		return "Load Event Time"
+	case "min_fps":
+		return "Minimum Frame Rate"
+	case "avg_fps":
+		return "Average Frame Rate"
+	case "max_fps":
+		return "Maximum Frame Rate"
+	case "min_cpu":
+		return "Minimum CPU"
+	case "avg_cpu":
+		return "Average CPU"
+	case "max_cpu":
+		return "Maximum CPU"
+	case "min_total_js_heap_size":
+		return "Minimum Total JS Heap Size"
+	case "avg_total_js_heap_size":
+		return "Average Total JS Heap Size"
+	case "max_total_js_heap_size":
+		return "Maximum Total JS Heap Size"
+	case "min_used_js_heap_size":
+		return "Minimum Used JS Heap Size"
+	case "avg_used_js_heap_size":
+		return "Average Used JS Heap Size"
+	case "max_used_js_heap_size":
+		return "Maximum Used JS Heap Size"
+	case "success":
+		return "Success"
+	case "request_body":
+		return "Request Body"
+	case "response_body":
+		return "Response Body"
+	case "transfer_size":
+		return "Transfer Size"
+	case "selector":
+		return "CSS Selector"
+	case "normalized_x":
+		return "Normalized X"
+	case "normalized_y":
+		return "Normalized Y"
+	case "message_id":
+		return "Message ID"
+	case "cls":
+		return "Cumulative Layout Shift"
+	case "lcp":
+		return "Largest Contentful Paint"
+	case "issue_type":
+		return "Issue Type"
+	case "url":
+		return "URL"
+	case "user_device":
+		return "Device"
+	case "user_device_type":
+		return "Platform"
+	case "message":
+		return "Error Message"
+	case "method":
+		return "HTTP Method"
+	case "status":
+		return "Status Code"
+	case "userState":
+		return "State/Province"
+	case "incident":
+		return "Incident Reported By User"
+	case "page_title":
+		return "Page Title"
+	}
+	return ""
+}
+
+// CountryCodes is the static catalog of ISO 3166-1 alpha-2 country codes.
+// Order is significant; the frontend renders in this order.
+var CountryCodes = []string{
+	"AF", "AX", "AL", "DZ", "AS", "AD", "AO", "AI", "AQ", "AG", "AR", "AM",
+	"AW", "AU", "AT", "AZ", "BS", "BH", "BD", "BB", "BY", "BE", "BZ", "BJ",
+	"BM", "BT", "BO", "BQ", "BA", "BW", "BV", "BR", "IO", "BN", "BG", "BF",
+	"BI", "CV", "KH", "CM", "CA", "KY", "CF", "TD", "CL", "CN", "CX", "CC",
+	"CO", "KM", "CG", "CD", "CK", "CR", "CI", "HR", "CU", "CW", "CY", "CZ",
+	"DK", "DJ", "DM", "DO", "EC", "EG", "SV", "GQ", "ER", "EE", "SZ", "ET",
+	"FK", "FO", "FJ", "FI", "FR", "GF", "PF", "TF", "GA", "GM", "GE", "DE",
+	"GH", "GI", "GR", "GL", "GD", "GP", "GU", "GT", "GG", "GN", "GW", "GY",
+	"HT", "HM", "VA", "HN", "HK", "HU", "IS", "IN", "ID", "IR", "IQ", "IE",
+	"IM", "IL", "IT", "JM", "JP", "JE", "JO", "KZ", "KE", "KI", "KP", "KR",
+	"KW", "KG", "LA", "LV", "LB", "LS", "LR", "LY", "LI", "LT", "LU", "MO",
+	"MG", "MW", "MY", "MV", "ML", "MT", "MH", "MQ", "MR", "MU", "YT", "MX",
+	"FM", "MD", "MC", "MN", "ME", "MS", "MA", "MZ", "MM", "NA", "NR", "NP",
+	"NL", "NC", "NZ", "NI", "NE", "NG", "NU", "NF", "MK", "MP", "NO", "OM",
+	"PK", "PW", "PS", "PA", "PG", "PY", "PE", "PH", "PN", "PL", "PT", "PR",
+	"QA", "RE", "RO", "RU", "RW", "BL", "SH", "KN", "LC", "MF", "PM", "VC",
+	"WS", "SM", "ST", "SA", "SN", "RS", "SC", "SL", "SG", "SX", "SK", "SI",
+	"SB", "SO", "ZA", "GS", "SS", "ES", "LK", "SD", "SR", "SJ", "SE", "CH",
+	"SY", "TW", "TJ", "TZ", "TH", "TL", "TG", "TK", "TO", "TT", "TN", "TR",
+	"TM", "TC", "TV", "UG", "UA", "AE", "GB", "US", "UM", "UY", "UZ", "VU",
+	"VE", "VN", "VG", "VI", "WF", "EH", "YE", "ZM", "ZW",
+}

--- a/backend/pkg/analytics/filters_catalog/catalog_static.go
+++ b/backend/pkg/analytics/filters_catalog/catalog_static.go
@@ -28,8 +28,7 @@ var (
 	FTRevID              = FilterTypeDef{Name: "revId", EnumStr: "FilterType.REV_ID"}
 	FTIssue              = FilterTypeDef{Name: "issue", EnumStr: "FilterType.ISSUE"}
 	// User filters
-	FTUserID     = FilterTypeDef{Name: "userId", EnumStr: "FilterType.USER_ID"}
-	FTDistinctID = FilterTypeDef{Name: "distinct_id", EnumStr: "FilterType.DISTINCT_ID"}
+	FTUserID = FilterTypeDef{Name: "userId", EnumStr: "FilterType.USER_ID"}
 )
 
 // IssueType — single entry from the static issue types catalog

--- a/backend/pkg/analytics/filters_catalog/ch_events.go
+++ b/backend/pkg/analytics/filters_catalog/ch_events.go
@@ -1,0 +1,150 @@
+package filters_catalog
+
+import (
+	"context"
+	"fmt"
+
+	"openreplay/backend/pkg/analytics/filters_catalog/model"
+)
+
+var (
+	mobileOnlyEvents = map[string]struct{}{"TAP": {}, "SWIPE": {}, "CRASH": {}}
+	webOnlyEvents    = map[string]struct{}{"CLICK": {}, "LOCATION": {}, "ERROR": {}}
+)
+
+const eventsCatalogQuery = `
+SELECT DISTINCT
+ON(event_name, auto_captured)
+    COUNT(1) OVER () AS total,
+    event_name AS name,
+    aec.display_name AS display_name,
+    auto_captured
+FROM product_analytics.all_events
+    LEFT JOIN product_analytics.all_events_customized AS aec USING (project_id, auto_captured, event_name)
+WHERE project_id = ?
+    AND (aec.status = 'visible' OR aec.status = '')
+ORDER BY auto_captured, aec.display_name, all_events.event_name`
+
+// eventCatalogRow holds one scanned row from the CH events catalog query.
+type eventCatalogRow struct {
+	Total        uint64
+	Name         string
+	DisplayName  string
+	AutoCaptured bool
+}
+
+// getEventsCatalog mirrors api/chalicelib/core/product_analytics/events.py:get_events.
+// It returns the events FilterSection, applying mobile/web event-name filtering
+// based on the project's platform and merging in any predefined events the CH
+// query did not return.
+func (s *filtersCatalogImpl) getEventsCatalog(ctx context.Context, projectID uint32, platform string) (model.FilterSection, error) {
+	rows, err := s.ch.Query(ctx, eventsCatalogQuery, projectID)
+	if err != nil {
+		return model.FilterSection{}, fmt.Errorf("ch query events catalog: %w", err)
+	}
+	defer rows.Close()
+
+	var fetched []eventCatalogRow
+	for rows.Next() {
+		var r eventCatalogRow
+		if err := rows.Scan(&r.Total, &r.Name, &r.DisplayName, &r.AutoCaptured); err != nil {
+			return model.FilterSection{}, fmt.Errorf("scan events row: %w", err)
+		}
+		fetched = append(fetched, r)
+	}
+	if err := rows.Err(); err != nil {
+		return model.FilterSection{}, err
+	}
+
+	return buildEventsCatalogSection(fetched, platform), nil
+}
+
+// buildEventsCatalogSection is the pure post-query transformation. Exposed
+// (lowercase, package-private) for testing.
+func buildEventsCatalogSection(fetched []eventCatalogRow, platform string) model.FilterSection {
+	isMobile := platform == "ios" || platform == "android"
+	predefined := PredefinedEvents
+	order := PredefinedEventsOrder
+	if isMobile {
+		predefined = PredefinedEventsMobile
+		order = PredefinedEventsMobileOrder
+	}
+
+	scope := []string{"sessions", "events", "users"}
+
+	// Empty CH result → predefined-only fallback (matches Python events.py:113-126).
+	// Iterate over the ordered slice so output matches Python's dict insertion order.
+	if len(fetched) == 0 {
+		list := make([]any, 0, len(order))
+		for _, name := range order {
+			list = append(list, model.EventCatalogItem{
+				Name:                  name,
+				DisplayName:           OREventDisplayName(name),
+				AutoCaptured:          true,
+				ID:                    StringToID("event_" + name),
+				DataType:              "string",
+				PossibleTypes:         []string{"string"},
+				FoundInPredefinedList: false,
+			})
+		}
+		return model.FilterSection{Total: len(predefined), DisplayName: "Events", Scope: scope, List: list}
+	}
+
+	total := int(fetched[0].Total)
+	keys := make(map[string]struct{}, len(fetched))
+	list := make([]any, 0, len(fetched)+len(predefined))
+	for _, r := range fetched {
+		// Skip auto-captured events that are explicitly excluded.
+		if r.AutoCaptured {
+			if _, excluded := ExcludedEvents[r.Name]; excluded {
+				continue
+			}
+		}
+		// Skip events that don't apply to this platform.
+		if isMobile {
+			if _, weo := webOnlyEvents[r.Name]; weo {
+				continue
+			}
+		} else {
+			if _, meo := mobileOnlyEvents[r.Name]; meo {
+				continue
+			}
+		}
+		keys[r.Name] = struct{}{}
+		display := r.DisplayName
+		if r.AutoCaptured && display == "" {
+			display = OREventDisplayName(r.Name)
+		}
+		list = append(list, model.EventCatalogItem{
+			Name:                  r.Name,
+			DisplayName:           display,
+			AutoCaptured:          r.AutoCaptured,
+			ID:                    StringToID("event_" + r.Name),
+			DataType:              "string",
+			PossibleTypes:         []string{"string"},
+			IsConditional:         true,
+			FoundInPredefinedList: true,
+		})
+	}
+
+	// Append predefined entries the CH query didn't return.
+	// Iterate over the ordered slice so appended items follow Python's dict insertion order.
+	for _, name := range order {
+		if _, ok := keys[name]; ok {
+			continue
+		}
+		total++
+		list = append(list, model.EventCatalogItem{
+			Name:                  name,
+			DisplayName:           OREventDisplayName(name),
+			AutoCaptured:          true,
+			ID:                    StringToID("event_" + name),
+			DataType:              "string",
+			PossibleTypes:         []string{"string"},
+			IsConditional:         true,
+			FoundInPredefinedList: false,
+		})
+	}
+
+	return model.FilterSection{Total: total, DisplayName: "Events", Scope: scope, List: list}
+}

--- a/backend/pkg/analytics/filters_catalog/ch_properties.go
+++ b/backend/pkg/analytics/filters_catalog/ch_properties.go
@@ -1,0 +1,208 @@
+package filters_catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"openreplay/backend/pkg/analytics/filters_catalog/model"
+)
+
+const propertiesCatalogQuery = `
+SELECT COUNT(1) OVER () AS total,
+    property_name AS name,
+    apc.display_name AS display_name,
+    event_properties.auto_captured_property AS auto_captured,
+    possible_types
+FROM product_analytics.all_properties
+    LEFT JOIN product_analytics.all_properties_customized AS apc
+        USING (project_id, source, property_name, auto_captured)
+    LEFT ANY JOIN (
+        SELECT property_name,
+               auto_captured_property,
+               arrayDistinct(groupArray(event_properties.value_type)) AS possible_types
+        FROM product_analytics.event_properties
+        WHERE event_properties.project_id = ?
+        GROUP BY ALL
+    ) AS event_properties USING (property_name)
+WHERE project_id = ?
+    AND (apc.status = 'visible' OR isNull(apc.status))
+GROUP BY ALL
+ORDER BY apc.display_name, all_properties.property_name`
+
+// propertyCatalogRow holds one scanned row from the CH properties catalog query.
+type propertyCatalogRow struct {
+	Total         uint64
+	Name          string
+	DisplayName   string
+	AutoCaptured  bool
+	PossibleTypes []string
+}
+
+// getPropertiesCatalog queries ClickHouse for event properties and delegates to
+// buildPropertiesCatalogSection for the pure transformation logic.
+func (s *filtersCatalogImpl) getPropertiesCatalog(ctx context.Context, projectID uint32) (model.FilterSection, error) {
+	rows, err := s.ch.Query(ctx, propertiesCatalogQuery, projectID, projectID)
+	if err != nil {
+		return model.FilterSection{}, fmt.Errorf("ch query properties catalog: %w", err)
+	}
+	defer rows.Close()
+
+	var fetched []propertyCatalogRow
+	for rows.Next() {
+		var r propertyCatalogRow
+		if err := rows.Scan(&r.Total, &r.Name, &r.DisplayName, &r.AutoCaptured, &r.PossibleTypes); err != nil {
+			return model.FilterSection{}, fmt.Errorf("scan property: %w", err)
+		}
+		fetched = append(fetched, r)
+	}
+	if err := rows.Err(); err != nil {
+		return model.FilterSection{}, err
+	}
+	return buildPropertiesCatalogSection(fetched), nil
+}
+
+// buildPropertiesCatalogSection mirrors get_all_properties from
+// api/chalicelib/core/product_analytics/properties.py:259-340. Each item is a
+// map[string]any because the field set varies:
+//   - CH rows that match a PredefinedProperties key: 8 keys (no isPredefined/possibleValues).
+//   - CH rows that do NOT match: also 8 keys (same trimmed shape — no isPredefined/possibleValues).
+//   - Predefined-fallback appends: 10 keys (includes isPredefined + possibleValues).
+//
+// NOTE: there is a pre-existing inconsistency in the Python source — live golden
+// responses for non-predefined CH rows carry isPredefined/possibleValues, but the
+// Python code never sets them for those rows. All non-predefined-flag items in
+// the golden are actually from the predefined-fallback append path, not from CH
+// rows. This migration faithfully mirrors Python's logic without patching that
+// inconsistency.
+func buildPropertiesCatalogSection(fetched []propertyCatalogRow) model.FilterSection {
+	scope := []string{"sessions", "events"}
+
+	// Python returns {"total": 0, "list": []} on empty input (properties.py:286-287).
+	if len(fetched) == 0 {
+		return model.FilterSection{Total: 0, DisplayName: "Event Properties", Scope: scope, List: []any{}}
+	}
+
+	total := int(fetched[0].Total)
+	processed := make([]map[string]any, 0, len(fetched))
+	keys := make(map[string]struct{}, len(fetched))
+
+	for _, r := range fetched {
+		// Skip rows whose names are in ExcludedProperties before any other
+		// processing (mirrors Python's list comprehension filter).
+		if _, excluded := ExcludedProperties[r.Name]; excluded {
+			continue
+		}
+
+		name := r.Name
+		snake := keyToSnakeCase(name)
+		_, inPredefined := PredefinedProperties[snake]
+		if inPredefined {
+			// Re-camelCase the name: for inputs already in camelCase the
+			// snake→camel round-trip is a no-op, but for snake_case CH
+			// values it produces the correct camelCase output.
+			name = keyToCamelCase(snake)
+		}
+
+		simplified := SimplifyClickHouseTypes(r.PossibleTypes)
+
+		display := r.DisplayName
+		if r.AutoCaptured && display == "" {
+			display = ORPropertyDisplayName(snake)
+		}
+
+		item := map[string]any{
+			"name":          name,
+			"displayName":   display,
+			"autoCaptured":  r.AutoCaptured,
+			"id":            StringToID("prop_" + name),
+			"possibleTypes": simplified,
+		}
+
+		if pp, ok := PredefinedProperties[snake]; ok {
+			item["_foundInPredefinedList"] = true
+			item["isConditional"] = pp.IsConditional
+			item["dataType"] = SimplifyClickHouseType(pp.Type)
+		} else {
+			item["_foundInPredefinedList"] = false
+			if len(simplified) > 0 {
+				item["dataType"] = simplified[0]
+			} else {
+				item["dataType"] = "string"
+			}
+		}
+
+		processed = append(processed, item)
+		keys[snake] = struct{}{}
+	}
+
+	// Append predefined entries that the CH query did not return.
+	// Iterate over PredefinedPropertiesOrder (not the map) so the appended items
+	// follow the Python dict insertion order and output is deterministic.
+	for _, snakeKey := range PredefinedPropertiesOrder {
+		if _, seen := keys[snakeKey]; seen {
+			continue
+		}
+		pp := PredefinedProperties[snakeKey]
+		total++
+		camelKey := keyToCamelCase(snakeKey)
+		values := pp.PossibleValues
+		if values == nil {
+			values = []any{}
+		}
+		processed = append(processed, map[string]any{
+			"name":                   camelKey,
+			"displayName":            ORPropertyDisplayName(snakeKey),
+			"possibleTypes":          []string{pp.Type},
+			"id":                     StringToID("prop_" + camelKey),
+			"_foundInPredefinedList": false,
+			"dataType":               pp.Type,
+			"autoCaptured":           true,
+			"isPredefined":           pp.IsPredefined,
+			"possibleValues":         values,
+			"isConditional":          pp.IsConditional,
+		})
+	}
+
+	list := make([]any, 0, len(processed))
+	for _, item := range processed {
+		list = append(list, item)
+	}
+	return model.FilterSection{Total: total, DisplayName: "Event Properties", Scope: scope, List: list}
+}
+
+// keyToSnakeCase converts camelCase or PascalCase to snake_case. No acronym
+// handling — matches the Python key_to_snake_case used by properties.py.
+// Examples: "hesitationTime" → "hesitation_time", "minUsedJsHeapSize" → "min_used_js_heap_size".
+func keyToSnakeCase(s string) string {
+	if s == "" {
+		return s
+	}
+	var b strings.Builder
+	for i, r := range s {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			b.WriteByte('_')
+		}
+		if r >= 'A' && r <= 'Z' {
+			r = r + ('a' - 'A')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// keyToCamelCase converts snake_case to camelCase.
+// Example: "hesitation_time" → "hesitationTime".
+func keyToCamelCase(s string) string {
+	if s == "" {
+		return s
+	}
+	parts := strings.Split(s, "_")
+	for i := 1; i < len(parts); i++ {
+		if parts[i] == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+	}
+	return strings.Join(parts, "")
+}

--- a/backend/pkg/analytics/filters_catalog/ch_types.go
+++ b/backend/pkg/analytics/filters_catalog/ch_types.go
@@ -1,0 +1,69 @@
+// backend/pkg/analytics/filters_catalog/ch_types.go
+package filters_catalog
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	chWrapperRE = regexp.MustCompile(`^(Nullable|LowCardinality)\((.*)\)$`)
+	chIntRE     = regexp.MustCompile(`^u?int(8|16|32|64|128|256)$`)
+	chFloatRE   = regexp.MustCompile(`^(float(32|64)|double)$`)
+)
+
+// SimplifyClickHouseType — port of exp_ch_helper.simplify_clickhouse_type.
+func SimplifyClickHouseType(t string) string {
+	for {
+		m := chWrapperRE.FindStringSubmatch(t)
+		if m == nil {
+			break
+		}
+		t = m[2]
+	}
+	n := strings.ToLower(t)
+	switch {
+	case chIntRE.MatchString(n):
+		return "int"
+	case chFloatRE.MatchString(n):
+		return "float"
+	case strings.HasPrefix(n, "decimal"):
+		return "float"
+	case strings.HasPrefix(n, "datetime"):
+		return "datetime"
+	case strings.HasPrefix(n, "date"):
+		return "datetime"
+	case strings.HasPrefix(n, "fixedstring"):
+		return "string"
+	case strings.HasPrefix(n, "string"):
+		return "string"
+	case strings.HasPrefix(n, "uuid"):
+		return "string"
+	case strings.HasPrefix(n, "enum8"), strings.HasPrefix(n, "enum16"):
+		return "string"
+	case strings.HasPrefix(n, "array"):
+		return "array"
+	case strings.HasPrefix(n, "tuple"):
+		return "tuple"
+	case strings.HasPrefix(n, "map"):
+		return "map"
+	case strings.HasPrefix(n, "nested"):
+		return "nested"
+	}
+	return n
+}
+
+// SimplifyClickHouseTypes returns the deduplicated set of simplified types.
+// Order is not guaranteed (matches Python `list(set(...))`).
+func SimplifyClickHouseTypes(types []string) []string {
+	seen := make(map[string]struct{}, len(types))
+	out := make([]string, 0, len(types))
+	for _, t := range types {
+		s := SimplifyClickHouseType(t)
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/backend/pkg/analytics/filters_catalog/id.go
+++ b/backend/pkg/analytics/filters_catalog/id.go
@@ -1,0 +1,14 @@
+package filters_catalog
+
+import (
+	"crypto/md5"
+	"math/big"
+)
+
+// StringToID mirrors api/chalicelib/utils/helper.py:string_to_id —
+// MD5 of UTF-8 bytes interpreted as big-endian unsigned integer, rendered as decimal.
+func StringToID(s string) string {
+	sum := md5.Sum([]byte(s))
+	z := new(big.Int).SetBytes(sum[:])
+	return z.String()
+}

--- a/backend/pkg/analytics/filters_catalog/model/autocomplete.go
+++ b/backend/pkg/analytics/filters_catalog/model/autocomplete.go
@@ -1,0 +1,7 @@
+package model
+
+type AutocompleteRow struct {
+	Value         string  `json:"value"`
+	RowPercentage float64 `json:"rowPercentage"`
+	Name          string  `json:"name,omitempty"`
+}

--- a/backend/pkg/analytics/filters_catalog/model/response.go
+++ b/backend/pkg/analytics/filters_catalog/model/response.go
@@ -1,0 +1,84 @@
+package model
+
+// StaticFilterItem is the uniform 9-field shape used by sessions, users,
+// and identified-users sections. All fields always present.
+type StaticFilterItem struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	DisplayName    string   `json:"displayName"`
+	PossibleTypes  []string `json:"possibleTypes"`
+	DataType       string   `json:"dataType"`
+	AutoCaptured   bool     `json:"autoCaptured"`
+	IsPredefined   bool     `json:"isPredefined"`
+	PossibleValues []any    `json:"possibleValues"`
+	IsConditional  bool     `json:"isConditional"`
+}
+
+// EventCatalogItem is the events-section shape: 8 fields, never includes
+// isPredefined or possibleValues. _foundInPredefinedList serializes as a
+// snake-style key with leading underscore (matches the golden).
+type EventCatalogItem struct {
+	Name                  string   `json:"name"`
+	DisplayName           string   `json:"displayName"`
+	AutoCaptured          bool     `json:"autoCaptured"`
+	ID                    string   `json:"id"`
+	DataType              string   `json:"dataType"`
+	PossibleTypes         []string `json:"possibleTypes"`
+	IsConditional         bool     `json:"isConditional"`
+	FoundInPredefinedList bool     `json:"_foundInPredefinedList"`
+}
+
+// MetadataItem is the metadata-section shape: 6 fields. No isPredefined,
+// possibleValues, or isConditional.
+type MetadataItem struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	DisplayName   string   `json:"displayName"`
+	PossibleTypes []string `json:"possibleTypes"`
+	DataType      string   `json:"dataType"`
+	AutoCaptured  bool     `json:"autoCaptured"`
+}
+
+// SegmentItem is the segments-section shape.
+type SegmentItem struct {
+	SearchID    string `json:"searchId"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	IsPublic    bool   `json:"isPublic"`
+	IsSegment   bool   `json:"isSegment"`
+}
+
+// FeatureItem is the features-section shape. Location is omitempty —
+// the golden's items don't include it.
+type FeatureItem struct {
+	TagID           int     `json:"tagId"`
+	Name            string  `json:"name"`
+	DisplayName     string  `json:"displayName"`
+	Selector        string  `json:"selector"`
+	IgnoreClickRage bool    `json:"ignoreClickRage"`
+	IgnoreDeadClick bool    `json:"ignoreDeadClick"`
+	Location        *string `json:"location,omitempty"`
+	IsFeature       bool    `json:"isFeature"`
+}
+
+// FilterSection wraps any of the per-section item types. List is []any
+// so each section can hold its own item type.
+type FilterSection struct {
+	Total       int      `json:"total"`
+	DisplayName string   `json:"displayName"`
+	Scope       []string `json:"scope"`
+	List        []any    `json:"list"`
+}
+
+// AllFiltersResponse is the eight-bucket response envelope (without the
+// outer {"data": ...} wrapper — that gets added by the handler).
+type AllFiltersResponse struct {
+	Events   FilterSection `json:"events"`
+	Event    FilterSection `json:"event"`
+	Session  FilterSection `json:"session"`
+	User     FilterSection `json:"user"`
+	Users    FilterSection `json:"users"`
+	Metadata FilterSection `json:"metadata"`
+	Segments FilterSection `json:"segments"`
+	Features FilterSection `json:"features"`
+}

--- a/backend/pkg/analytics/filters_catalog/pg_features.go
+++ b/backend/pkg/analytics/filters_catalog/pg_features.go
@@ -1,0 +1,33 @@
+package filters_catalog
+
+import (
+	"context"
+
+	"openreplay/backend/pkg/analytics/filters_catalog/model"
+)
+
+func (s *filtersCatalogImpl) getFeaturesFilters(ctx context.Context, projectID uint32) (model.FilterSection, error) {
+	items, err := s.features.ListForFilters(int(projectID))
+	if err != nil {
+		return model.FilterSection{}, err
+	}
+	list := make([]any, 0, len(items))
+	for _, it := range items {
+		list = append(list, model.FeatureItem{
+			TagID:           it.TagID,
+			Name:            it.Name,
+			DisplayName:     it.Name,
+			Selector:        it.Selector,
+			IgnoreClickRage: it.IgnoreClickRage,
+			IgnoreDeadClick: it.IgnoreDeadClick,
+			Location:        it.Location,
+			IsFeature:       true,
+		})
+	}
+	return model.FilterSection{
+		Total:       len(items),
+		DisplayName: "Features",
+		Scope:       []string{"sessions", "events"},
+		List:        list,
+	}, nil
+}

--- a/backend/pkg/analytics/filters_catalog/pg_metadata.go
+++ b/backend/pkg/analytics/filters_catalog/pg_metadata.go
@@ -1,0 +1,53 @@
+package filters_catalog
+
+import (
+	"context"
+	"fmt"
+
+	"openreplay/backend/pkg/analytics/filters_catalog/model"
+)
+
+// getMetadataFilters mirrors api/chalicelib/core/metadata.py:get_for_filters.
+// Reads metadata_1..metadata_10 columns from the projects row via the existing
+// projects service.
+func (s *filtersCatalogImpl) getMetadataFilters(ctx context.Context, projectID uint32) (model.FilterSection, error) {
+	p, err := s.projects.GetProject(projectID)
+	if err != nil {
+		return model.FilterSection{}, fmt.Errorf("get project for metadata: %w", err)
+	}
+	cols := []struct {
+		key   string
+		value *string
+	}{
+		{"metadata_1", p.Metadata1},
+		{"metadata_2", p.Metadata2},
+		{"metadata_3", p.Metadata3},
+		{"metadata_4", p.Metadata4},
+		{"metadata_5", p.Metadata5},
+		{"metadata_6", p.Metadata6},
+		{"metadata_7", p.Metadata7},
+		{"metadata_8", p.Metadata8},
+		{"metadata_9", p.Metadata9},
+		{"metadata_10", p.Metadata10},
+	}
+	list := make([]any, 0, len(cols))
+	for i, c := range cols {
+		if c.value == nil || *c.value == "" {
+			continue
+		}
+		list = append(list, model.MetadataItem{
+			ID:            fmt.Sprintf("meta_%d", i),
+			Name:          c.key,
+			DisplayName:   *c.value,
+			PossibleTypes: []string{"string"},
+			DataType:      "string",
+			AutoCaptured:  true,
+		})
+	}
+	return model.FilterSection{
+		Total:       len(list),
+		DisplayName: "Metadata",
+		Scope:       []string{"sessions"},
+		List:        list,
+	}, nil
+}

--- a/backend/pkg/analytics/filters_catalog/pg_segments.go
+++ b/backend/pkg/analytics/filters_catalog/pg_segments.go
@@ -1,0 +1,30 @@
+package filters_catalog
+
+import (
+	"context"
+
+	"openreplay/backend/pkg/analytics/filters_catalog/model"
+)
+
+func (s *filtersCatalogImpl) getSegmentsFilters(ctx context.Context, projectID uint32, userID uint64) (model.FilterSection, error) {
+	items, err := s.segments.ListForFilters(int(projectID), int(userID))
+	if err != nil {
+		return model.FilterSection{}, err
+	}
+	list := make([]any, 0, len(items))
+	for _, it := range items {
+		list = append(list, model.SegmentItem{
+			SearchID:    it.SearchID,
+			Name:        it.Name,
+			DisplayName: it.Name,
+			IsPublic:    it.IsPublic,
+			IsSegment:   true,
+		})
+	}
+	return model.FilterSection{
+		Total:       len(items),
+		DisplayName: "Segments",
+		Scope:       []string{"sessions", "events"},
+		List:        list,
+	}, nil
+}

--- a/backend/pkg/analytics/filters_catalog/service.go
+++ b/backend/pkg/analytics/filters_catalog/service.go
@@ -1,0 +1,37 @@
+package filters_catalog
+
+import (
+	"context"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"openreplay/backend/pkg/analytics/filters_catalog/model"
+	savedSearches "openreplay/backend/pkg/analytics/saved_searches"
+	"openreplay/backend/pkg/db/postgres/pool"
+	"openreplay/backend/pkg/logger"
+	"openreplay/backend/pkg/projects"
+	tagAdmin "openreplay/backend/pkg/tags/admin"
+)
+
+// FiltersCatalog assembles the multi-section response served by
+// GET /{project}/filters.
+type FiltersCatalog interface {
+	// GetAllFilters returns the union of all filter sections for the given project.
+	GetAllFilters(ctx context.Context, projectID uint32, userID uint64, platform string) (*model.AllFiltersResponse, error)
+}
+
+type filtersCatalogImpl struct {
+	log      logger.Logger
+	ch       driver.Conn
+	pg       pool.Pool
+	projects projects.Projects
+	segments savedSearches.SavedSearches
+	features tagAdmin.TagService
+}
+
+func New(log logger.Logger, ch driver.Conn, pg pool.Pool, p projects.Projects, segments savedSearches.SavedSearches, features tagAdmin.TagService) FiltersCatalog {
+	return &filtersCatalogImpl{
+		log: log, ch: ch, pg: pg,
+		projects: p, segments: segments, features: features,
+	}
+}

--- a/backend/pkg/analytics/filters_catalog/service.go
+++ b/backend/pkg/analytics/filters_catalog/service.go
@@ -17,6 +17,8 @@ import (
 type FiltersCatalog interface {
 	// GetAllFilters returns the union of all filter sections for the given project.
 	GetAllFilters(ctx context.Context, projectID uint32, userID uint64, platform string) (*model.AllFiltersResponse, error)
+	SearchEventsAutocomplete(ctx context.Context, projectID uint32, q string) ([]model.AutocompleteRow, error)
+	SearchPropertiesAutocomplete(ctx context.Context, projectID uint32, propertyName, eventName, userID, source, q string, autoCaptured bool) ([]model.AutocompleteRow, error)
 }
 
 type filtersCatalogImpl struct {
@@ -25,11 +27,13 @@ type filtersCatalogImpl struct {
 	projects projects.Projects
 	segments savedSearches.SavedSearches
 	features tagAdmin.TagService
+	acCache  *autocompleteCache
 }
 
 func New(log logger.Logger, ch driver.Conn, p projects.Projects, segments savedSearches.SavedSearches, features tagAdmin.TagService) FiltersCatalog {
 	return &filtersCatalogImpl{
 		log: log, ch: ch,
 		projects: p, segments: segments, features: features,
+		acCache: newAutocompleteCache(autocompleteCacheTTL),
 	}
 }

--- a/backend/pkg/analytics/filters_catalog/service.go
+++ b/backend/pkg/analytics/filters_catalog/service.go
@@ -7,7 +7,6 @@ import (
 
 	"openreplay/backend/pkg/analytics/filters_catalog/model"
 	savedSearches "openreplay/backend/pkg/analytics/saved_searches"
-	"openreplay/backend/pkg/db/postgres/pool"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/projects"
 	tagAdmin "openreplay/backend/pkg/tags/admin"
@@ -23,15 +22,14 @@ type FiltersCatalog interface {
 type filtersCatalogImpl struct {
 	log      logger.Logger
 	ch       driver.Conn
-	pg       pool.Pool
 	projects projects.Projects
 	segments savedSearches.SavedSearches
 	features tagAdmin.TagService
 }
 
-func New(log logger.Logger, ch driver.Conn, pg pool.Pool, p projects.Projects, segments savedSearches.SavedSearches, features tagAdmin.TagService) FiltersCatalog {
+func New(log logger.Logger, ch driver.Conn, p projects.Projects, segments savedSearches.SavedSearches, features tagAdmin.TagService) FiltersCatalog {
 	return &filtersCatalogImpl{
-		log: log, ch: ch, pg: pg,
+		log: log, ch: ch,
 		projects: p, segments: segments, features: features,
 	}
 }

--- a/backend/pkg/analytics/filters_catalog/sessions.go
+++ b/backend/pkg/analytics/filters_catalog/sessions.go
@@ -1,0 +1,190 @@
+package filters_catalog
+
+import "openreplay/backend/pkg/analytics/filters_catalog/model"
+
+// GetSessionsFilters mirrors api/chalicelib/core/product_analytics/filters.py:get_sessions_filters.
+// The Total field is intentionally 13 (Python's hard-coded literal) even though the list has 17
+// items — the frontend uses len(List), not Total. Order matches the Python source.
+func GetSessionsFilters() model.FilterSection {
+	str := []string{"string"}
+
+	// Country values: convert []string to []any.
+	countryValues := make([]any, 0, len(CountryCodes))
+	for _, c := range CountryCodes {
+		countryValues = append(countryValues, c)
+	}
+
+	// Issue values: golden shape is {id, name, autoCaptured} — only 3 of IssueType's 5 fields.
+	issueValues := make([]any, 0, len(IssueTypes))
+	for _, it := range IssueTypes {
+		issueValues = append(issueValues, map[string]any{
+			"id":           it.Type,
+			"name":         it.Name,
+			"autoCaptured": it.AutoCaptured,
+		})
+	}
+
+	deviceTypeValues := []any{"desktop", "mobile", "tablet"}
+
+	// mkEnum builds a StaticFilterItem for a named filter type.
+	// prefix is the ID namespace (e.g. "sf"); the helper appends "_" before def.EnumStr.
+	mkEnum := func(prefix string, def FilterTypeDef, display, dataType string, types []string, predefined, conditional bool, values []any) model.StaticFilterItem {
+		if values == nil {
+			values = []any{}
+		}
+		return model.StaticFilterItem{
+			ID:             StringToID(prefix + "_" + def.EnumStr),
+			Name:           def.Name,
+			DisplayName:    display,
+			PossibleTypes:  types,
+			DataType:       dataType,
+			AutoCaptured:   true,
+			IsPredefined:   predefined,
+			PossibleValues: values,
+			IsConditional:  conditional,
+		}
+	}
+
+	// mkLiteral builds a StaticFilterItem for filters without a FilterTypeDef enum
+	// (screenHeight, screenWidth). idInput is the full string passed to StringToID.
+	mkLiteral := func(idInput, name, display, dataType string, types []string, conditional bool) model.StaticFilterItem {
+		return model.StaticFilterItem{
+			ID:             StringToID(idInput),
+			Name:           name,
+			DisplayName:    display,
+			PossibleTypes:  types,
+			DataType:       dataType,
+			AutoCaptured:   true,
+			IsPredefined:   false,
+			PossibleValues: []any{},
+			IsConditional:  conditional,
+		}
+	}
+
+	list := []any{
+		mkEnum("sf", FTReferrer, "Referrer", "string", str, false, false, nil),
+		mkEnum("sf", FTDuration, "Duration", "int", []string{"int"}, false, true, nil),
+		mkEnum("sf", FTUTMSource, "UTM Source", "string", str, false, false, nil),
+		mkEnum("sf", FTUTMMedium, "UTM Medium", "string", str, false, false, nil),
+		mkEnum("sf", FTUTMCampaign, "UTM Campaign", "string", str, false, false, nil),
+		mkEnum("sf", FTUserCountry, "Country", "string", str, true, true, countryValues),
+		mkEnum("sf", FTUserCity, "City", "string", str, false, false, nil),
+		mkEnum("sf", FTUserState, "State / Province", "string", str, false, false, nil),
+		mkEnum("sf", FTUserOS, "OS", "string", str, false, true, nil),
+		mkEnum("sf", FTUserBrowser, "Browser", "string", str, false, true, nil),
+		mkEnum("sf", FTUserBrowserVersion, "Browser Version", "string", str, false, true, nil),
+		mkEnum("sf", FTUserDevice, "Device", "string", str, false, true, nil),
+		mkEnum("sf", FTUserDeviceType, "Device Type", "string", str, true, false, deviceTypeValues),
+		mkEnum("sf", FTRevID, "Version ID", "string", str, false, false, nil),
+		mkEnum("sf", FTIssue, "Issue", "string", str, true, false, issueValues),
+		mkLiteral("sf_screenHeight", "screenHeight", "Screen Height", "UInt16", []string{"UInt16"}, false),
+		mkLiteral("sf_screenWidth", "screenWidth", "Screen Width", "UInt16", []string{"UInt16"}, false),
+	}
+
+	return model.FilterSection{
+		Total:       13,
+		DisplayName: "Session Filters",
+		Scope:       []string{"sessions"},
+		List:        list,
+	}
+}
+
+// GetUsersFilters mirrors the Python get_user_filters() output.
+// Both entries use the "uf" prefix via FilterTypeDef enum strings.
+func GetUsersFilters() model.FilterSection {
+	str := []string{"string"}
+
+	mkEnum := func(prefix string, def FilterTypeDef, display, dataType string, types []string, predefined, conditional bool, values []any) model.StaticFilterItem {
+		if values == nil {
+			values = []any{}
+		}
+		return model.StaticFilterItem{
+			ID:             StringToID(prefix + "_" + def.EnumStr),
+			Name:           def.Name,
+			DisplayName:    display,
+			PossibleTypes:  types,
+			DataType:       dataType,
+			AutoCaptured:   true,
+			IsPredefined:   predefined,
+			PossibleValues: values,
+			IsConditional:  conditional,
+		}
+	}
+
+	list := []any{
+		mkEnum("uf", FTUserID, "User ID", "string", str, false, true, nil),
+		mkEnum("uf", FTDistinctID, "User Distinct ID", "string", str, false, true, nil),
+	}
+	return model.FilterSection{
+		Total:       2,
+		DisplayName: "User Filters",
+		Scope:       []string{"sessions"},
+		List:        list,
+	}
+}
+
+// GetUsersIdentifiedFilters mirrors the Python get_identified_users_filters() output.
+// IDs are computed via StringToID("uif_" + name) — not via FilterTypeDef enum strings.
+func GetUsersIdentifiedFilters() model.FilterSection {
+	type cfg struct {
+		name, display, dataType string
+		predefined              bool
+		values                  []any
+	}
+
+	countryValues := make([]any, 0, len(CountryCodes))
+	for _, c := range CountryCodes {
+		countryValues = append(countryValues, c)
+	}
+
+	rows := []cfg{
+		{"$user_id", "User ID", "string", false, nil},
+		{"$email", "Email", "string", false, nil},
+		{"$name", "Name", "string", false, nil},
+		{"$first_name", "First Name", "string", false, nil},
+		{"$last_name", "Last Name", "string", false, nil},
+		{"$phone", "Phone", "string", false, nil},
+		{"$sdk_edition", "SDK Edition", "string", false, nil},
+		{"$sdk_version", "SDK Version", "string", false, nil},
+		{"$current_url", "Current URL", "string", false, nil},
+		{"$current_path", "Current Path", "string", false, nil},
+		{"$initial_referrer", "Initial Referrer", "string", false, nil},
+		{"$referring_domain", "Referring Domain", "string", false, nil},
+		{"initial_utm_source", "Initial UTM Source", "string", false, nil},
+		{"initial_utm_medium", "Initial UTM Medium", "string", false, nil},
+		{"initial_utm_campaign", "Initial UTM Campaign", "string", false, nil},
+		{"$country", "Country", "string", true, countryValues},
+		{"$state", "State", "string", false, nil},
+		{"$city", "City", "string", false, nil},
+		{"$or_api_endpoint", "OR API Endpoint", "string", false, nil},
+		{"$created_at", "Created At", "timestamp", false, nil},
+		{"$first_event_at", "First Event At", "timestamp", false, nil},
+		{"$last_seen", "Last Seen", "timestamp", false, nil},
+	}
+
+	list := make([]any, 0, len(rows))
+	for _, r := range rows {
+		values := r.values
+		if values == nil {
+			values = []any{}
+		}
+		list = append(list, model.StaticFilterItem{
+			ID:             StringToID("uif_" + r.name),
+			Name:           r.name,
+			DisplayName:    r.display,
+			PossibleTypes:  []string{r.dataType},
+			DataType:       r.dataType,
+			AutoCaptured:   true,
+			IsPredefined:   r.predefined,
+			PossibleValues: values,
+			IsConditional:  false,
+		})
+	}
+
+	return model.FilterSection{
+		Total:       len(list),
+		DisplayName: "Identified User Filters",
+		Scope:       []string{"events", "users"},
+		List:        list,
+	}
+}

--- a/backend/pkg/analytics/filters_catalog/sessions.go
+++ b/backend/pkg/analytics/filters_catalog/sessions.go
@@ -89,8 +89,7 @@ func GetSessionsFilters() model.FilterSection {
 	}
 }
 
-// GetUsersFilters mirrors the Python get_user_filters() output.
-// Both entries use the "uf" prefix via FilterTypeDef enum strings.
+// GetUsersFilters mirrors the Python get_users_filters() output.
 func GetUsersFilters() model.FilterSection {
 	str := []string{"string"}
 
@@ -113,7 +112,6 @@ func GetUsersFilters() model.FilterSection {
 
 	list := []any{
 		mkEnum("uf", FTUserID, "User ID", "string", str, false, true, nil),
-		mkEnum("uf", FTDistinctID, "User Distinct ID", "string", str, false, true, nil),
 	}
 	return model.FilterSection{
 		Total:       2,

--- a/backend/pkg/analytics/saved_searches/saved_searches.go
+++ b/backend/pkg/analytics/saved_searches/saved_searches.go
@@ -28,12 +28,20 @@ const (
 	statsQueryTimeout    = 10 * time.Second
 )
 
+// SegmentsListItem is a lightweight projection used by the filters catalog.
+type SegmentsListItem struct {
+	SearchID string
+	Name     string
+	IsPublic bool
+}
+
 type SavedSearches interface {
 	Save(projectID int, userID uint64, req *model.SavedSearchRequest) (*model.SavedSearchResponse, error)
 	Get(projectID int, searchID string) (*model.SavedSearch, error)
 	List(ctx context.Context, projectID int, userID uint64, limit, offset int, sort, order string) ([]*model.SavedSearch, int, error)
 	Update(projectID int, userID uint64, searchID string, req *model.SavedSearchRequest) (*model.SavedSearchResponse, error)
 	Delete(projectID int, userID uint64, searchID string) error
+	ListForFilters(projectID, userID int) ([]SegmentsListItem, error)
 }
 
 type savedSearchesImpl struct {
@@ -376,6 +384,31 @@ func (s *savedSearchesImpl) Delete(projectID int, userID uint64, searchID string
 	}
 
 	return nil
+}
+
+func (s *savedSearchesImpl) ListForFilters(projectID, userID int) ([]SegmentsListItem, error) {
+	const q = `
+        SELECT search_id, name, is_public
+        FROM public.saved_searches
+        WHERE project_id = $1
+          AND deleted_at IS NULL
+          AND is_share = FALSE
+          AND (user_id = $2 OR is_public)
+        ORDER BY name`
+	rows, err := s.pgconn.Query(q, projectID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []SegmentsListItem
+	for rows.Next() {
+		var item SegmentsListItem
+		if err := rows.Scan(&item.SearchID, &item.Name, &item.IsPublic); err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
 }
 
 func (s *savedSearchesImpl) checkOwnership(ctx context.Context, projectID int, userID uint64, searchID, op string) error {

--- a/backend/pkg/api/builder.go
+++ b/backend/pkg/api/builder.go
@@ -224,7 +224,7 @@ func NewServiceBuilder(log logger.Logger, cfg *config.Config, webMetrics web.Web
 	}
 
 	filtersCatalogService := filtersCatalog.New(log, chconn, projects, savedSearchesService, tagAdminService)
-	filtersCatalogHandlers, err := filtersCatalogAPI.NewHandlers(log, requestHandler, filtersCatalogService, projects)
+	filtersCatalogHandlers, err := filtersCatalogAPI.NewHandlers(log, requestHandler, filtersCatalogService, projects, assistProxy)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/api/builder.go
+++ b/backend/pkg/api/builder.go
@@ -69,9 +69,8 @@ type serviceBuilder struct {
 }
 
 func (b *serviceBuilder) Handlers() []api.Handlers {
-	return []api.Handlers{b.sessionAPI, b.eventAPI, b.analyticsEventsAPI, b.favoriteAPI, b.noteAPI, b.replayAPI, b.apiKeyAPI, b.conditionsAPI,
-		b.chartsAPI, b.dashboardsAPI, b.cardsAPI, b.searchAPI, b.savedSearchesAPI, b.usersAPI, b.lexiconAPI, b.tagsAdminAPI,
-		b.filtersCatalogAPI}
+	return []api.Handlers{b.sessionAPI, b.eventAPI, b.filtersCatalogAPI, b.analyticsEventsAPI, b.favoriteAPI, b.noteAPI, b.replayAPI, b.apiKeyAPI, b.conditionsAPI,
+		b.chartsAPI, b.dashboardsAPI, b.cardsAPI, b.searchAPI, b.savedSearchesAPI, b.usersAPI, b.lexiconAPI, b.tagsAdminAPI}
 }
 
 func NewServiceBuilder(log logger.Logger, cfg *config.Config, webMetrics web.Web, pgconn pool.Pool, chconn clickhouse.Conn, chSessionFactory chdb.SessionFactory, objStore objectstorage.ObjectStorage, projects projects.Projects, canvases canvas.Canvases) (api.ServiceBuilder, error) {

--- a/backend/pkg/api/builder.go
+++ b/backend/pkg/api/builder.go
@@ -12,6 +12,8 @@ import (
 	"openreplay/backend/pkg/analytics/dashboards"
 	analyticsEvents "openreplay/backend/pkg/analytics/events"
 	analyticsEventsAPI "openreplay/backend/pkg/analytics/events/api"
+	filtersCatalog "openreplay/backend/pkg/analytics/filters_catalog"
+	filtersCatalogAPI "openreplay/backend/pkg/analytics/filters_catalog/api"
 	"openreplay/backend/pkg/analytics/lexicon"
 	lexiconAPI "openreplay/backend/pkg/analytics/lexicon/api"
 	"openreplay/backend/pkg/analytics/model"
@@ -63,11 +65,13 @@ type serviceBuilder struct {
 	usersAPI           api.Handlers
 	lexiconAPI         api.Handlers
 	tagsAdminAPI       api.Handlers
+	filtersCatalogAPI  api.Handlers
 }
 
 func (b *serviceBuilder) Handlers() []api.Handlers {
 	return []api.Handlers{b.sessionAPI, b.eventAPI, b.analyticsEventsAPI, b.favoriteAPI, b.noteAPI, b.replayAPI, b.apiKeyAPI, b.conditionsAPI,
-		b.chartsAPI, b.dashboardsAPI, b.cardsAPI, b.searchAPI, b.savedSearchesAPI, b.usersAPI, b.lexiconAPI, b.tagsAdminAPI}
+		b.chartsAPI, b.dashboardsAPI, b.cardsAPI, b.searchAPI, b.savedSearchesAPI, b.usersAPI, b.lexiconAPI, b.tagsAdminAPI,
+		b.filtersCatalogAPI}
 }
 
 func NewServiceBuilder(log logger.Logger, cfg *config.Config, webMetrics web.Web, pgconn pool.Pool, chconn clickhouse.Conn, chSessionFactory chdb.SessionFactory, objStore objectstorage.ObjectStorage, projects projects.Projects, canvases canvas.Canvases) (api.ServiceBuilder, error) {
@@ -219,6 +223,12 @@ func NewServiceBuilder(log logger.Logger, cfg *config.Config, webMetrics web.Web
 		return nil, err
 	}
 
+	filtersCatalogService := filtersCatalog.New(log, chconn, pgconn, projects, savedSearchesService, tagAdminService)
+	filtersCatalogHandlers, err := filtersCatalogAPI.NewHandlers(log, requestHandler, filtersCatalogService, projects)
+	if err != nil {
+		return nil, err
+	}
+
 	return &serviceBuilder{
 		sessionAPI:         sessionHandlers,
 		eventAPI:           eventHandlers,
@@ -236,5 +246,6 @@ func NewServiceBuilder(log logger.Logger, cfg *config.Config, webMetrics web.Web
 		usersAPI:           usersHandlers,
 		lexiconAPI:         lexiconHandlers,
 		tagsAdminAPI:       tagAdminHandlers,
+		filtersCatalogAPI:  filtersCatalogHandlers,
 	}, nil
 }

--- a/backend/pkg/api/builder.go
+++ b/backend/pkg/api/builder.go
@@ -223,7 +223,7 @@ func NewServiceBuilder(log logger.Logger, cfg *config.Config, webMetrics web.Web
 		return nil, err
 	}
 
-	filtersCatalogService := filtersCatalog.New(log, chconn, pgconn, projects, savedSearchesService, tagAdminService)
+	filtersCatalogService := filtersCatalog.New(log, chconn, projects, savedSearchesService, tagAdminService)
 	filtersCatalogHandlers, err := filtersCatalogAPI.NewHandlers(log, requestHandler, filtersCatalogService, projects)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/assist/proxy/assist.go
+++ b/backend/pkg/assist/proxy/assist.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +27,7 @@ type Assist interface {
 	GetLiveSessionByID(projID uint32, sessID uint64) (interface{}, error)
 	GetLiveSessionsWS(projID uint32, req *GetLiveSessionsRequest) (interface{}, error)
 	IsLive(projID uint32, sessID uint64) (bool, error)
+	Autocomplete(projID uint32, q, key string) ([]map[string]interface{}, error)
 }
 
 type assistImpl struct {
@@ -243,6 +245,97 @@ func (r *GetLiveSessionsRequest) Parse() *GetAssistSessionsPayload {
 		}
 	}
 	return res
+}
+
+func (a *assistImpl) Autocomplete(projID uint32, q, key string) ([]map[string]interface{}, error) {
+	if projID == 0 {
+		return nil, errors.New("projID is 0")
+	}
+	proj, err := a.projects.GetProject(projID)
+	if err != nil {
+		return nil, err
+	}
+	base := fmt.Sprintf(a.cfg.AssistUrl, a.cfg.AssistKey) + a.cfg.AssistListSuffix + "/" + proj.ProjectKey + "/autocomplete"
+	u, err := url.Parse(base)
+	if err != nil {
+		return nil, err
+	}
+	query := u.Query()
+	query.Set("q", q)
+	if key != "" {
+		query.Set("key", key)
+	}
+	u.RawQuery = query.Encode()
+
+	client := &http.Client{Timeout: a.cfg.AssistRequestTimeout}
+	resp, err := client.Get(u.String())
+	if err != nil {
+		return nil, fmt.Errorf("assist autocomplete request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("assist autocomplete returned status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read assist autocomplete response: %w", err)
+	}
+	var parsed struct {
+		Data []map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("parse assist autocomplete response: %w", err)
+	}
+	for _, r := range parsed.Data {
+		if t, ok := r["type"].(string); ok {
+			r["type"] = changeAssistKey(t)
+		}
+	}
+	return parsed.Data, nil
+}
+
+func changeAssistKey(key string) string {
+	switch strings.ToUpper(key) {
+	case "PAGETITLE":
+		return "pageTitle"
+	case "ACTIVE":
+		return "active"
+	case "LIVE":
+		return "live"
+	case "SESSIONID":
+		return "sessionId"
+	case "METADATA":
+		return "metadata"
+	case "USERID":
+		return "userId"
+	case "USERUUID":
+		return "userUuid"
+	case "PROJECTKEY":
+		return "projectKey"
+	case "REVID":
+		return "revId"
+	case "TIMESTAMP":
+		return "timestamp"
+	case "TRACKERVERSION":
+		return "trackerVersion"
+	case "ISSNIPPET":
+		return "isSnippet"
+	case "USEROS":
+		return "userOs"
+	case "USERBROWSER":
+		return "userBrowser"
+	case "USERBROWSERVERSION":
+		return "userBrowserVersion"
+	case "USERDEVICE":
+		return "userDevice"
+	case "USERDEVICETYPE":
+		return "userDeviceType"
+	case "USERCOUNTRY":
+		return "userCountry"
+	case "PROJECTID":
+		return "projectId"
+	}
+	return key
 }
 
 func (a *assistImpl) requestAssistData(assistURL string, payload []byte) (interface{}, error) {

--- a/backend/pkg/tags/admin/service.go
+++ b/backend/pkg/tags/admin/service.go
@@ -20,11 +20,22 @@ var (
 	ErrNoFieldsToUpdate = errors.New("no fields to update")
 )
 
+// TagsForFiltersItem is a lightweight projection used by the filters catalog.
+type TagsForFiltersItem struct {
+	TagID           int
+	Name            string
+	Selector        string
+	IgnoreClickRage bool
+	IgnoreDeadClick bool
+	Location        *string
+}
+
 type TagService interface {
 	Create(ctx context.Context, projectID uint32, req *CreateTagRequest) (int, error)
 	List(ctx context.Context, projectID uint32, limit, offset int) (*ListTagsResponse, error)
 	Update(ctx context.Context, projectID uint32, tagID int, req *UpdateTagRequest) error
 	Delete(ctx context.Context, projectID uint32, tagID int) error
+	ListForFilters(projectID int) ([]TagsForFiltersItem, error)
 }
 
 type tagServiceImpl struct {
@@ -210,4 +221,26 @@ func (s *tagServiceImpl) Delete(ctx context.Context, projectID uint32, tagID int
 		return fmt.Errorf("delete tag: %s", err)
 	}
 	return nil
+}
+
+func (s *tagServiceImpl) ListForFilters(projectID int) ([]TagsForFiltersItem, error) {
+	const q = `
+        SELECT tag_id, name, selector, ignore_click_rage, ignore_dead_click, location
+        FROM public.tags
+        WHERE project_id = $1 AND deleted_at IS NULL
+        ORDER BY name`
+	rows, err := s.pgconn.Query(q, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []TagsForFiltersItem
+	for rows.Next() {
+		var t TagsForFiltersItem
+		if err := rows.Scan(&t.TagID, &t.Name, &t.Selector, &t.IgnoreClickRage, &t.IgnoreDeadClick, &t.Location); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new v2 filters catalog endpoint with unified analytics filters and platform-aware fallbacks, plus event/property autocomplete to speed up filter building. Also removes an unused Postgres dependency.

- **New Features**
  - New endpoint GET `/{project}/filters` via `filters_catalog` returning eight sections: events, event properties, session, user, users (identified), metadata, segments, and features.
  - Events and properties pulled from ClickHouse with type simplification and platform-aware filtering; static catalogs for session/user filters, issue types, and country codes; metadata from project `metadata_1..10`; segments via `saved_searches.ListForFilters`; features via `tags.ListForFilters`.
  - Autocomplete endpoints GET `/{project}/events/autocomplete` and `/{project}/properties/autocomplete`, with optional `live=true` using the assist service and a 3-minute in-memory cache for common queries.

- **Refactors**
  - Removed unused Postgres pool field from the `filters_catalog` service and constructor; updated API builder wiring to register catalog and autocomplete handlers.

<sup>Written for commit 31508a99c250cca08dbff1c3d968e82db5aa3402. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

