### PR TITLE
Updated patch build from main 83b620519dbeadd6beba73fde47beb8c56827476

### DIFF
--- a/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.5"
+AppVersion: "v1.27.6"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the `openreplay/charts/chalice` Helm chart AppVersion from v1.27.5 to v1.27.6 to publish the latest patch build. Merging this PR will trigger the tag update job automatically.

<sup>Written for commit bacfde0d57dfbdd094aae6c8a4b9dbd32faf518a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

