### PR TITLE
refactor(chalice): refactored JWT token validation

### DIFF
--- a/api/chalicelib/core/authorizers.py
+++ b/api/chalicelib/core/authorizers.py
@@ -16,6 +16,8 @@ def get_supported_audience():
 
 def is_spot_token(token: str) -> bool:
     try:
+        if len(token) < 5 or "." not in token:
+            return False
         decoded_token = jwt.decode(token, options={"verify_signature": False, "verify_exp": False})
         audience = decoded_token.get("aud")
         return audience == spot.AUDIENCE
@@ -25,7 +27,7 @@ def is_spot_token(token: str) -> bool:
 
 
 def jwt_authorizer(scheme: str, token: str, leeway=0) -> dict | None:
-    if scheme.lower() != "bearer" or len(token) < 5:
+    if scheme.lower() != "bearer" or len(token) < 5 or "." not in token:
         return None
     if not token or token.count(".") != 2:
         logger.debug("! JWT Malformed token")
@@ -49,7 +51,7 @@ def jwt_authorizer(scheme: str, token: str, leeway=0) -> dict | None:
 
 
 def jwt_refresh_authorizer(scheme: str, token: str):
-    if scheme.lower() != "bearer":
+    if scheme.lower() != "bearer" or len(token) < 5 or "." not in token:
         return None
     if not token or token.count(".") != 2:
         logger.debug("! JWT-refresh Malformed token")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened JWT validation to reject malformed tokens early and avoid unnecessary decode attempts.
Added checks for bearer scheme, minimum length, and presence of '.' before decoding in is_spot_token, jwt_authorizer, and jwt_refresh_authorizer.

<sup>Written for commit fbd35951743b3b2b5fc9a17dbdb08189064ebf3e. Summary will update on new commits. <a href="https://cubic.dev/pr/openreplay/openreplay/pull/4639?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

