### PR TITLE
fix(api): return 404 for missing sessions on replay endpoints

### DIFF
--- a/backend/pkg/assist/proxy/assist.go
+++ b/backend/pkg/assist/proxy/assist.go
@@ -15,9 +15,12 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 
 	"openreplay/backend/internal/config/api"
+	"openreplay/backend/pkg/db/postgres"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/projects"
 )
+
+var ErrNoLiveSession = errors.New("no live session")
 
 type Assist interface {
 	GetLiveSessionByID(projID uint32, sessID uint64) (interface{}, error)
@@ -58,41 +61,45 @@ func (a *assistImpl) GetLiveSessionByID(projID uint32, sessID uint64) (interface
 
 	proj, err := a.projects.GetProject(projID)
 	if err != nil {
+		if postgres.IsNoRowsErr(err) {
+			return nil, ErrNoLiveSession
+		}
 		return nil, err
 	}
 	assistUrl := fmt.Sprintf(a.cfg.AssistUrl, a.cfg.AssistKey) + a.cfg.AssistLiveSuffix + "/" + proj.ProjectKey + "/" + strconv.Itoa(int(sessID))
 
 	resp, err := http.Get(assistUrl)
 	if err != nil {
-		fmt.Println("Error making request:", err)
-		return nil, err
+		return nil, fmt.Errorf("assist request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
-	// Read response body
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		fmt.Println("Error reading response:", err)
-		return nil, err
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNoLiveSession
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("assist returned status %d", resp.StatusCode)
 	}
 
-	// Parse the JSON response
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read assist response: %w", err)
+	}
+
 	type assistResponse struct {
 		Data map[string]interface{} `json:"data"`
 	}
 	var response assistResponse
-	err = json.Unmarshal(body, &response)
-	if err != nil {
-		fmt.Println("Error parsing JSON response:", err)
-		return nil, err
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("parse assist response: %w", err)
 	}
-	if response.Data == nil {
-		response.Data = make(map[string]interface{})
+	if len(response.Data) == 0 {
+		return nil, ErrNoLiveSession
 	}
 
 	response.Data["live"] = true
 	if token, err := a.getAgentToken(projID, proj.ProjectKey, sessID); err != nil {
-		a.log.Error(context.Background(), "[proxy] GetLiveSessionByID: ", err)
+		a.log.Error(context.Background(), "[proxy] GetLiveSessionByID: %v", err)
 	} else {
 		response.Data["agentToken"] = token
 	}

--- a/backend/pkg/server/api/model.go
+++ b/backend/pkg/server/api/model.go
@@ -45,5 +45,5 @@ type RouterMiddleware interface {
 }
 
 type ErrorResponse struct {
-	Error string `json:"error"`
+	Errors []string `json:"errors"`
 }

--- a/backend/pkg/server/api/responser.go
+++ b/backend/pkg/server/api/responser.go
@@ -27,7 +27,7 @@ func NewResponser(webMetrics web.Web) Responser {
 }
 
 type response struct {
-	Error string `json:"error"`
+	Errors []string `json:"errors"`
 }
 
 func (r *responserImpl) ResponseOK(log logger.Logger, ctx context.Context, w http.ResponseWriter, requestStart time.Time, url string, bodySize int) {
@@ -49,7 +49,7 @@ func (r *responserImpl) ResponseWithJSON(log logger.Logger, ctx context.Context,
 
 func (r *responserImpl) ResponseWithError(log logger.Logger, ctx context.Context, w http.ResponseWriter, code int, err error, requestStart time.Time, url string, bodySize int) {
 	log.Error(ctx, "response error, code: %d, error: %s", code, err)
-	body, err := json.Marshal(&response{err.Error()})
+	body, err := json.Marshal(&response{Errors: []string{err.Error()}})
 	if err != nil {
 		log.Error(ctx, "can't marshal response: %s", err)
 	} else {

--- a/backend/pkg/session/api/handlers.go
+++ b/backend/pkg/session/api/handlers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strings"
 	"time"
 
 	sessionCfg "openreplay/backend/internal/config/api"
@@ -65,19 +64,24 @@ func (e *handlersImpl) getReplay(w http.ResponseWriter, r *http.Request) {
 
 	data, err := e.sessions.GetReplay(projID, sessID, currUser.GetIDAsString())
 	if err != nil {
-		e.log.Warn(r.Context(), "Error getting replay data: %v", err)
-		if strings.Contains(err.Error(), session.NoSession) {
-			data, err := e.assist.GetLiveSessionByID(projID, sessID)
-			if err != nil {
-				e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusInternalServerError, err, time.Now(), r.URL.Path, 0)
-				return
-			}
-			response["data"] = data
-		} else {
-			// FYI: this is a direct copy of the chalice’s logic for compatibility support.
-			e.responser.ResponseWithJSON(e.log, r.Context(), w, map[string]interface{}{"errors": []string{"session not found"}}, startTime, r.URL.Path, bodySize)
+		if !errors.Is(err, session.ErrNoSession) {
+			e.log.Error(r.Context(), "Error getting replay data: %v", err)
+			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusInternalServerError, errors.New("failed to load session"), startTime, r.URL.Path, bodySize)
 			return
 		}
+
+		e.log.Info(r.Context(), "stored session not found, checking assist for live session")
+		liveData, liveErr := e.assist.GetLiveSessionByID(projID, sessID)
+		if liveErr != nil {
+			if errors.Is(liveErr, proxy.ErrNoLiveSession) {
+				e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusNotFound, errors.New("session not found"), startTime, r.URL.Path, bodySize)
+				return
+			}
+			e.log.Error(r.Context(), "Error getting live session: %v", liveErr)
+			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusInternalServerError, errors.New("failed to load session"), startTime, r.URL.Path, bodySize)
+			return
+		}
+		response["data"] = liveData
 	} else {
 		data.Live, err = e.assist.IsLive(projID, sessID)
 		if err != nil {
@@ -152,11 +156,21 @@ func (e *handlersImpl) getLiveSession(w http.ResponseWriter, r *http.Request) {
 
 	data, err := e.assist.GetLiveSessionByID(projID, sessionID)
 	if err != nil {
-		currUser := api.GetUser(r)
+		if !errors.Is(err, proxy.ErrNoLiveSession) {
+			e.log.Error(r.Context(), "Error getting live session: %v", err)
+			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusInternalServerError, errors.New("failed to load session"), startTime, r.URL.Path, bodySize)
+			return
+		}
 
+		currUser := api.GetUser(r)
 		data, err = e.sessions.GetReplay(projID, sessionID, currUser.GetIDAsString())
 		if err != nil {
-			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusInternalServerError, err, startTime, r.URL.Path, bodySize)
+			if errors.Is(err, session.ErrNoSession) {
+				e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusNotFound, errors.New("session not found"), startTime, r.URL.Path, bodySize)
+				return
+			}
+			e.log.Error(r.Context(), "Error getting replay data: %v", err)
+			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusInternalServerError, errors.New("failed to load session"), startTime, r.URL.Path, bodySize)
 			return
 		}
 	}

--- a/backend/pkg/session/session.go
+++ b/backend/pkg/session/session.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"openreplay/backend/pkg/db/postgres"
 	"openreplay/backend/pkg/db/postgres/pool"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/replays/service"
@@ -173,7 +174,10 @@ func (s *serviceImpl) GetReplay(projectID uint32, sessionID uint64, userID strin
 		&si.UserDeviceMemory, &si.UserDeviceHeap, &si.UserCountry, &si.UserCity, &si.UserState, &si.PagesCount,
 		&si.EventsCount, &si.IssueTypes, &si.UtmSource, &si.UtmMedium, &si.UtmCampaign, &si.Referrer,
 		&si.BaseReferrer, &si.Timezone, &si.ScreenWidth, &si.ScreenHeight, &si.Favorite, &si.Viewed, &si.Metadata); err != nil {
-		return nil, fmt.Errorf("%w, %s", ErrNoSession, err)
+		if postgres.IsNoRowsErr(err) {
+			return nil, ErrNoSession
+		}
+		return nil, fmt.Errorf("get session: %w", err)
 	}
 
 	// Get all pre-signed urls

--- a/backend/pkg/session/session.go
+++ b/backend/pkg/session/session.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -82,6 +83,8 @@ type SessionReplay struct {
 const (
 	NoSession string = "no session in db"
 )
+
+var ErrNoSession = errors.New(NoSession)
 
 // FYI: full_data, include_fav_viewed and group_metadata are always True, so I didn't move it to Go
 func (s *serviceImpl) GetReplay(projectID uint32, sessionID uint64, userID string) (*SessionReplay, error) {
@@ -170,7 +173,7 @@ func (s *serviceImpl) GetReplay(projectID uint32, sessionID uint64, userID strin
 		&si.UserDeviceMemory, &si.UserDeviceHeap, &si.UserCountry, &si.UserCity, &si.UserState, &si.PagesCount,
 		&si.EventsCount, &si.IssueTypes, &si.UtmSource, &si.UtmMedium, &si.UtmCampaign, &si.Referrer,
 		&si.BaseReferrer, &si.Timezone, &si.ScreenWidth, &si.ScreenHeight, &si.Favorite, &si.Viewed, &si.Metadata); err != nil {
-		return nil, fmt.Errorf(NoSession+", %s", err)
+		return nil, fmt.Errorf("%w, %s", ErrNoSession, err)
 	}
 
 	// Get all pre-signed urls


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return 404 Not Found for missing sessions on replay endpoints and standardize error payloads to {"errors": [...]}, improving client behavior and clarity.

- **Bug Fixes**
  - `GET /sessions/:id/replay` and `GET /sessions/:id/live` return 404 when the session is missing in DB or Assist.
  - Use `postgres.IsNoRowsErr` and `errors.Is` with `session.ErrNoSession` and `proxy.ErrNoLiveSession` to detect not-found cases reliably.
  - `backend/pkg/assist/proxy/assist.go`: map Assist 404/empty data to not-found; treat non-2xx as errors; improved error messages and logging.
  - `backend/pkg/server/api`: error responses now use `errors: string[]` (was `error: string`).
  - Non-not-found errors return 500 with a generic message.

- **Migration**
  - Clients must read `errors: string[]` instead of `error: string`.
  - Handle HTTP 404 for “session not found” (previously could be a 200 with an `errors` body).

<sup>Written for commit a3465d7ede8b89bbd4f23312c30e5fac7113e5b4. Summary will update on new commits. <a href="https://cubic.dev/pr/openreplay/openreplay/pull/4641?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

