### PR TITLE
Updated patch build from main e29c92ec6f04bbbca02baaa1e125718206d73181

### DIFF
--- a/scripts/helmcharts/openreplay/charts/assist/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/assist/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.2"
+AppVersion: "v1.27.3"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `assist` Helm chart `AppVersion` from v1.27.2 to v1.27.3 so Helm deployments pull the latest patch release.

<sup>Written for commit 9612276932e8c9aec0803dc5ff3177520549abc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

