### PR TITLE
Updated patch build from main 9119e2719621adae8c8a709bb9dca485cc9eaeca

### DIFF
--- a/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.10
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.0"
+AppVersion: "v1.27.1"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump frontend Helm chart AppVersion from v1.27.0 to v1.27.1 to release the latest patch build and ensure deployments use the newest frontend version. Merging will trigger the tag update job to publish the chart.

<sup>Written for commit 0eda41d44a19c67e0f6d66c01ba46934813bffbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

