### PR TITLE
refactor(chalice): removed distinct_id

### DIFF
--- a/api/chalicelib/core/product_analytics/filters.py
+++ b/api/chalicelib/core/product_analytics/filters.py
@@ -251,17 +251,17 @@ def get_users_filters(project_id: int):
                 "possibleValues": [],
                 "isConditional": True
             },
-            {
-                "id": helper.string_to_id(f'uf_{schemas.FilterType.DISTINCT_ID}'),
-                "name": schemas.FilterType.DISTINCT_ID,
-                "displayName": "User Distinct ID",
-                "possibleTypes": ["string"],
-                "dataType": "string",
-                "autoCaptured": True,
-                "isPredefined": False,
-                "possibleValues": [],
-                "isConditional": True
-            },
+            # {
+            #     "id": helper.string_to_id(f'uf_{schemas.FilterType.DISTINCT_ID}'),
+            #     "name": schemas.FilterType.DISTINCT_ID,
+            #     "displayName": "User Distinct ID",
+            #     "possibleTypes": ["string"],
+            #     "dataType": "string",
+            #     "autoCaptured": True,
+            #     "isPredefined": False,
+            #     "possibleValues": [],
+            #     "isConditional": True
+            # },
             # {
             #     "id": helper.string_to_id(f'uf_{schemas.FilterType.USER_ANONYMOUS_ID}'),
             #     "name": schemas.FilterType.USER_ANONYMOUS_ID,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the `DISTINCT_ID` user filter from product analytics so it no longer appears in the users filter list. This aligns the filters with the current data model and prevents selecting an unsupported field.

<sup>Written for commit a9a89f955060310906b79b6ed52d3dd396dede3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

