### PR TITLE
assist: fix msize error

### DIFF
--- a/ee/assist/app/socket.js
+++ b/ee/assist/app/socket.js
@@ -251,6 +251,7 @@ async function onAny(socket, eventName, ...args) {
             }
         }
         const batch = Array.isArray(args[0]?.data) ? args[0].data.length : '?';
+        const messageSize = JSON.stringify(args[0]).length;
         logger.debug(`ev=${eventName} from=${socket.id}/${socket.handshake.query.identity} room=${room} recipients=[${recipients.join(',')}] batch=${batch} size:${messageSize}`);
         sendFrom(socket, room, eventName, args[0]);
         for (const a of agentSockets) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add message size calculation to the socket `onAny` handler and include it in the debug log to address the "msize" error and make payload sizes visible during debugging. No changes to message routing behavior.

<sup>Written for commit e2ba17f7a743016f5204a0233f84b5a9a790e1d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

