### PR TITLE
Updated patch build from main e28f6ba3b769078a7b56bc5ae61e4a3c86f6f4c3

### DIFF
--- a/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.2"
+AppVersion: "v1.27.3"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `openreplay/charts/chalice` Helm chart AppVersion from v1.27.2 to v1.27.3 to publish the latest patch. After merge, the tag update job will run automatically.

<sup>Written for commit 27881b8ec25f73683596f66b2f4fd40e55bbb1b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

