### PR TITLE
fix(search): tags search default to autoCapture and nested

### DIFF
--- a/backend/pkg/analytics/charts/query.go
+++ b/backend/pkg/analytics/charts/query.go
@@ -83,6 +83,8 @@ var propertyKeyMap = map[string]filterConfig{
 	"FETCHSTATUSCODE": {LogicalProperty: "status", IsNumeric: true, InDProperties: true, InProperties: false},
 	//	For some reason, the code is looking for property-name 'url_path' like event name
 	"URL_PATH": {LogicalProperty: "$current_path", InDProperties: false, InProperties: false},
+	"TAGID":    {LogicalProperty: "tag_id", IsNumeric: true, InDProperties: true, InProperties: false},
+	"TAG_ID":   {LogicalProperty: "tag_id", IsNumeric: true, InDProperties: true, InProperties: false},
 }
 
 // The list of event filters that are represented by columns in the events table


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed tags search to default to autoCapture and nested filters by mapping TAGID and TAG_ID to the numeric tag_id property in the analytics query map. This makes tag filters work correctly in autoCapture and nested property searches.

<sup>Written for commit 8c3d57ed8a74c452cb724e14b706f6731f979efb. Summary will update on new commits. <a href="https://cubic.dev/pr/openreplay/openreplay/pull/4631?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

