### PR TITLE
Main UI patches

### DIFF
--- a/frontend/app/components/DataManagement/Events/EventsList.tsx
+++ b/frontend/app/components/DataManagement/Events/EventsList.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react-lite';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+import SimpleEmptyImage from 'Components/DataManagement/SimpleEmptyImage';
 import { TextEllipsis } from 'UI';
 
 import FullPagination from 'Shared/FullPagination';
@@ -35,7 +36,7 @@ function EventsList({
   });
   const emptyState = (
     <Empty
-      image={Empty.PRESENTED_IMAGE_SIMPLE}
+      image={<SimpleEmptyImage />}
       description={
         <div className="flex flex-col items-center gap-2 pt-2">
           <div className="text-base font-medium">{t('No events')}</div>

--- a/frontend/app/components/DataManagement/Properties/ListPage.tsx
+++ b/frontend/app/components/DataManagement/Properties/ListPage.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useStore } from 'App/mstore';
 import { useHistory, useLocation } from 'App/routing';
+import SimpleEmptyImage from 'Components/DataManagement/SimpleEmptyImage';
 import { TextEllipsis } from 'UI';
 
 import FullPagination from 'Shared/FullPagination';
@@ -264,7 +265,7 @@ function EventPropsList({
   });
   const emptyState = (
     <Empty
-      image={Empty.PRESENTED_IMAGE_SIMPLE}
+      image={<SimpleEmptyImage />}
       description={
         <div className="flex flex-col items-center gap-2 pt-2">
           <div className="text-base font-medium">{t('No properties')}</div>
@@ -369,7 +370,7 @@ function UserPropsList({
   });
   const emptyState = (
     <Empty
-      image={Empty.PRESENTED_IMAGE_SIMPLE}
+      image={<SimpleEmptyImage />}
       description={
         <div className="flex flex-col items-center gap-2 pt-2">
           <div className="text-base font-medium">{t('No properties')}</div>

--- a/frontend/app/components/DataManagement/Segments/SegmentsList.tsx
+++ b/frontend/app/components/DataManagement/Segments/SegmentsList.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useStore } from 'App/mstore';
 import { sessions } from 'App/routes';
+import SimpleEmptyImage from 'Components/DataManagement/SimpleEmptyImage';
 import { CopyButton, TextEllipsis } from 'UI';
 
 import FullPagination from 'Shared/FullPagination';
@@ -168,7 +169,7 @@ function SegmentsList({
 
   const emptyState = (
     <Empty
-      image={Empty.PRESENTED_IMAGE_SIMPLE}
+      image={<SimpleEmptyImage />}
       description={
         <div className="flex flex-col items-center gap-3 pt-2">
           <div className="text-base font-medium">{t('No segments')}</div>

--- a/frontend/app/components/DataManagement/SimpleEmptyImage.tsx
+++ b/frontend/app/components/DataManagement/SimpleEmptyImage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import AnimatedSVG from 'Shared/AnimatedSVG';
+import { ICONS } from 'Shared/AnimatedSVG/AnimatedSVG';
+
+function SimpleEmptyImage() {
+  return <AnimatedSVG name={ICONS.NO_RESULTS} size={60} />;
+}
+
+export default SimpleEmptyImage;

--- a/frontend/app/components/DataManagement/Tags/index.tsx
+++ b/frontend/app/components/DataManagement/Tags/index.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { sessions, withSiteId } from 'App/routes';
 import { useHistory } from 'App/routing';
 import type { Tag } from 'App/services/TagWatchService';
+import SimpleEmptyImage from 'Components/DataManagement/SimpleEmptyImage';
 import { useModal } from 'Components/ModalContext';
 import { TextEllipsis } from 'UI';
 
@@ -25,7 +26,7 @@ function TagsPage() {
 
   const emptyState = (
     <Empty
-      image={Empty.PRESENTED_IMAGE_SIMPLE}
+      image={<SimpleEmptyImage />}
       description={
         <div className="flex flex-col items-center gap-3 pt-2">
           <div className="text-base font-medium">{t('No features')}</div>

--- a/frontend/app/components/DataManagement/UsersEvents/components/UsersList.tsx
+++ b/frontend/app/components/DataManagement/UsersEvents/components/UsersList.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { diffIfRecent } from 'App/date';
 import { useStore } from 'App/mstore';
 import ColumnsModal from 'Components/DataManagement/Activity/ColumnsModal';
+import SimpleEmptyImage from 'Components/DataManagement/SimpleEmptyImage';
 import { CountryFlag } from 'UI';
 
 import FilterListHeader from 'Shared/Filters/FilterList/FilterListHeader';
@@ -38,7 +39,7 @@ function UsersList({
 
   const emptyState = (
     <Empty
-      image={Empty.PRESENTED_IMAGE_SIMPLE}
+      image={<SimpleEmptyImage />}
       description={
         <div className="flex flex-col items-center gap-2 pt-2">
           <div className="text-base font-medium">{t('No users')}</div>

--- a/frontend/app/components/shared/Filters/FilterItem/FilterItem.tsx
+++ b/frontend/app/components/shared/Filters/FilterItem/FilterItem.tsx
@@ -14,6 +14,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { FilterKey } from 'App/types/filter/filterType';
 
 import { getIconForFilter } from 'Shared/Filters/FilterModal';
+import { getFilterDisplayCategory } from 'Shared/Filters/FilterModal/utils';
 
 import FilterOperator from '../FilterOperator';
 import FilterSelection from '../FilterSelection';
@@ -277,6 +278,9 @@ function FilterItem(props: Props) {
               isSubItem ? 'Properties' : filter.isEvent ? 'Events' : 'Filters'
             }
             scope={scope}
+            initialCategory={
+              filter?.category ? getFilterDisplayCategory(filter) : undefined
+            }
           >
             <Button
               type="default"
@@ -429,6 +433,7 @@ function FilterItem(props: Props) {
                 }
                 isFirst={index === 0}
                 isLast={isLast && index === filteredSubFilters.length - 1}
+                scope={(filter.scope?.[0] as Props['scope']) ?? scope}
               />
             </div>
           ))}

--- a/frontend/app/components/shared/Filters/FilterModal/FilterModal.tsx
+++ b/frontend/app/components/shared/Filters/FilterModal/FilterModal.tsx
@@ -30,7 +30,7 @@ function FilterModal({
   const { t } = useTranslation();
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedQuery = useDebounce(searchQuery);
-  const [category, setCategory] = useState('All');
+  const [category, setCategory] = useState(`All${type ? ` ${type}` : ''}`);
   const groupedFilters = useMemo(
     () => groupFiltersByCategory(filters),
     [filters],

--- a/frontend/app/components/shared/Filters/FilterModal/FilterModal.tsx
+++ b/frontend/app/components/shared/Filters/FilterModal/FilterModal.tsx
@@ -19,21 +19,28 @@ function FilterModal({
   filters = [],
   activeFilters = [],
   type,
+  initialCategory,
 }: {
   onFilterClick: (f: Filter) => void;
   filters: Filter[];
   activeFilters?: string[];
   type?: 'Events' | 'Filters' | 'Properties';
+  initialCategory?: string;
 }) {
   const eventModal = filters.every((f) => f.isEvent) || type === 'Events';
   const inputRef = React.useRef(null);
   const { t } = useTranslation();
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedQuery = useDebounce(searchQuery);
-  const [category, setCategory] = useState(`All${type ? ` ${type}` : ''}`);
+  const allCategoryLabel = `All${type ? ` ${type}` : ''}`;
   const groupedFilters = useMemo(
     () => groupFiltersByCategory(filters),
     [filters],
+  );
+  const [category, setCategory] = useState(
+    initialCategory && groupedFilters[initialCategory]
+      ? initialCategory
+      : allCategoryLabel,
   );
   const { matchingCategories, matchingFilters } = useMemo(
     () => getFilteredEntries(debouncedQuery, groupedFilters, type),

--- a/frontend/app/components/shared/Filters/FilterModal/utils.tsx
+++ b/frontend/app/components/shared/Filters/FilterModal/utils.tsx
@@ -38,17 +38,21 @@ export const getCategoryDisplayName = (category: string): string => {
   return category.charAt(0).toUpperCase() + category.slice(1);
 };
 
+export const getFilterCategoryKey = (filter: Filter): string =>
+  filter.autoCaptured && filter.category?.includes('event')
+    ? 'autocapture'
+    : filter.category || 'Other';
+
+export const getFilterDisplayCategory = (filter: Filter): string =>
+  getCategoryDisplayName(getFilterCategoryKey(filter));
+
 export const groupFiltersByCategory = (
   filters: Filter[],
 ): Record<string, Filter[]> => {
   if (!filters?.length) return {};
   return filters.reduce(
     (acc, filter) => {
-      const key =
-        filter.autoCaptured && filter.category.includes('event')
-          ? 'autocapture'
-          : filter.category || 'Other';
-      const cat = getCategoryDisplayName(key);
+      const cat = getFilterDisplayCategory(filter);
       (acc[cat] ||= []).push(filter);
       return acc;
     },

--- a/frontend/app/components/shared/Filters/FilterSelection/FilterSelection.tsx
+++ b/frontend/app/components/shared/Filters/FilterSelection/FilterSelection.tsx
@@ -17,6 +17,7 @@ interface FilterSelectionProps {
   disabled?: boolean;
   loading?: boolean;
   type?: 'Events' | 'Filters' | 'Properties';
+  initialCategory?: string;
 }
 
 const FilterSelection: React.FC<FilterSelectionProps> = observer(
@@ -28,6 +29,7 @@ const FilterSelection: React.FC<FilterSelectionProps> = observer(
     loading = false,
     activeFilters,
     type,
+    initialCategory,
   }) => {
     const [open, setOpen] = useState(false);
 
@@ -83,9 +85,10 @@ const FilterSelection: React.FC<FilterSelectionProps> = observer(
             onFilterClick={handleFilterClick}
             filters={filters}
             type={type}
+            initialCategory={initialCategory}
           />
         ),
-      [loading, filters, handleFilterClick],
+      [loading, filters, handleFilterClick, initialCategory],
     );
 
     const isDisabled = disabled || loading;

--- a/frontend/app/components/shared/Filters/FilterValue/ValueAutoComplete.tsx
+++ b/frontend/app/components/shared/Filters/FilterValue/ValueAutoComplete.tsx
@@ -163,13 +163,12 @@ const ValueAutoComplete = observer(
     const mappedTopValues: OptionType[] = useMemo(() => {
       return topValues
         .filter(
-          (i): i is { value: string; rowPercentage: number } =>
-            typeof i.value === 'string',
+          (i): i is TopValue & { value: string } => typeof i.value === 'string',
         )
         .sort((a, b) => (b.rowPercentage ?? 0) - (a.rowPercentage ?? 0))
         .map((i) => ({
           value: i.value,
-          label: i.value,
+          label: i.label ?? i.name ?? i.value,
           percentage: i.rowPercentage,
         }));
     }, [topValues]);
@@ -265,7 +264,7 @@ const ValueAutoComplete = observer(
           const _options =
             safeData.map((i: any) => ({
               value: i.value,
-              label: i.value,
+              label: i.label ?? i.name ?? i.value,
               percentage: i.rowPercentage ?? 0,
             })) || [];
           setOptions(_options);

--- a/frontend/app/layout/AlertsBanner.tsx
+++ b/frontend/app/layout/AlertsBanner.tsx
@@ -1,18 +1,17 @@
-import React from 'react';
-import { Alert, Button } from 'antd';
+import { Button } from 'antd';
+import { TriangleAlert } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
+import React from 'react';
+
 import { useStore } from 'App/mstore';
 
-const levelToType: Record<
-  string,
-  'success' | 'info' | 'warning' | 'error'
-> = {
-  alert: 'error',
-  error: 'error',
-  warning: 'warning',
-  warn: 'warning',
-  info: 'info',
-  success: 'success',
+const levelToBg: Record<string, string> = {
+  alert: 'bg-red-light',
+  error: 'bg-red-light',
+  warning: 'bg-yellow',
+  warn: 'bg-yellow',
+  info: 'bg-light-blue-bg',
+  success: 'bg-green-light',
 };
 
 function AlertsBanner() {
@@ -23,27 +22,27 @@ function AlertsBanner() {
   return (
     <>
       {alerts.map((alert, idx) => {
-        const type = levelToType[alert.level?.toLowerCase() ?? ''] ?? 'info';
-        const action =
-          alert.button && alert.url ? (
-            <Button
-              size="small"
-              onClick={() =>
-                window.open(alert.url, '_blank', 'noopener,noreferrer')
-              }
-            >
-              {alert.button}
-            </Button>
-          ) : null;
+        const bgClass =
+          levelToBg[alert.level?.toLowerCase() ?? ''] ?? levelToBg.info;
         return (
-          <Alert
+          <div
             key={idx}
-            message={alert.text}
-            type={type}
-            showIcon
-            banner
-            action={action}
-          />
+            className={`px-4 py-2 flex items-center justify-center gap-3 w-full ${bgClass}`}
+          >
+            <TriangleAlert className="text-red" size={16} strokeWidth={2} />
+            <div className="font-bold">{alert.text}</div>
+            {alert.button && alert.url ? (
+              <Button
+                size="small"
+                type="primary"
+                onClick={() =>
+                  window.open(alert.url, '_blank', 'noopener,noreferrer')
+                }
+              >
+                {alert.button}
+              </Button>
+            ) : null}
+          </div>
         );
       })}
     </>

--- a/frontend/app/mstore/filterStore.ts
+++ b/frontend/app/mstore/filterStore.ts
@@ -1,6 +1,6 @@
 import { countries } from '@/constants';
 import { projectStore } from '@/mstore/index';
-import { makeAutoObservable, runInAction } from 'mobx';
+import { makeAutoObservable, reaction, runInAction } from 'mobx';
 
 import { filterService, searchService } from 'App/services';
 import { arraysIntersect, normalizeDataType } from 'App/utils';
@@ -67,6 +67,18 @@ export default class FilterStore {
   constructor() {
     makeAutoObservable(this);
     this.initCommonFilters();
+
+    reaction(
+      () => projectStore.activeSiteId,
+      (newId, prevId) => {
+        if (newId !== prevId) {
+          runInAction(() => {
+            this.clearCache();
+            this.topValues = {};
+          });
+        }
+      },
+    );
   }
 
   // getEventOptions = (siteId: string): FilterOption[] => {

--- a/frontend/app/mstore/filterStore.ts
+++ b/frontend/app/mstore/filterStore.ts
@@ -23,6 +23,8 @@ export interface TopValue {
   rowCount?: number;
   rowPercentage?: number;
   value?: string;
+  label?: string;
+  name?: string;
 }
 
 export interface TopValues {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refreshed empty states and account alerts, and improved filter selection usability with smarter defaults and richer autocomplete labels.

- **New Features**
  - Added `SimpleEmptyImage` for consistent empty-state icons across Events, Properties, Segments, Tags, and Users lists.
  - Filter modal now defaults to a type-aware “All” category and accepts `initialCategory`; filter items pass category and preserve scope for subfilters.
  - Autocomplete uses `label`/`name` when available for filter values, not just the raw value.
  - Replaced `antd` `Alert` with a custom banner using `lucide-react` `TriangleAlert`, with level-based background styles and an optional CTA button.

- **Bug Fixes**
  - Clear filter cache and top values when `projectStore.activeSiteId` changes to prevent stale event property suggestions.

<sup>Written for commit 13e5f94dd83bbd761a42650d1dee99a113cb2c1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

