### PR TITLE
chore(cert-manager): add install crds

### DIFF
--- a/scripts/helmcharts/certmanager.sh
+++ b/scripts/helmcharts/certmanager.sh
@@ -32,5 +32,5 @@ sudo sed -i "s/email: .*/email: \"${EMAIL_ADDRESS}\"/g" clusterIssuer.yaml
 info "Installing cert-manager for auto letsencrypt certificate"
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
-helm upgrade --install cert-manager --namespace cert-manager --version v1.20.0 jetstack/cert-manager --create-namespace
+helm upgrade --install cert-manager --namespace cert-manager --version v1.20.0 jetstack/cert-manager --create-namespace --set crds.enabled=true
 kubectl apply -f clusterIssuer.yaml


### PR DESCRIPTION
This removes the error one will get on install when running the script `bash certmanager.sh`:

```bash
kubectl apply -f clusterIssuer.yaml
error: resource mapping not found for name: "letsencrypt-prod" namespace: "" from "clusterIssuer.yaml": no matches for kind "ClusterIssuer" in version "cert-manager.io/v1" ensure CRDs are installed first
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install cert-manager CRDs during Helm install to prevent the “no matches for kind ClusterIssuer” error when running the setup script.

Adds `--set crds.enabled=true` to the `jetstack/cert-manager` Helm command in `certmanager.sh`.

<sup>Written for commit 16481bbeccac62f65de43272119e743b28798c81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

