### PR TITLE
Updated patch build from main 29509544d6a7b6a123b3752f196a40729af581d5

### DIFF
--- a/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/chalice/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.6"
+AppVersion: "v1.27.7"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `chalice` Helm chart `AppVersion` from v1.27.6 to v1.27.7. Aligns the chart with the latest patch build and triggers the tag update job on merge.

<sup>Written for commit b2b7aa37e9e1c2bb17040016864110513f6c87cb. Summary will update on new commits. <a href="https://cubic.dev/pr/openreplay/openreplay/pull/4638?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

