### PR TITLE
Updated patch build from main 2ac362b175709b995e0aee1d2940f7a91bfe15ef

### DIFF
--- a/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.1"
+AppVersion: "v1.27.2"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `AppVersion` in the `openreplay/charts/chalice` Helm chart from v1.27.1 to v1.27.2 to release the latest patch build and keep the chart in sync. Merging triggers the automated tag update job.

<sup>Written for commit 84b98805b78ff8858995e2ae66ab78d922ed5aae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

