### PR TITLE
fix(tracker-assist): declare types entry for ESM consumers

### DIFF
--- a/tracker/tracker-assist/package.json
+++ b/tracker/tracker-assist/package.json
@@ -11,6 +11,7 @@
   "author": "Aleksandr K <alex@openreplay.com>",
   "license": "MIT",
   "type": "module",
+  "types": "./lib/index.d.ts",
   "main": "./lib/index.js",
   "scripts": {
     "tsrun": "tsc",


### PR DESCRIPTION
## Problem

Under modern TypeScript / tsgo (Go-rewritten compiler), packages with `"type": "module"` and no explicit `"types"` field fail to resolve types because the legacy sibling-`.d.ts` fallback is being removed.

The `@openreplay/tracker-assist` package currently has no `"types"` field, causing TypeScript consumers to see type resolution issues as tsgo tightens its module resolution.

## Fix

One line added to `tracker/tracker-assist/package.json`:
```json
"types": "./lib/index.d.ts"
```

Points at the `.d.ts` declaration file the package already ships in `lib/`.

## Impact

- No behavioral change — pure manifest fix
- TypeScript / tsgo consumers can now resolve types deterministically

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an explicit types entry to `@openreplay/tracker-assist` so ESM TypeScript consumers resolve declarations correctly under modern TypeScript/tsgo. Sets "types": "./lib/index.d.ts"; no runtime or API changes.

<sup>Written for commit 3de1b54bd34b219153ad3858ce2fcf58ccb06aca. Summary will update on new commits. <a href="https://cubic.dev/pr/openreplay/openreplay/pull/4633?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

