### PR TITLE
ui: adjust in player shortcuts

### DIFF
--- a/frontend/app/components/Session/Player/ReplayPlayer/EventsBlock/UserCard/UserCard.js
+++ b/frontend/app/components/Session/Player/ReplayPlayer/EventsBlock/UserCard/UserCard.js
@@ -60,7 +60,7 @@ function UserCard({ className, width, height }) {
 
   React.useEffect(() => {
     const handler = (e) => {
-      if (e.shiftKey) {
+      if (e.shiftKey && !e.ctrlKey && !e.metaKey) {
         if (
           e.target instanceof HTMLInputElement ||
           e.target instanceof HTMLTextAreaElement

--- a/frontend/app/components/Session/Player/ReplayPlayer/useShortcuts.ts
+++ b/frontend/app/components/Session/Player/ReplayPlayer/useShortcuts.ts
@@ -53,7 +53,7 @@ function useShortcuts({
       ) {
         return false;
       }
-      if (e.shiftKey) {
+      if (e.shiftKey && !e.ctrlKey && !e.metaKey) {
         e.preventDefault();
         player.toggleInspectorMode(false);
         switch (e.key) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Limit Shift-based shortcuts to only fire when Shift is pressed alone, ignoring Ctrl/Cmd combos. This prevents conflicts with system/browser shortcuts and avoids accidental inspector toggling in the Replay Player and User Card.

<sup>Written for commit ccba7f85220583b22a6b77d7d56723fd8b15fdbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

