### PR TITLE
refactor(chalice): changed autocomplete to use source instead of scope

### DIFF
--- a/api/routers/subs/product_analytics.py
+++ b/api/routers/subs/product_analytics.py
@@ -116,7 +116,7 @@ def autocomplete_properties(
         propertyName: str,
         eventName: Optional[str] = None,
         userId: Optional[str] = None,
-        scope: Optional[str] = None,
+        source: Optional[str] = None,
         q: Optional[str] = None,
         ac: bool = Query(description="auto captured"),
         live: bool = False,
@@ -124,6 +124,13 @@ def autocomplete_properties(
 ):
     if live:
         return assist.autocomplete(project_id=projectId, q=q, key=propertyName)
+    scope = None
+    if source == "session" or source == "sessions":
+        scope = "sessions"
+    elif source == "event" or source == "events":
+        scope = "events"
+    elif source == "user" or source == "users":
+        scope = "users"
     # Auto-captured properties should be transformed from camelCase to snake_case
     if ac:
         propertyName = helper.key_to_snake_case(propertyName)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactors the product analytics autocomplete endpoint to use a `source` query param instead of `scope`, aligning terminology across the API. Accepts singular/plural values (`session(s)`, `event(s)`, `user(s)`) and maps them to internal scopes; live mode behavior is unchanged.

<sup>Written for commit fb15d6ef21c36d59cc93a9383860c66c5ceb6e15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

