### PR TITLE
Updated patch build from main 3f748ca15395a320a905b955815d4851bdcb2980

### DIFF
--- a/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.10
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.5"
+AppVersion: "v1.27.6"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the frontend Helm chart AppVersion from v1.27.5 to v1.27.6 to pick up the latest patch build. New deployments will use the updated frontend image.

<sup>Written for commit ba54e2086469177ed73fd967b8151f9c2fc3171f. Summary will update on new commits. <a href="https://cubic.dev/pr/openreplay/openreplay/pull/4625?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

