### PR TITLE
revert: return autocomplete category

### DIFF
--- a/frontend/app/mstore/filterStore.ts
+++ b/frontend/app/mstore/filterStore.ts
@@ -475,10 +475,7 @@ export default class FilterStore {
 
     Object.entries(data).forEach(([category, categoryData]) => {
       const { list = [] } = categoryData || {};
-      if (category === 'event') {
-        // skip event properties
-        return;
-      }
+
       const customScope = categoryData.scope;
       if (category === 'events') {
         const autoCaptured = list.filter(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores filter autocomplete for the `event` category by processing it like other categories. Users now see `event` properties in suggestions again.

<sup>Written for commit 7cab715acb6629bb7c3b3408e245550acd3c9095. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

