### PR TITLE
Updated patch build from main 399493aae3b624bfae97e83d8d5ef83e3121212f

### DIFF
--- a/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.10
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.2"
+AppVersion: "v1.27.3"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the OpenReplay frontend Helm chart AppVersion from v1.27.2 to v1.27.3 to release the latest patch build. Merging this will trigger the automated tag update job.

<sup>Written for commit b47bda726d5068cb002a24dd51b94920675824dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

