### PR TITLE
fix(chalice): autocomplete fix to support sessions attributes with di…

### DIFF
--- a/api/routers/subs/product_analytics.py
+++ b/api/routers/subs/product_analytics.py
@@ -125,7 +125,9 @@ def autocomplete_properties(
     if live:
         return assist.autocomplete(project_id=projectId, q=q, key=propertyName)
     scope = None
-    if source == "session" or source == "sessions":
+    if source == "session" or source == "sessions" \
+            or source == "metadata" or source == "metadatas" \
+            or (source == "user" or source == "users") and not propertyName.startswith("$"):
         scope = "sessions"
     elif source == "event" or source == "events":
         scope = "events"


### PR DESCRIPTION
…fferent sources

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes product analytics autocomplete so session attributes resolve correctly when using different source names. Prevents empty or wrong suggestions for session properties.

- **Bug Fixes**
  - Map `metadata`/`metadatas` to the `sessions` scope.
  - Map `user`/`users` to `sessions` when the property does not start with `$`.
  - Keep `event`/`events` mapped to `events` as before.

<sup>Written for commit 04e9690ee03ae84bf8274fd3569e816c644f4665. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

