### PR TITLE
Updated patch build from main 9aaab9700bfba4b4cacd5d2b57fbf9271196b778

### DIFF
--- a/scripts/helmcharts/openreplay/charts/alerts/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/alerts/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.0"
+AppVersion: "v1.27.1"

--- a/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.0"
+AppVersion: "v1.27.1"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `AppVersion` for the `alerts` and `chalice` Helm charts from v1.27.0 to v1.27.1 to ship the latest patch build. Merging will trigger the tag update job.

<sup>Written for commit 1a06578e044a7cd81edae04c75331abbdebcc922. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

