### PR TITLE
refactor(DB): v1.28.0 PG changes

### DIFF
--- a/ee/scripts/schema/db/init_dbs/postgresql/1.28.0/1.28.0.sql
+++ b/ee/scripts/schema/db/init_dbs/postgresql/1.28.0/1.28.0.sql
@@ -20,6 +20,7 @@ $fn_def$, :'next_version')
 --
 
 DROP TABLE IF EXISTS public.errors_tags;
+DROP TABLE IF EXISTS public.user_favorite_errors;
 DROP TABLE IF EXISTS events.errors;
 DROP TABLE IF EXISTS public.errors;
 DROP TYPE IF EXISTS error_source;

--- a/scripts/schema/db/init_dbs/postgresql/1.28.0/1.28.0.sql
+++ b/scripts/schema/db/init_dbs/postgresql/1.28.0/1.28.0.sql
@@ -20,6 +20,7 @@ $fn_def$, :'next_version')
 --
 
 DROP TABLE IF EXISTS public.errors_tags;
+DROP TABLE IF EXISTS public.user_favorite_errors;
 DROP TABLE IF EXISTS events.errors;
 DROP TABLE IF EXISTS public.errors;
 DROP TYPE IF EXISTS error_source;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update PostgreSQL 1.28.0 init scripts to drop the `public.user_favorite_errors` table, ensuring a clean schema and preventing migration conflicts. Applied to both OSS and EE scripts to keep them in sync.

<sup>Written for commit 9e83332c780626fd83d442d7769ca92df8317f6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

