### PR TITLE
fix(chalice): fixed payload validation

### DIFF
--- a/api/schemas/schemas.py
+++ b/api/schemas/schemas.py
@@ -895,6 +895,8 @@ class SessionsSearchPayloadSchema(_TimedSchema, _PaginatedSchema):
     @classmethod
     def remove_wrong_filter_values(cls, values):
         for f in values.get("filters", []):
+            if not isinstance(f, dict):
+                continue
             vals = []
             for v in f.get("value", []):
                 if f.get("name", "") == FilterType.DURATION.value and v is None:

--- a/ee/api/chalicelib/core/traces.py
+++ b/ee/api/chalicelib/core/traces.py
@@ -91,7 +91,8 @@ async def write_traces_batch(traces: List[TraceSchema]):
         cur.execute(
             cur.mogrify(
                 f"""INSERT INTO traces(user_id, tenant_id, created_at, auth, action, method, path_format, endpoint, payload, parameters, status)
-                    VALUES {" , ".join(values)};""",
+                    VALUES {" , ".join(values)}
+                    ON CONFLICT DO NOTHING;""",
                 params)
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened request payload validation by skipping non-dict filter entries and made trace batch writes resilient by ignoring duplicate inserts.

- **Bug Fixes**
  - Ignore non-dict items in `filters` during validation to prevent crashes on malformed payloads.
  - Add `ON CONFLICT DO NOTHING` to `traces` batch insert to avoid duplicate-key errors.

<sup>Written for commit 68567e4b9b8c99035aed8b09140f131a9a2dd200. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

