### PR TITLE
refactor(DB): changed CH-events sort keys

### DIFF
--- a/ee/scripts/schema/db/init_dbs/clickhouse/create/init_schema.sql
+++ b/ee/scripts/schema/db/init_dbs/clickhouse/create/init_schema.sql
@@ -308,7 +308,7 @@ CREATE TABLE IF NOT EXISTS product_analytics.events
     _deleted_at                 DateTime DEFAULT '1970-01-01 00:00:00',
     _timestamp                  DateTime DEFAULT now()
 ) ENGINE = ReplacingMergeTree(_timestamp)
-      ORDER BY (project_id, "$event_name", created_at, session_id)
+      ORDER BY (project_id, session_id, "$event_name", created_at, event_id)
       TTL _deleted_at + INTERVAL 1 DAY DELETE WHERE _deleted_at != '1970-01-01 00:00:00' AND NOT is_vault
       SETTINGS allow_experimental_json_type = 1, enable_json_type = 1;
 

--- a/scripts/schema/db/init_dbs/clickhouse/create/init_schema.sql
+++ b/scripts/schema/db/init_dbs/clickhouse/create/init_schema.sql
@@ -292,7 +292,7 @@ CREATE TABLE IF NOT EXISTS product_analytics.events
     _deleted_at                 DateTime DEFAULT '1970-01-01 00:00:00',
     _timestamp                  DateTime DEFAULT now()
 ) ENGINE = ReplacingMergeTree(_timestamp)
-      ORDER BY (project_id, "$event_name", created_at, session_id)
+      ORDER BY (project_id, session_id, "$event_name", created_at, event_id)
       TTL _deleted_at + INTERVAL 1 DAY DELETE WHERE _deleted_at != '1970-01-01 00:00:00'
       SETTINGS allow_experimental_json_type = 1, enable_json_type = 1;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reordered ClickHouse sort keys for the `product_analytics.events` table to prioritize `session_id` and add `event_id`. This improves session-based query performance and avoids unintended dedup in `ReplacingMergeTree`.

- **Refactors**
  - Changed ORDER BY to `(project_id, session_id, "$event_name", created_at, event_id)`.
  - Updated both `ee/` and `scripts/` init schemas.

- **Migration**
  - New deployments get this automatically.
  - Existing clusters: recreate the table with the new ORDER BY (create new table, insert from old, then swap/rename).

<sup>Written for commit cf261b00b4dec3cd11cda05736bc3e25219fcc54. Summary will update on new commits. <a href="https://cubic.dev/pr/openreplay/openreplay/pull/4634?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

