### PR TITLE
Patch api v1.27.0

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -50,6 +50,11 @@ func main() {
 		return chConnection.Ping(ctx)
 	})
 
+	chSessionFactory, err := clickhouse.NewSessionFactory(cfg.Clickhouse)
+	if err != nil {
+		log.Fatal(ctx, "can't init clickhouse session factory: %s", err)
+	}
+
 	objStore, err := store.NewStore(&cfg.ObjectsConfig)
 	if err != nil {
 		log.Fatal(ctx, "can't init object storage: %s", err)
@@ -65,7 +70,7 @@ func main() {
 		log.Fatal(ctx, "can't init project service: %s", err)
 	}
 
-	services, err := apiService.NewServiceBuilder(log, cfg, webMetrics, pgPool, chConnection, objStore, projects, canvases)
+	services, err := apiService.NewServiceBuilder(log, cfg, webMetrics, pgPool, chConnection, chSessionFactory, objStore, projects, canvases)
 	if err != nil {
 		log.Fatal(ctx, "can't init services and handlers: %s", err)
 	}

--- a/backend/pkg/analytics/charts/charts.go
+++ b/backend/pkg/analytics/charts/charts.go
@@ -10,6 +10,7 @@ import (
 
 	"openreplay/backend/pkg/analytics/lexicon"
 	"openreplay/backend/pkg/analytics/model"
+	chdb "openreplay/backend/pkg/db/clickhouse"
 	"openreplay/backend/pkg/logger"
 )
 
@@ -18,15 +19,17 @@ type Charts interface {
 }
 
 type chartsImpl struct {
-	chConn     driver.Conn
-	Logger     logger.Logger
-	filterRefs []lexicon.FilterRef
+	chConn        driver.Conn
+	chSessionConn chdb.SessionFactory
+	Logger        logger.Logger
+	filterRefs    []lexicon.FilterRef
 }
 
-func New(logger logger.Logger, chConn driver.Conn, segments lexicon.Segments) (Charts, error) {
+func New(logger logger.Logger, chConn driver.Conn, chSessionConn chdb.SessionFactory, segments lexicon.Segments) (Charts, error) {
 	return &chartsImpl{
-		chConn: chConn,
-		Logger: logger,
+		chConn:        chConn,
+		chSessionConn: chSessionConn,
+		Logger:        logger,
 		filterRefs: []lexicon.FilterRef{
 			lexicon.NewSegmentFilterRef(segments),
 		},
@@ -53,7 +56,7 @@ func (s *chartsImpl) GetData(ctx context.Context, projectId int, userID uint64, 
 		s.Logger.Error(ctx, "Error validating payload", zap.Error(err))
 		return nil, fmt.Errorf("error validating payload: %v", err)
 	}
-	qb, err := NewQueryBuilder(s.Logger, payload)
+	qb, err := NewQueryBuilder(s.Logger, payload, s.chSessionConn)
 	if err != nil {
 		s.Logger.Error(ctx, "Error creating query builder", zap.Error(err))
 		return nil, fmt.Errorf("error creating query builder: %v", err)

--- a/backend/pkg/analytics/charts/metric_table.go
+++ b/backend/pkg/analytics/charts/metric_table.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 
 	"openreplay/backend/pkg/analytics/model"
+	chdb "openreplay/backend/pkg/db/clickhouse"
 )
 
 var validMetricOfValues = map[MetricOfTable]struct{}{
@@ -29,7 +30,8 @@ var validMetricOfValues = map[MetricOfTable]struct{}{
 }
 
 type TableQueryBuilder struct {
-	Logger logger.Logger
+	Logger      logger.Logger
+	SessionConn chdb.SessionFactory
 }
 
 type TableValue struct {
@@ -129,7 +131,7 @@ func (t *TableQueryBuilder) Execute(ctx context.Context, p *Payload, conn driver
 	seriesKey := SeriesKey(p.Name, p.MetricOf)
 	return WrapInSeries(seriesKey, &TableResponse{Total: valuesCount, Count: overallCount, Values: rawValues}), nil
 }
-func (t *TableQueryBuilder) executeForTableOfResolutions(ctx context.Context, p *Payload, conn driver.Conn) (interface{}, error) {
+func (t *TableQueryBuilder) executeForTableOfResolutions(ctx context.Context, p *Payload, _ driver.Conn) (interface{}, error) {
 	queries, params, err := t.buildTableOfResolutionsQuery(p)
 	if err != nil {
 		return nil, fmt.Errorf("error building screenResolution queries: %w", err)
@@ -137,6 +139,22 @@ func (t *TableQueryBuilder) executeForTableOfResolutions(ctx context.Context, p 
 	if len(queries) == 0 {
 		return nil, fmt.Errorf("No queries to execute for table of resolutions")
 	}
+
+	// Q1 creates a CLICKHOUSE TEMPORARY TABLE that Q2 reads from. Temp-table
+	// lifetime is bound to a single TCP session, so we acquire a dedicated
+	// 1-conn handle here instead of using the shared pool.
+	if t.SessionConn == nil {
+		return nil, fmt.Errorf("screenResolution table requires a clickhouse session factory")
+	}
+	conn, err := t.SessionConn()
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire pinned clickhouse connection: %w", err)
+	}
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			t.Logger.Warn(ctx, "failed to close screenResolution clickhouse session: %s", cerr)
+		}
+	}()
 
 	chCtx := clickhouse.Context(context.Background(), clickhouse.WithQueryID(uuid.NewString()))
 

--- a/backend/pkg/analytics/charts/metric_table.go
+++ b/backend/pkg/analytics/charts/metric_table.go
@@ -265,7 +265,7 @@ func (t *TableQueryBuilder) buildQuery(r *Payload) (string, map[string]any, erro
 
 	numBreakdowns := len(r.Breakdowns)
 
-	var sessionsSelect []string = []string{"session_id", "user_id", "events_count"}
+	var sessionsSelect []string = []string{"session_id", "user_id", "greatest(1, events_count) AS events_count"}
 	if numBreakdowns > 0 {
 		sessionsSelect = append(sessionsSelect, GetTableBreakdownProjection(r.Breakdowns)...)
 	}
@@ -457,11 +457,14 @@ func (t *TableQueryBuilder) buildTableOfResolutionsQuery(r *Payload) ([]string, 
 
 	//Determine aggregation column&function
 	main_column := "session_id"
+	mainProjection := "session_id"
 	countFunction := "count(DISTINCT %s)"
 	if r.MetricFormat == MetricFormatUserCount {
 		main_column = "user_id"
+		mainProjection = "user_id"
 	} else if r.MetricFormat == MetricFormatEventCount {
-		main_column = "events_count"
+		main_column = "greatest(1, events_count)"
+		mainProjection = "greatest(1, events_count) AS events_count"
 		countFunction = "sum(%s)"
 	}
 	countFunction = fmt.Sprintf(countFunction, main_column)
@@ -497,7 +500,7 @@ CREATE TEMPORARY TABLE base_%[1]v AS (
        			  LIMIT 1 BY session_id
        			  %[4]v) AS raw
 			GROUP BY ALL);`,
-			tableKey, main_column, strings.Join(queryConditions, " AND "), joinClause, joinEvents, countFunction),
+			tableKey, mainProjection, strings.Join(queryConditions, " AND "), joinClause, joinEvents, countFunction),
 			fmt.Sprintf(`
 SELECT CAST(full_count AS UInt64) AS full_count,
        CAST(number_of_rows AS UInt64)       AS number_of_rows,

--- a/backend/pkg/analytics/charts/metric_user_journey.go
+++ b/backend/pkg/analytics/charts/metric_user_journey.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/google/uuid"
+
+	chdb "openreplay/backend/pkg/db/clickhouse"
 )
 
 // Node represents a point in the journey diagram.
@@ -74,10 +76,11 @@ var PredefinedJourneys = map[string]JourneyStep{
 }
 
 type UserJourneyQueryBuilder struct {
-	Logger logger.Logger
+	Logger      logger.Logger
+	SessionConn chdb.SessionFactory
 }
 
-func (h *UserJourneyQueryBuilder) Execute(ctx context.Context, p *Payload, conn driver.Conn) (interface{}, error) {
+func (h *UserJourneyQueryBuilder) Execute(ctx context.Context, p *Payload, _ driver.Conn) (interface{}, error) {
 	queries, err := h.buildQuery(p)
 	if err != nil {
 		return nil, err
@@ -85,6 +88,23 @@ func (h *UserJourneyQueryBuilder) Execute(ctx context.Context, p *Payload, conn 
 	if len(queries) == 0 {
 		return nil, fmt.Errorf("No queries to execute for userJourney")
 	}
+
+	// Q1/Q2 create CLICKHOUSE TEMPORARY TABLES whose lifetime is bound to a single
+	// TCP session. The shared pool may dispatch each statement on a different
+	// connection, so we acquire a dedicated 1-conn handle here and run all three
+	// queries through it.
+	if h.SessionConn == nil {
+		return nil, fmt.Errorf("userJourney requires a clickhouse session factory")
+	}
+	conn, err := h.SessionConn()
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire pinned clickhouse connection: %w", err)
+	}
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			h.Logger.Warn(ctx, "failed to close userJourney clickhouse session: %s", cerr)
+		}
+	}()
 
 	chCtx := clickhouse.Context(context.Background(), clickhouse.WithQueryID(uuid.NewString()))
 

--- a/backend/pkg/analytics/charts/query.go
+++ b/backend/pkg/analytics/charts/query.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 
 	"openreplay/backend/pkg/analytics/model"
+	chdb "openreplay/backend/pkg/db/clickhouse"
 )
 
 const (
@@ -39,7 +40,7 @@ type QueryBuilder interface {
 	Execute(ctx context.Context, p *Payload, conn driver.Conn) (interface{}, error)
 }
 
-func NewQueryBuilder(logger logger.Logger, p *Payload) (QueryBuilder, error) {
+func NewQueryBuilder(logger logger.Logger, p *Payload, sessionConn chdb.SessionFactory) (QueryBuilder, error) {
 	switch p.MetricType {
 	case MetricTypeTimeseries:
 		return &TimeSeriesQueryBuilder{Logger: logger}, nil
@@ -49,13 +50,13 @@ func NewQueryBuilder(logger logger.Logger, p *Payload) (QueryBuilder, error) {
 		if p.MetricOf == "jsException" {
 			return &TableErrorsQueryBuilder{Logger: logger}, nil
 		}
-		return &TableQueryBuilder{Logger: logger}, nil
+		return &TableQueryBuilder{Logger: logger, SessionConn: sessionConn}, nil
 	case MetricTypeHeatmap:
 		return &HeatmapSessionQueryBuilder{Logger: logger}, nil
 	case MetricTypeSession:
 		return &HeatmapQueryBuilder{Logger: logger}, nil
 	case MetricUserJourney:
-		return &UserJourneyQueryBuilder{Logger: logger}, nil
+		return &UserJourneyQueryBuilder{Logger: logger, SessionConn: sessionConn}, nil
 	case MetricWebVitals:
 		return WebVitalsQueryBuilder{Logger: logger}, nil
 	default:

--- a/backend/pkg/api/builder.go
+++ b/backend/pkg/api/builder.go
@@ -20,16 +20,17 @@ import (
 	"openreplay/backend/pkg/analytics/users"
 	usersAPI "openreplay/backend/pkg/analytics/users/api"
 	"openreplay/backend/pkg/api_key"
-	"openreplay/backend/pkg/jobs"
 	"openreplay/backend/pkg/assist/proxy"
 	"openreplay/backend/pkg/canvas"
 	"openreplay/backend/pkg/conditions"
 	conditionsApi "openreplay/backend/pkg/conditions/projects_api"
+	chdb "openreplay/backend/pkg/db/clickhouse"
 	"openreplay/backend/pkg/db/postgres/pool"
 	"openreplay/backend/pkg/events"
 	eventAPI "openreplay/backend/pkg/events/api"
 	"openreplay/backend/pkg/favorite"
 	favoriteAPI "openreplay/backend/pkg/favorite/api"
+	"openreplay/backend/pkg/jobs"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/metrics/web"
 	"openreplay/backend/pkg/notes"
@@ -69,7 +70,7 @@ func (b *serviceBuilder) Handlers() []api.Handlers {
 		b.chartsAPI, b.dashboardsAPI, b.cardsAPI, b.searchAPI, b.savedSearchesAPI, b.usersAPI, b.lexiconAPI, b.tagsAdminAPI}
 }
 
-func NewServiceBuilder(log logger.Logger, cfg *config.Config, webMetrics web.Web, pgconn pool.Pool, chconn clickhouse.Conn, objStore objectstorage.ObjectStorage, projects projects.Projects, canvases canvas.Canvases) (api.ServiceBuilder, error) {
+func NewServiceBuilder(log logger.Logger, cfg *config.Config, webMetrics web.Web, pgconn pool.Pool, chconn clickhouse.Conn, chSessionFactory chdb.SessionFactory, objStore objectstorage.ObjectStorage, projects projects.Projects, canvases canvas.Canvases) (api.ServiceBuilder, error) {
 	responser := api.NewResponser(webMetrics)
 
 	reqValidator := validator.New()
@@ -192,7 +193,7 @@ func NewServiceBuilder(log logger.Logger, cfg *config.Config, webMetrics web.Web
 		return nil, err
 	}
 
-	chartsService, err := charts.New(log, chconn, segmentsService)
+	chartsService, err := charts.New(log, chconn, chSessionFactory, segmentsService)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/db/clickhouse/connection.go
+++ b/backend/pkg/db/clickhouse/connection.go
@@ -15,7 +15,13 @@ import (
 	"openreplay/backend/internal/config/common"
 )
 
-func NewConnection(cfg common.Clickhouse) (driver.Conn, error) {
+// SessionFactory returns a fresh single-connection ClickHouse handle bound to one
+// physical TCP session. Callers MUST close the returned conn when done — typically
+// with `defer conn.Close()`. Use this when a sequence of statements depends on
+// session-scoped state (e.g. CREATE TEMPORARY TABLE).
+type SessionFactory func() (driver.Conn, error)
+
+func buildNativeOptions(cfg common.Clickhouse) (*clickhouse.Options, error) {
 	tlsConfig, err := buildTLSConfig(cfg)
 	if err != nil {
 		return nil, err
@@ -47,8 +53,16 @@ func NewConnection(cfg common.Clickhouse) (driver.Conn, error) {
 			Method: clickhouse.CompressionLZ4,
 		}
 	}
-	var conn driver.Conn
-	if conn, err = clickhouse.Open(opts); err != nil {
+	return opts, nil
+}
+
+func NewConnection(cfg common.Clickhouse) (driver.Conn, error) {
+	opts, err := buildNativeOptions(cfg)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := clickhouse.Open(opts)
+	if err != nil {
 		return nil, err
 	}
 	if err := conn.Ping(context.Background()); err != nil {
@@ -58,7 +72,25 @@ func NewConnection(cfg common.Clickhouse) (driver.Conn, error) {
 		}
 		return nil, err
 	}
-	return conn, err
+	return conn, nil
+}
+
+// NewSessionFactory returns a factory that opens a fresh 1-connection ClickHouse
+// handle on each call. The handle's pool caps (MaxOpenConns/MaxIdleConns = 1)
+// guarantee every statement executed against it lands on the same TCP session,
+// which is required for `CREATE TEMPORARY TABLE` workflows where a later query
+// must see a table created by an earlier one. Callers own the returned conn and
+// must Close() it.
+func NewSessionFactory(cfg common.Clickhouse) (SessionFactory, error) {
+	opts, err := buildNativeOptions(cfg)
+	if err != nil {
+		return nil, err
+	}
+	opts.MaxOpenConns = 1
+	opts.MaxIdleConns = 1
+	return func() (driver.Conn, error) {
+		return clickhouse.Open(opts)
+	}, nil
 }
 func NewSqlDBConnection(cfg common.Clickhouse) (*sqlx.DB, error) {
 	tlsConfig, err := buildTLSConfig(cfg)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes flaky analytics queries that rely on ClickHouse temporary tables by running them on a single sticky session. Also ensures event-based metrics never report zero by clamping to at least 1.

- **Bug Fixes**
  - User journey and screen-resolution table queries now execute on one ClickHouse session using a new `SessionFactory`, so temp tables persist across statements.
  - Event-count aggregations use `greatest(1, events_count)` to avoid zero-count sessions.

- **Refactors**
  - Added `SessionFactory` and `NewSessionFactory` in `backend/pkg/db/clickhouse`, and threaded it through `main`, API service builder, and `charts` (constructor and query builders).
  - Adjusted queries and projections for temp-table flow and ensured session connections are closed with warnings on error.

<sup>Written for commit c8313c68449c1ee988ce2893911555d4cfaa1c60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

