### PR TITLE
ui: skip properties from filters, add source to autocomplete

### DIFF
--- a/frontend/app/components/shared/Filters/FilterValue/FilterValue.tsx
+++ b/frontend/app/components/shared/Filters/FilterValue/FilterValue.tsx
@@ -87,6 +87,7 @@ function FilterValue(props: Props) {
       autoCaptured: filter.autoCaptured,
       possibleValues: filter.possibleValues,
       isPredefined: filter.isPredefined,
+      category: filter.category.toLowerCase(),
     };
 
     if (filter.isEvent || eventName) {

--- a/frontend/app/components/shared/Filters/FilterValue/ValueAutoComplete.tsx
+++ b/frontend/app/components/shared/Filters/FilterValue/ValueAutoComplete.tsx
@@ -244,6 +244,7 @@ const ValueAutoComplete = observer(
             q: trimmedQuery,
             ac: params.autoCaptured,
             live: isLive,
+            source: params.category?.toLowerCase(),
           };
 
           if (params.propertyName) {

--- a/frontend/app/mstore/filterStore.ts
+++ b/frontend/app/mstore/filterStore.ts
@@ -148,6 +148,7 @@ export default class FilterStore {
       if (page) {
         params['scope'] = page;
       }
+      params['source'] = filter.category?.toLowerCase();
       params.ac = filter.autoCaptured;
 
       const response = await searchService.fetchTopValues(params);
@@ -474,7 +475,10 @@ export default class FilterStore {
 
     Object.entries(data).forEach(([category, categoryData]) => {
       const { list = [] } = categoryData || {};
-
+      if (category === 'event') {
+        // skip event properties
+        return;
+      }
       const customScope = categoryData.scope;
       if (category === 'events') {
         const autoCaptured = list.filter(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip event properties in filters and add a `source` param (from the filter category) to autocomplete requests to improve suggestion relevance.

- **Bug Fixes**
  - Exclude event properties when building filter lists.

- **New Features**
  - Send `source` (lowercased `category`) with top-values and autocomplete requests to scope results.
  - Pass the lowercased `category` through `FilterValue` into `ValueAutoComplete`.

<sup>Written for commit a280722d2ff954139c7aff457b3832a29d3ab5eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

