### PR TITLE
Updated patch build from main f24955f64c6e23fe354fd28129eb31bea0b9937b

### DIFF
--- a/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.4"
+AppVersion: "v1.27.5"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `openreplay/chalice` Helm chart AppVersion to v1.27.5 to align with the latest patch build from main. Merging will trigger the tag update job to publish the chart.

<sup>Written for commit 939ad4965d1161e2eceb34b4a094da996a3ec184. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

