### PR TITLE
assist: add backpressure var to chart

### DIFF
--- a/ee/assist/server.js
+++ b/ee/assist/server.js
@@ -45,7 +45,10 @@ const io = new Server({
 
 io.use(async (socket, next) => await authorizer.check(socket, next));
 io.on('connection', (socket) => onConnect(socket));
-io.attachApp(app);
+io.attachApp(app, {
+    maxBackpressure: process.env.MAX_BACKPRESSURE_KB
+    ? parseInt(process.env.MAX_BACKPRESSURE_KB) * 1024 : 256 * 1024 }
+);
 setSocketIOServer(io);
 
 const HOST = process.env.LISTEN_HOST || '0.0.0.0';

--- a/scripts/helmcharts/openreplay/charts/assist/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/assist/values.yaml
@@ -103,6 +103,9 @@ env:
   debug: 0
   redis: false
   CLEAR_SOCKET_TIME: 720
+  # Max bytes (in KB) uWebSockets.js will buffer per WebSocket before silently
+  # skipping outgoing messages. uWS default is 64 KB
+  MAX_BACKPRESSURE_KB: 128
   # Raise Node.js max HTTP header size from 16KB to 64KB.
   # WebSocket upgrade requests to /ws-assist carry a long URL (session metadata)
   # plus browser cookies and proxy headers that easily exceed the 16KB default,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose a tunable backpressure limit for the Assist WebSocket server to reduce silent message drops on slow or slow/bursty connections. Adds `MAX_BACKPRESSURE_KB` and wires it to `uWebSockets.js` via `Socket.IO`.

- **New Features**
  - Reads `MAX_BACKPRESSURE_KB` to set `maxBackpressure` in `io.attachApp`; fallback is 256 KB.
  - Helm chart sets `MAX_BACKPRESSURE_KB: 128` by default and documents uWS behavior.
  - Lets operators adjust buffering to balance delivery reliability vs. memory use.

<sup>Written for commit 363e6d87efc64e088bedf9d8a6eb0997dd1137e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

