### PR TITLE
Dbipnote

### DIFF
--- a/frontend/app/components/Session/Player/ReplayPlayer/EventsBlock/UserCard/UserCard.js
+++ b/frontend/app/components/Session/Player/ReplayPlayer/EventsBlock/UserCard/UserCard.js
@@ -117,7 +117,6 @@ function UserCard({ className, width, height }) {
             <span className="mx-1 font-bold text-xl">&#183;</span>
             {userCity && <span className="mr-1">{userCity},</span>}
             <span>{countries[userCountry]}</span>
-            <DbIPNotice className="ml-1" />
             <span className="mx-1 font-bold text-xl">&#183;</span>
             <span>
               {userBrowser ? `${capitalize(userBrowser)}, ` : ''}
@@ -133,9 +132,13 @@ function UserCard({ className, width, height }) {
                     comp={<CountryFlag country={userCountry} height={11} />}
                     label={countries[userCountry]}
                     value={
-                      <span style={{ whiteSpace: 'nowrap' }}>
+                      <span
+                        className="inline-flex items-center"
+                        style={{ whiteSpace: 'nowrap' }}
+                      >
                         {userCity && <span className="mr-1">{userCity},</span>}
                         {userState && <span className="mr-1">{userState}</span>}
+                        <DbIPNotice className="ml-1" />
                       </span>
                     }
                   />

--- a/frontend/app/components/Session/Player/ReplayPlayer/EventsBlock/UserCard/UserCard.js
+++ b/frontend/app/components/Session/Player/ReplayPlayer/EventsBlock/UserCard/UserCard.js
@@ -3,7 +3,7 @@ import { countries } from 'App/constants';
 import { useStore } from 'App/mstore';
 import { browserIcon, osIcon, deviceTypeIcon } from 'App/iconNames';
 import { formatTimeOrDate } from 'App/date';
-import { Avatar, TextEllipsis, CountryFlag, Icon, Tooltip } from 'UI';
+import { Avatar, TextEllipsis, CountryFlag, DbIPNotice, Icon, Tooltip } from 'UI';
 import cn from 'classnames';
 import { withRequest } from 'HOCs';
 import SessionInfoItem from 'Components/Session_/SessionInfoItem';
@@ -117,6 +117,7 @@ function UserCard({ className, width, height }) {
             <span className="mx-1 font-bold text-xl">&#183;</span>
             {userCity && <span className="mr-1">{userCity},</span>}
             <span>{countries[userCountry]}</span>
+            <DbIPNotice className="ml-1" />
             <span className="mx-1 font-bold text-xl">&#183;</span>
             <span>
               {userBrowser ? `${capitalize(userBrowser)}, ` : ''}

--- a/frontend/app/components/shared/SessionItem/SessionItem.tsx
+++ b/frontend/app/components/shared/SessionItem/SessionItem.tsx
@@ -1,8 +1,9 @@
+import { Tooltip } from 'antd';
 import cn from 'classnames';
 import { Duration } from 'luxon';
 import { observer } from 'mobx-react-lite';
-import React, { useState, useCallback, useMemo } from 'react';
-import { RouteComponentProps, useHistory, withRouter } from 'App/routing';
+import React, { useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { durationFormatted, formatTimeOrDate } from 'App/date';
 import { useStore } from 'App/mstore';
@@ -12,16 +13,15 @@ import {
   liveSession,
   sessions as sessionsRoute,
 } from 'App/routes';
+import { RouteComponentProps, useHistory, withRouter } from 'App/routing';
 import { capitalize } from 'App/utils';
-import { Avatar, CountryFlag, DbIPNotice, Icon, Label, TextEllipsis } from 'UI';
+import { Avatar, CountryFlag, Icon, Label, TextEllipsis } from 'UI';
 
 import Counter from './Counter';
 import ErrorBars from './ErrorBars';
 import PlayLink from './PlayLink';
 import SessionMetaList from './SessionMetaList';
 import stl from './sessionItem.module.css';
-import { useTranslation } from 'react-i18next';
-import { Tooltip } from 'antd';
 
 const ASSIST_ROUTE = assistRoute();
 const ASSIST_LIVE_SESSION = liveSession();
@@ -405,7 +405,6 @@ function SessionItem(props: RouteComponentProps & Props) {
                   country={userCountry}
                   showLabel={true}
                 />
-                <DbIPNotice className="ml-1" />
               </div>
               <div className="flex items-center text-sm text-neutral-500">
                 {userBrowser && (

--- a/frontend/app/components/shared/SessionItem/SessionItem.tsx
+++ b/frontend/app/components/shared/SessionItem/SessionItem.tsx
@@ -13,7 +13,7 @@ import {
   sessions as sessionsRoute,
 } from 'App/routes';
 import { capitalize } from 'App/utils';
-import { Avatar, CountryFlag, Icon, Label, TextEllipsis } from 'UI';
+import { Avatar, CountryFlag, DbIPNotice, Icon, Label, TextEllipsis } from 'UI';
 
 import Counter from './Counter';
 import ErrorBars from './ErrorBars';
@@ -395,13 +395,17 @@ function SessionItem(props: RouteComponentProps & Props) {
                 slim ? 'gap-1' : 'gap-2',
               )}
             >
-              <div style={{ height: slim ? undefined : '21px' }}>
+              <div
+                style={{ height: slim ? undefined : '21px' }}
+                className="flex items-center"
+              >
                 <CountryFlag
                   userCity={userCity}
                   userState={userState}
                   country={userCountry}
                   showLabel={true}
                 />
+                <DbIPNotice className="ml-1" />
               </div>
               <div className="flex items-center text-sm text-neutral-500">
                 {userBrowser && (

--- a/frontend/app/components/ui/CountryFlag/CountryFlag.tsx
+++ b/frontend/app/components/ui/CountryFlag/CountryFlag.tsx
@@ -41,7 +41,7 @@ const CountryFlag: FC<CountryFlagProps> = ({
 
   const renderGeoInfo = displayGeoInfo && (
     <span className="mx-1">
-      <TextEllipsis text={displayGeoInfo} maxWidth="150px" />
+      <TextEllipsis text={displayGeoInfo} maxWidth="300px" />
     </span>
   );
 

--- a/frontend/app/components/ui/CountryFlag/DbIPNotice.tsx
+++ b/frontend/app/components/ui/CountryFlag/DbIPNotice.tsx
@@ -7,26 +7,23 @@ interface Props {
   className?: string;
 }
 
-const DbIPNotice = () => null;
-
-// saas only for now
-// const DbIPNotice: React.FC<Props> = ({ size = 14, className = '' }) => (
-//   <Tooltip
-//     title={
-//       <a
-//         href="https://db-ip.com"
-//         target="_blank"
-//         rel="noopener noreferrer"
-//         style={{ color: 'inherit', textDecoration: 'underline' }}
-//       >
-//         Geolocation by DB-IP
-//       </a>
-//     }
-//   >
-//     <span className={`inline-flex items-center ${className}`}>
-//       <Icon name="info-circle" size={size} />
-//     </span>
-//   </Tooltip>
-// );
+const DbIPNotice: React.FC<Props> = ({ size = 8, className = '' }) => (
+  <Tooltip
+    title={
+      <a
+        href="https://db-ip.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ color: 'inherit', textDecoration: 'underline' }}
+      >
+        Geolocation by DB-IP
+      </a>
+    }
+  >
+    <span className={`inline-flex items-center ${className}`}>
+      <Icon name="info-circle" size={size} />
+    </span>
+  </Tooltip>
+);
 
 export default DbIPNotice;

--- a/frontend/app/components/ui/CountryFlag/DbIPNotice.tsx
+++ b/frontend/app/components/ui/CountryFlag/DbIPNotice.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Tooltip } from 'antd';
+import { Icon } from 'UI';
+
+interface Props {
+  size?: number;
+  className?: string;
+}
+
+const DbIPNotice = () => null;
+
+// saas only for now
+// const DbIPNotice: React.FC<Props> = ({ size = 14, className = '' }) => (
+//   <Tooltip
+//     title={
+//       <a
+//         href="https://db-ip.com"
+//         target="_blank"
+//         rel="noopener noreferrer"
+//         style={{ color: 'inherit', textDecoration: 'underline' }}
+//       >
+//         Geolocation by DB-IP
+//       </a>
+//     }
+//   >
+//     <span className={`inline-flex items-center ${className}`}>
+//       <Icon name="info-circle" size={size} />
+//     </span>
+//   </Tooltip>
+// );
+
+export default DbIPNotice;

--- a/frontend/app/components/ui/index.js
+++ b/frontend/app/components/ui/index.js
@@ -21,6 +21,7 @@ export { default as Tabs } from './Tabs';
 export { default as Notification } from './Notification';
 export { default as JSONTree } from './JSONTree';
 export { default as CountryFlag } from './CountryFlag';
+export { default as DbIPNotice } from './CountryFlag/DbIPNotice';
 export { default as confirm, MountPoint } from './Confirmation';
 export { default as SideMenuitem } from './SideMenuItem';
 export { default as Avatar } from './Avatar';

--- a/tracker/tracker/src/webworker/QueueSender.ts
+++ b/tracker/tracker/src/webworker/QueueSender.ts
@@ -137,7 +137,7 @@ export default class QueueSender {
       }
     }
 
-    fetch(`${this.ingestURL}?batch=${this.pageNo ?? 'noPageNum'}_${batchNumStr ?? 'noBatchNum'}`, {
+    fetch(`${this.ingestURL}?batch=${this.pageNo ?? 'noPageNum'}_${batchNumStr ?? 'noBatchNum'}&keepalive=${useKeepalive ? 'yes' : 'no'}`, {
       // @ts-ignore
       body: batch,
       method: 'POST',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a small DB‑IP attribution tooltip to the user location in the Replay Player and improves how long locations are displayed. Also appends a `keepalive` query flag to tracker batch requests for easier debugging.

- **New Features**
  - Adds `DbIPNotice` info icon next to city/state in the Player with a tooltip linking to DB‑IP.

- **Refactors**
  - Increases `CountryFlag` geo text max width to 300px for longer locations.
  - Aligns the location row in the session list and tidies imports.
  - Appends `keepalive` param to tracker batch POST URL based on `useKeepalive`.

<sup>Written for commit 787fb8f03280ff8b1837d647f748c4b427635718. Summary will update on new commits. <a href="https://cubic.dev/pr/openreplay/openreplay/pull/4624?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

