### PR TITLE
dev

### DIFF
--- a/api/chalicelib/core/authorizers.py
+++ b/api/chalicelib/core/authorizers.py
@@ -27,6 +27,9 @@ def is_spot_token(token: str) -> bool:
 def jwt_authorizer(scheme: str, token: str, leeway=0) -> dict | None:
     if scheme.lower() != "bearer" or len(token) < 5:
         return None
+    if not token or token.count(".") != 2:
+        logger.debug("! JWT Malformed token")
+        return None
     try:
         payload = jwt.decode(jwt=token,
                              key=config("JWT_SECRET") if not is_spot_token(token) else config("JWT_SPOT_SECRET"),
@@ -47,6 +50,10 @@ def jwt_authorizer(scheme: str, token: str, leeway=0) -> dict | None:
 
 def jwt_refresh_authorizer(scheme: str, token: str):
     if scheme.lower() != "bearer":
+        return None
+    if not token or token.count(".") != 2:
+        logger.debug("! JWT-refresh Malformed token")
+        logger.debug(token)
         return None
     try:
         payload = jwt.decode(jwt=token,

--- a/api/chalicelib/core/events/events_ch.py
+++ b/api/chalicelib/core/events/events_ch.py
@@ -96,7 +96,7 @@ def extract_required_values(rows):
                 if _numeric_property_available(props, "load_event_end") \
                 else None
             row["domContentLoadedTime"] = int(props["dom_content_loaded_event_end"]) \
-                                          - int(props["dom_content_loaded_event_start"]) \
+                                          - int(props.get("dom_content_loaded_event_start", 0)) \
                 if "dom_content_loaded_event_end" in props and \
                    (isinstance(props["dom_content_loaded_event_end"], str) \
                     and props["dom_content_loaded_event_end"].isnumeric() \

--- a/api/requirements-alerts.txt
+++ b/api/requirements-alerts.txt
@@ -1,13 +1,13 @@
 urllib3==2.6.3
 requests==2.33.1
-boto3==1.43.0
+boto3==1.43.2
 pyjwt==2.12.1
 psycopg2-binary==2.9.12
-psycopg[pool,binary]==3.3.3
+psycopg[pool,binary]==3.3.4
 clickhouse-connect==0.15.1
 elasticsearch==9.3.0
 jira==3.10.5
-cachetools==7.0.6
+cachetools==7.1.1
 
 fastapi==0.136.1
 uvicorn[standard]==0.46.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,13 +1,13 @@
 urllib3==2.6.3
 requests==2.33.1
-boto3==1.43.0
+boto3==1.43.2
 pyjwt==2.12.1
 psycopg2-binary==2.9.12
-psycopg[pool,binary]==3.3.3
+psycopg[pool,binary]==3.3.4
 clickhouse-connect==0.15.1
 elasticsearch==9.3.0
 jira==3.10.5
-cachetools==7.0.6
+cachetools==7.1.1
 
 fastapi==0.136.1
 uvicorn[standard]==0.46.0

--- a/ee/api/auth/auth_jwt.py
+++ b/ee/api/auth/auth_jwt.py
@@ -19,6 +19,9 @@ def _get_current_auth_context(request: Request, jwt_payload: dict) -> schemas.Cu
     if user is None:
         logger.warning("User not found.")
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="User not found.")
+    if user.get("roleId") is None:
+        logger.warning("No assigned role to the user.")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="No assigned role to the user.")
     request.state.authorizer_identity = "jwt"
     request.state.currentContext = schemas.CurrentContext(tenantId=jwt_payload.get("tenantId", -1),
                                                           userId=jwt_payload.get("userId", -1),

--- a/ee/api/chalicelib/core/traces.py
+++ b/ee/api/chalicelib/core/traces.py
@@ -44,6 +44,7 @@ IGNORE_ROUTES = [
     {"method": ["*"], "path": re.compile("^/{projectId}/dashboard/.*")},
     {"method": ["*"], "path": re.compile("^/{projectId}/funnels$")},
     {"method": ["*"], "path": re.compile("^/{projectId}/funnels/.*")},
+    {"method": ["GET"], "path": "/limits"},
 ]
 IGNORE_IN_PAYLOAD = ["token", "password", "authorizationToken", "authHeader", "xQueryKey", "awsSecretAccessKey",
                      "serviceAccountCredentials", "accessKey", "applicationKey", "apiKey"]

--- a/ee/api/chalicelib/core/traces.py
+++ b/ee/api/chalicelib/core/traces.py
@@ -17,6 +17,7 @@ from schemas import CurrentContext
 
 IGNORE_ROUTES = [
     {"method": ["*"], "path": "/notifications"},
+    {"method": ["GET"], "path": "/notifications/count"},
     {"method": ["*"], "path": "/announcements"},
     {"method": ["*"], "path": "/client"},
     {"method": ["*"], "path": "/account"},

--- a/ee/api/requirements-alerts.txt
+++ b/ee/api/requirements-alerts.txt
@@ -1,13 +1,13 @@
 urllib3==2.6.3
 requests==2.33.1
-boto3==1.43.0
+boto3==1.43.2
 pyjwt==2.12.1
 psycopg2-binary==2.9.12
-psycopg[pool,binary]==3.3.3
+psycopg[pool,binary]==3.3.4
 clickhouse-connect==0.15.1
 elasticsearch==9.3.0
 jira==3.10.5
-cachetools==7.0.6
+cachetools==7.1.1
 
 fastapi==0.136.1
 uvicorn[standard]==0.46.0

--- a/ee/api/requirements-crons.txt
+++ b/ee/api/requirements-crons.txt
@@ -1,13 +1,13 @@
 urllib3==2.6.3
 requests==2.33.1
-boto3==1.43.0
+boto3==1.43.2
 pyjwt==2.12.1
 psycopg2-binary==2.9.12
-psycopg[pool,binary]==3.3.3
+psycopg[pool,binary]==3.3.4
 clickhouse-connect==0.15.1
 elasticsearch==9.3.0
 jira==3.10.5
-cachetools==7.0.6
+cachetools==7.1.1
 
 fastapi==0.136.1
 python-decouple==3.8

--- a/ee/api/requirements.txt
+++ b/ee/api/requirements.txt
@@ -1,13 +1,13 @@
 urllib3==2.6.3
 requests==2.33.1
-boto3==1.43.0
+boto3==1.43.2
 pyjwt==2.12.1
 psycopg2-binary==2.9.12
-psycopg[pool,binary]==3.3.3
+psycopg[pool,binary]==3.3.4
 clickhouse-connect==0.15.1
 elasticsearch==9.3.0
 jira==3.10.5
-cachetools==7.0.6
+cachetools==7.1.1
 
 fastapi==0.136.1
 uvicorn[standard]==0.46.0


### PR DESCRIPTION
- **refactor(chalice): upgraded dependencies**
- **fix(chalice): fixed open api**
- **refactor(chalice): refactored trace logs**
- **fix(chalice): check JWT token format before decoding**
- **refactor(chalice): refactored trace logs**
- **fix(chalice): check role before context creation**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened JWT auth and request tracing, fixed a DOM timing calculation, and updated dependencies for reliability.

- **Bug Fixes**
  - Validate JWT format (three segments) before decoding in both access and refresh authorizers.
  - Enforce role presence in EE auth; users without `roleId` get 403.
  - Handle missing `dom_content_loaded_event_start` when computing `domContentLoadedTime`.
  - Reduce trace noise by ignoring GET `/notifications/count` and `/limits`.

- **Dependencies**
  - Bumped `boto3` to 1.43.2, `psycopg[pool,binary]` to 3.3.4, and `cachetools` to 7.1.1 across `api` and `ee` requirement files.

<sup>Written for commit 4065cf2b1c577032a766a4b464a4b698762322c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

