### PR TITLE
Updated patch build from main b1774ba0e01057ca604ebaaf1749ec68591b0a2a

### DIFF
--- a/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.10
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.3"
+AppVersion: "v1.27.4"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `openreplay` frontend Helm chart AppVersion from v1.27.3 to v1.27.4 so deployments use the latest patch build. Merging will trigger the tag update job to publish the chart.

<sup>Written for commit 611459914c32f516f0359f285887d58855e16920. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

