### PR TITLE
refactor

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -14,6 +14,7 @@ from starlette.responses import StreamingResponse
 
 from chalicelib.utils import helper
 from chalicelib.utils import pg_client, ch_client
+from chalicelib.utils.log import sanitize
 from crons import core_crons, core_dynamic_crons
 from routers import core, core_dynamic
 from routers.subs import insights, metrics, health, usability_tests, spot, product_analytics
@@ -95,11 +96,11 @@ IGNORE_ENDPOINT_LOG = ["/"]
 
 @app.middleware("http")
 async def log_all_requests(request: Request, call_next):
-    method = request.method
-    endpoint = request.url.path
+    method = sanitize(request.method, max_length=16)
+    endpoint = sanitize(request.url.path)
     response: Response = await call_next(request)
     # Log all endpoints except health check
-    if endpoint not in IGNORE_ENDPOINT_LOG or response.status_code != 200:
+    if request.url.path not in IGNORE_ENDPOINT_LOG or response.status_code != 200:
         logger.info(f"{method}:{endpoint} {response.status_code}")
     return response
 
@@ -111,15 +112,15 @@ async def or_middleware(request: Request, call_next):
     try:
         response: StreamingResponse = await call_next(request)
     except:
-        logging.error(f"{request.method}: {request.url.path} FAILED!")
+        logging.error(f"{sanitize(request.method, max_length=16)}: {sanitize(request.url.path)} FAILED!")
         raise
     if response.status_code // 100 != 2:
-        logging.warning(f"{request.method}:{request.url.path} {response.status_code}!")
+        logging.warning(f"{sanitize(request.method, max_length=16)}:{sanitize(request.url.path)} {response.status_code}!")
     if helper.TRACK_TIME:
         now = time.time() - now
         if now > 2:
             now = round(now, 2)
-            logging.warning(f"Execution time: {now} s for {request.method}: {request.url.path}")
+            logging.warning(f"Execution time: {now} s for {sanitize(request.method, max_length=16)}: {sanitize(request.url.path)}")
     response.headers["x-robots-tag"] = 'noindex, nofollow'
     return response
 

--- a/api/auth/auth_jwt.py
+++ b/api/auth/auth_jwt.py
@@ -14,6 +14,13 @@ from chalicelib.core import authorizers, users, spot
 logger = logging.getLogger(__name__)
 
 
+def _get_jwt_leeway() -> datetime.timedelta:
+    days = config("JWT_LEEWAY_DAYS", default=None)
+    if days is not None:
+        return datetime.timedelta(days=int(days))
+    return datetime.timedelta(seconds=config("JWT_LEEWAY_S", cast=int, default=300))
+
+
 def _get_current_auth_context(request: Request, jwt_payload: dict) -> schemas.CurrentContext:
     user = users.get_user(user_id=jwt_payload.get("userId", -1), tenant_id=jwt_payload.get("tenantId", -1))
     if user is None:
@@ -99,9 +106,7 @@ class JWTAuth(HTTPBearer):
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                                     detail="Invalid authentication scheme.")
             old_jwt_payload = authorizers.jwt_authorizer(scheme=credentials.scheme, token=credentials.credentials,
-                                                         leeway=datetime.timedelta(
-                                                             days=config("JWT_LEEWAY_DAYS", cast=int, default=3)
-                                                         ))
+                                                         leeway=_get_jwt_leeway())
             if old_jwt_payload is None \
                     or old_jwt_payload.get("userId") is None \
                     or old_jwt_payload.get("userId") != jwt_payload.get("userId"):
@@ -114,7 +119,7 @@ class JWTAuth(HTTPBearer):
 
     async def __process_spot_refresh_call(self, request: Request) -> schemas.CurrentContext:
         if "spotRefreshToken" not in request.cookies:
-            logger.warning("Missing soptRefreshToken cookie.")
+            logger.warning("Missing spotRefreshToken cookie.")
             jwt_payload = None
         else:
             jwt_payload = authorizers.jwt_refresh_authorizer(scheme="Bearer", token=request.cookies["spotRefreshToken"])
@@ -137,9 +142,7 @@ class JWTAuth(HTTPBearer):
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                                     detail="Invalid spot-authentication scheme.")
             old_jwt_payload = authorizers.jwt_authorizer(scheme=credentials.scheme, token=credentials.credentials,
-                                                         leeway=datetime.timedelta(
-                                                             days=config("JWT_LEEWAY_DAYS", cast=int, default=3)
-                                                         ))
+                                                         leeway=_get_jwt_leeway())
             if old_jwt_payload is None \
                     or old_jwt_payload.get("userId") is None \
                     or old_jwt_payload.get("userId") != jwt_payload.get("userId"):

--- a/api/auth/auth_project.py
+++ b/api/auth/auth_project.py
@@ -6,6 +6,7 @@ from starlette.exceptions import HTTPException
 
 import schemas
 from chalicelib.core import projects
+from chalicelib.utils.log import sanitize
 from or_dependencies import OR_context
 
 logger = logging.getLogger(__name__)
@@ -28,7 +29,7 @@ class ProjectAuthorizer:
             current_project = projects.get_by_project_key(project_key=value)
 
         if current_project is None:
-            logger.debug(f"unauthorized project {self.project_identifier}:{value}")
+            logger.debug(f"unauthorized project {self.project_identifier}:{sanitize(value)}")
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="project not found.")
         else:
             current_project = schemas.ProjectContext(projectId=current_project["projectId"],

--- a/api/chalicelib/core/alerts/alerts.py
+++ b/api/chalicelib/core/alerts/alerts.py
@@ -11,6 +11,7 @@ from chalicelib.core.collaborations.collaboration_msteams import MSTeams
 from chalicelib.core.collaborations.collaboration_slack import Slack
 from chalicelib.utils import pg_client, helper, email_helper, smtp
 from chalicelib.utils.TimeUTC import TimeUTC
+from chalicelib.utils.log import sanitize
 from starlette import status
 from starlette.exceptions import HTTPException
 
@@ -35,7 +36,7 @@ def get(project_id, id):
 
         return helper.custom_alert_to_front(__process_circular(a))
     except Exception as e:
-        logger.error(f"Error fetching alert: {str(e)}")
+        logger.error(f"Error fetching alert: {sanitize(str(e))}")
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Alert not found.")
 
 
@@ -113,7 +114,7 @@ def update(project_id: int, id: int, data: schemas.AlertSchema):
 
         return {"data": helper.custom_alert_to_front(__process_circular(a))}
     except Exception as e:
-        logger.error(f"Error updating alert: {str(e)}")
+        logger.error(f"Error updating alert: {sanitize(str(e))}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to update alert.")
 
 
@@ -147,25 +148,25 @@ def process_notifications(data):
                     send_to_slack_batch(notifications_list=notifications_list)
                 except Exception as e:
                     logger.error("!!!Error while sending slack notifications batch")
-                    logger.error(str(e))
+                    logger.error(sanitize(str(e)))
             elif t == "msteams":
                 try:
                     send_to_msteams_batch(notifications_list=notifications_list)
                 except Exception as e:
                     logger.error("!!!Error while sending msteams notifications batch")
-                    logger.error(str(e))
+                    logger.error(sanitize(str(e)))
             elif t == "email":
                 try:
                     send_by_email_batch(notifications_list=notifications_list)
                 except Exception as e:
                     logger.error("!!!Error while sending email notifications batch")
-                    logger.error(str(e))
+                    logger.error(sanitize(str(e)))
             elif t == "webhook":
                 try:
                     webhook.trigger_batch(data_list=notifications_list)
                 except Exception as e:
                     logger.error("!!!Error while sending webhook notifications batch")
-                    logger.error(str(e))
+                    logger.error(sanitize(str(e)))
 
 
 def send_by_email(notification, destination):

--- a/api/chalicelib/core/assist.py
+++ b/api/chalicelib/core/assist.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException, status
 import schemas
 from chalicelib.core import projects
 from chalicelib.utils.TimeUTC import TimeUTC
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,7 @@ def __get_live_sessions_ws(project_id, data):
                                 json=data, timeout=config("assistTimeout", cast=int, default=5))
         if results.status_code != 200:
             logger.error(f"!! issue with the peer-server code:{results.status_code} for __get_live_sessions_ws")
-            logger.error(results.text)
+            logger.error(sanitize(results.text))
             return {"total": 0, "sessions": []}
         live_peers = results.json().get("data", [])
     except requests.exceptions.Timeout:
@@ -67,7 +68,7 @@ def __get_live_sessions_ws(project_id, data):
         logger.exception(e)
         logger.error("expected JSON, received:")
         try:
-            logger.error(results.text)
+            logger.error(sanitize(results.text))
         except:
             logger.error("couldn't get response")
         live_peers = {"total": 0, "sessions": []}
@@ -106,7 +107,7 @@ def get_live_session_by_id(project_id, session_id):
                                timeout=config("assistTimeout", cast=int, default=5))
         if results.status_code != 200:
             logger.error(f"!! issue with the peer-server code:{results.status_code} for get_live_session_by_id")
-            logger.error(results.text)
+            logger.error(sanitize(results.text))
             return None
         results = results.json().get("data")
         if results is None:
@@ -121,7 +122,7 @@ def get_live_session_by_id(project_id, session_id):
         logger.exception(e)
         logger.error("expected JSON, received:")
         try:
-            logger.error(results.text)
+            logger.error(sanitize(results.text))
         except:
             logger.error("couldn't get response")
         return None
@@ -136,7 +137,7 @@ def is_live(project_id, session_id, project_key=None):
                                timeout=config("assistTimeout", cast=int, default=5))
         if results.status_code != 200:
             logger.error(f"!! issue with the peer-server code:{results.status_code} for is_live")
-            logger.error(results.text)
+            logger.error(sanitize(results.text))
             return False
         results = results.json().get("data")
     except requests.exceptions.Timeout:
@@ -147,7 +148,7 @@ def is_live(project_id, session_id, project_key=None):
         logger.exception(e)
         logger.error("expected JSON, received:")
         try:
-            logger.error(results.text)
+            logger.error(sanitize(results.text))
         except:
             logger.error("couldn't get response")
         return False
@@ -165,7 +166,7 @@ def autocomplete(project_id, q: str, key: str = None):
             params=params, timeout=config("assistTimeout", cast=int, default=5))
         if results.status_code != 200:
             logger.error(f"!! issue with the peer-server code:{results.status_code} for autocomplete")
-            logger.error(results.text)
+            logger.error(sanitize(results.text))
             return {"errors": [f"Something went wrong wile calling assist:{results.text}"]}
         results = results.json().get("data", [])
     except requests.exceptions.Timeout:
@@ -176,7 +177,7 @@ def autocomplete(project_id, q: str, key: str = None):
         logger.exception(e)
         logger.error("expected JSON, received:")
         try:
-            logger.error(results.text)
+            logger.error(sanitize(results.text))
         except:
             logger.error("couldn't get response")
         return {"errors": ["Something went wrong wile calling assist"]}
@@ -243,7 +244,7 @@ def session_exists(project_id, session_id):
                                timeout=config("assistTimeout", cast=int, default=5))
         if results.status_code != 200:
             logger.error(f"!! issue with the peer-server code:{results.status_code} for session_exists")
-            logger.error(results.text)
+            logger.error(sanitize(results.text))
             return None
         results = results.json().get("data")
         if results is None:
@@ -257,7 +258,7 @@ def session_exists(project_id, session_id):
         logger.exception(e)
         logger.error("expected JSON, received:")
         try:
-            logger.error(results.text)
+            logger.error(sanitize(results.text))
         except:
             logger.error("couldn't get response")
         return False

--- a/api/chalicelib/core/authorizers.py
+++ b/api/chalicelib/core/authorizers.py
@@ -6,6 +6,7 @@ from decouple import config
 from chalicelib.core import tenants
 from chalicelib.core import users, spot
 from chalicelib.utils.TimeUTC import TimeUTC
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +23,7 @@ def is_spot_token(token: str) -> bool:
         audience = decoded_token.get("aud")
         return audience == spot.AUDIENCE
     except jwt.InvalidTokenError:
-        logger.error(f"Invalid token for is_spot_token: {token}")
+        logger.error(f"Invalid token for is_spot_token: {sanitize(token, max_length=16)}...")
         raise
 
 

--- a/api/chalicelib/core/collaborations/collaboration_msteams.py
+++ b/api/chalicelib/core/collaborations/collaboration_msteams.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException, status
 import schemas
 from chalicelib.core import webhook
 from chalicelib.core.collaborations.collaboration_base import BaseCollaboration
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ class MSTeams(BaseCollaboration):
                 timeout=3)
             if r.status_code != 200:
                 logger.warning("MSTeams integration failed")
-                logger.warning(r.text)
+                logger.warning(sanitize(r.text))
                 return False
         except Exception as e:
             logger.warning("!!! MSTeams integration failed")
@@ -58,7 +59,7 @@ class MSTeams(BaseCollaboration):
                 timeout=5)
             if r.status_code != 200:
                 logger.warning(f"!! issue sending msteams raw; webhookId:{webhook_id} code:{r.status_code}")
-                logger.warning(r.text)
+                logger.warning(sanitize(r.text))
                 return None
         except requests.exceptions.Timeout:
             logger.warning(f"!! Timeout sending msteams raw webhookId:{webhook_id}")
@@ -89,7 +90,7 @@ class MSTeams(BaseCollaboration):
                               })
             if r.status_code != 200:
                 logger.warning("!!!! something went wrong")
-                logger.warning(r.text)
+                logger.warning(sanitize(r.text))
 
     @classmethod
     def __share(cls, tenant_id, integration_id, attachement, extra=None):

--- a/api/chalicelib/core/collaborations/collaboration_slack.py
+++ b/api/chalicelib/core/collaborations/collaboration_slack.py
@@ -7,7 +7,11 @@ from fastapi import HTTPException, status
 import schemas
 from chalicelib.core import webhook
 from chalicelib.core.collaborations.collaboration_base import BaseCollaboration
+import logging
 
+from chalicelib.utils.log import sanitize
+
+logger = logging.getLogger(__name__)
 
 class Slack(BaseCollaboration):
     @classmethod
@@ -35,8 +39,8 @@ class Slack(BaseCollaboration):
                 ]
             })
         if r.status_code != 200:
-            print("slack integration failed")
-            print(r.text)
+            logger.error("slack integration failed")
+            logger.error(sanitize(r.text))
             return False
         return True
 
@@ -51,15 +55,15 @@ class Slack(BaseCollaboration):
                 json=body,
                 timeout=5)
             if r.status_code != 200:
-                print(f"!! issue sending slack raw; webhookId:{webhook_id} code:{r.status_code}")
-                print(r.text)
+                logger.warning(f"!! issue sending slack raw; webhookId:{webhook_id} code:{r.status_code}")
+                logger.warning(sanitize(r.text))
                 return None
         except requests.exceptions.Timeout:
-            print(f"!! Timeout sending slack raw webhookId:{webhook_id}")
+            logger.warning(f"!! Timeout sending slack raw webhookId:{webhook_id}")
             return None
         except Exception as e:
-            print(f"!! Issue sending slack raw webhookId:{webhook_id}")
-            print(str(e))
+            logger.warning(f"!! Issue sending slack raw webhookId:{webhook_id}")
+            logger.warning(sanitize(str(e)))
             return None
         return {"data": r.text}
 
@@ -68,16 +72,14 @@ class Slack(BaseCollaboration):
         integration = cls.get_integration(tenant_id=tenant_id, integration_id=webhook_id)
         if integration is None:
             return {"errors": ["slack integration not found"]}
-        print(f"====> sending slack batch notification: {len(attachments)}")
+        logger.debug(f"====> sending slack batch notification: {len(attachments)}")
         for i in range(0, len(attachments), 100):
             r = requests.post(
                 url=integration["endpoint"],
                 json={"attachments": attachments[i:i + 100]})
             if r.status_code != 200:
-                print("!!!! something went wrong while sending to:")
-                print(integration)
-                print(r)
-                print(r.text)
+                logger.warning(f"!!!! something went wrong while sending slack batch; webhookId:{webhook_id} code:{r.status_code}")
+                logger.warning(sanitize(r.text))
 
     @classmethod
     def __share(cls, tenant_id, integration_id, attachement, extra=None):

--- a/api/chalicelib/core/db_request_handler.py
+++ b/api/chalicelib/core/db_request_handler.py
@@ -1,6 +1,7 @@
 import logging
 
 from chalicelib.utils import pg_client
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +104,7 @@ class DatabaseRequestHandler:
                 cur.execute(mogrified_query)
                 return cur.fetchall() if cur.description else None
         except Exception as e:
-            self.logger.error(f"Database operation failed: {e}")
+            self.logger.error(f"Database operation failed: {sanitize(str(e))}")
             raise
 
     def fetchall(self):
@@ -155,7 +156,7 @@ class DatabaseRequestHandler:
                 cur.execute(mogrified_query)
                 return cur.fetchall()
         except Exception as e:
-            self.logger.error(f"Database batch insert operation failed: {e}")
+            self.logger.error(f"Database batch insert operation failed: {sanitize(str(e))}")
             raise
 
     def raw_query(self, query, params=None):
@@ -165,7 +166,7 @@ class DatabaseRequestHandler:
                 cur.execute(mogrified_query)
                 return cur.fetchall() if cur.description else None
         except Exception as e:
-            self.logger.error(f"Database operation failed: {e}")
+            self.logger.error(f"Database operation failed: {sanitize(str(e))}")
             raise
 
     def batch_update(self, items):
@@ -201,5 +202,5 @@ class DatabaseRequestHandler:
                 mogrified_query = cur.mogrify(query, combined_params)
                 cur.execute(mogrified_query)
         except Exception as e:
-            self.logger.error(f"Database batch update operation failed: {e}")
+            self.logger.error(f"Database batch update operation failed: {sanitize(str(e))}")
             raise

--- a/api/chalicelib/core/feature_flags.py
+++ b/api/chalicelib/core/feature_flags.py
@@ -6,6 +6,7 @@ import schemas
 from chalicelib.utils import helper
 from chalicelib.utils import pg_client
 from chalicelib.utils.TimeUTC import TimeUTC
+from chalicelib.utils.log import sanitize
 from fastapi import HTTPException, status
 
 logger = logging.getLogger(__name__)
@@ -51,7 +52,7 @@ def update_feature_flag_status(project_id: int, feature_flag_id: int, is_active:
 
             return {"is_active": cur.fetchone()["is_active"]}
     except Exception as e:
-        logger.error(f"Failed to update feature flag status: {e}")
+        logger.error(f"Failed to update feature flag status: {sanitize(str(e))}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                             detail="Failed to update feature flag status")
 

--- a/api/chalicelib/core/health.py
+++ b/api/chalicelib/core/health.py
@@ -6,6 +6,7 @@ from decouple import config
 
 from chalicelib.utils import pg_client
 from chalicelib.utils.TimeUTC import TimeUTC
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +86,7 @@ def __check_be_service(service_name):
                 logger.error(
                     f"!! issue with the {service_name}-health code:{results.status_code}"
                 )
-                logger.error(results.text)
+                logger.error(sanitize(results.text))
                 # fail_response["details"]["errors"].append(results.text)
                 logger.info("__check_be_service(%s): end", service_name)
                 return fail_response
@@ -98,7 +99,7 @@ def __check_be_service(service_name):
             logger.error(f"!! Issue getting {service_name}-health response")
             logger.exception(e)
             try:
-                logger.error(results.text)
+                logger.error(sanitize(results.text))
                 # fail_response["details"]["errors"].append(results.text)
             except Exception:
                 logger.error("couldn't get response")

--- a/api/chalicelib/core/issue_tracking/base_issue.py
+++ b/api/chalicelib/core/issue_tracking/base_issue.py
@@ -1,4 +1,9 @@
+import logging
 from abc import ABC, abstractmethod
+
+from chalicelib.utils.log import sanitize
+
+logger = logging.getLogger(__name__)
 
 
 class RequestException(Exception):
@@ -6,8 +11,8 @@ class RequestException(Exception):
 
 
 def proxy_issues_handler(e):
-    print("=======__proxy_issues_handler=======")
-    print(str(e))
+    logger.error("=======__proxy_issues_handler=======")
+    logger.error(sanitize(str(e)))
     return {"errors": [str(e)]}
 
 

--- a/api/chalicelib/core/log_tools/bugsnag.py
+++ b/api/chalicelib/core/log_tools/bugsnag.py
@@ -1,7 +1,12 @@
+import logging
+
 import requests
+
 from chalicelib.core.log_tools import log_tools
+from chalicelib.utils.log import sanitize
 from schemas import schemas
 
+logger = logging.getLogger(__name__)
 IN_TY = "bugsnag"
 
 
@@ -10,10 +15,9 @@ def list_projects(auth_token):
                      params={"per_page": "100"},
                      headers={"Authorization": "token " + auth_token, "X-Version": "2"})
     if r.status_code != 200:
-        print("=======> bugsnag get organizations: something went wrong")
-        print(r)
-        print(r.status_code)
-        print(r.text)
+        logger.error("=======> bugsnag get organizations: something went wrong")
+        logger.error(r.status_code)
+        logger.error(sanitize(r.text))
         return []
 
     orgs = []
@@ -23,10 +27,9 @@ def list_projects(auth_token):
                           params={"per_page": "100"},
                           headers={"Authorization": "token " + auth_token, "X-Version": "2"})
         if pr.status_code != 200:
-            print("=======> bugsnag get projects: something went wrong")
-            print(pr)
-            print(r.status_code)
-            print(r.text)
+            logger.error("=======> bugsnag get projects: something went wrong")
+            logger.error(pr.status_code)
+            logger.error(sanitize(pr.text))
             continue
         orgs.append({"name": i["name"], "projects": [{"name": p["name"], "id": p["id"]} for p in pr.json()]})
     return orgs

--- a/api/chalicelib/core/log_tools/sentry.py
+++ b/api/chalicelib/core/log_tools/sentry.py
@@ -1,6 +1,12 @@
+import logging
+
 import requests
+
 from chalicelib.core.log_tools import log_tools
+from chalicelib.utils.log import sanitize
 from schemas import schemas
+
+logger = logging.getLogger(__name__)
 
 IN_TY = "sentry"
 
@@ -60,8 +66,7 @@ def proxy_get(tenant_id, project_id, event_id):
             "organization_slug": i["organizationSlug"], "project_slug": i["projectSlug"], "event_id": event_id},
         headers={"Authorization": "Bearer " + i["token"]})
     if r.status_code != 200:
-        print("=======> sentry get: something went wrong")
-        print(r)
-        print(r.status_code)
-        print(r.text)
+        logger.error("=======> sentry get: something went wrong")
+        logger.error(r.status_code)
+        logger.error(sanitize(r.text))
     return r.json()

--- a/api/chalicelib/core/reset_password.py
+++ b/api/chalicelib/core/reset_password.py
@@ -5,12 +5,13 @@ from fastapi import BackgroundTasks
 import schemas
 from chalicelib.core import users
 from chalicelib.utils import email_helper, captcha, helper, smtp
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
 
 def reset(data: schemas.ForgetPasswordPayloadSchema, background_tasks: BackgroundTasks):
-    logger.info(f"forget password request for: {data.email}")
+    logger.info(f"forget password request for: {sanitize(data.email)}")
     if helper.allow_captcha() and not captcha.is_valid(data.g_recaptcha_response):
         return {"errors": ["Invalid captcha."]}
     if not smtp.has_smtp():
@@ -22,5 +23,5 @@ def reset(data: schemas.ForgetPasswordPayloadSchema, background_tasks: Backgroun
                                   recipient=data.email,
                                   invitation_link=invitation_link)
     else:
-        logger.warning(f"!!!invalid email address [{data.email}]")
+        logger.warning(f"!!!invalid email address [{sanitize(data.email)}]")
     return {"data": {"state": "A reset link will be sent if this email exists in our system."}}

--- a/api/chalicelib/core/sessions/sessions_pg.py
+++ b/api/chalicelib/core/sessions/sessions_pg.py
@@ -7,6 +7,7 @@ from chalicelib.core import metadata
 from . import performance_event
 from chalicelib.utils import pg_client, helper, metrics_helper
 from chalicelib.utils import sql_helper as sh
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +70,7 @@ def search2_series(data: schemas.SessionsSearchPayloadSchema, project_id: int, d
                 logger.warning("--------- SESSIONS-SERIES QUERY EXCEPTION -----------")
                 logger.warning(main_query.decode('UTF-8'))
                 logger.warning("--------- PAYLOAD -----------")
-                logger.warning(data.model_dump_json())
+                logger.warning(sanitize(data.model_dump_json(), max_length=4096))
                 logger.warning("--------------------")
                 raise err
             sessions = cur.fetchall()

--- a/api/chalicelib/core/signup.py
+++ b/api/chalicelib/core/signup.py
@@ -7,6 +7,7 @@ from chalicelib.utils import captcha, smtp
 from chalicelib.utils import helper
 from chalicelib.utils import pg_client
 from chalicelib.utils.TimeUTC import TimeUTC
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ async def create_tenant(data: schemas.UserSignupSchema):
         return {"errors": ["tenants already registered"]}
 
     email = data.email
-    logger.debug(f"email: {email}")
+    logger.debug(f"email: {sanitize(email)}")
     password = data.password.get_secret_value()
     fullname = data.fullname
 
@@ -44,7 +45,7 @@ async def create_tenant(data: schemas.UserSignupSchema):
 
     if len(errors) > 0:
         logger.warning(
-            f"==> signup error for:\n email:{data.email}, fullname:{data.fullname}, organizationName:{data.organizationName}")
+            f"==> signup error for:\n email:{sanitize(data.email)}, fullname:{sanitize(data.fullname)}, organizationName:{sanitize(data.organizationName)}")
         logger.warning(errors)
         return {"errors": errors}
 

--- a/api/chalicelib/core/sourcemaps/sourcemaps.py
+++ b/api/chalicelib/core/sourcemaps/sourcemaps.py
@@ -1,10 +1,14 @@
+import logging
 from urllib.parse import urlparse
 
 import requests
 from decouple import config
 
 from chalicelib.core.sourcemaps import sourcemaps_parser
+from chalicelib.utils.log import sanitize
 from chalicelib.utils.storage import StorageClient, generators
+
+logger = logging.getLogger(__name__)
 
 
 def presign_share_urls(project_id, urls):
@@ -72,8 +76,8 @@ def url_exists(url):
         r = requests.head(url, allow_redirects=False)
         return r.status_code == 200 and "text/html" not in r.headers.get("Content-Type", "")
     except Exception as e:
-        print(f"!! Issue checking if URL exists: {url}")
-        print(e)
+        logger.warning(f"!! Issue checking if URL exists: {sanitize(url)}")
+        logger.warning(sanitize(str(e)))
         return False
 
 
@@ -91,20 +95,20 @@ def get_traces_group(project_id, payload):
         params_idx = file_url.find("?")
         if file_url and len(file_url) > 0 \
                 and not (file_url[:params_idx] if params_idx > -1 else file_url).endswith(".js"):
-            print(f"{u['absPath']} sourcemap is not a JS file")
+            logger.debug(f"{sanitize(u['absPath'])} sourcemap is not a JS file")
             payloads[key] = None
 
         if key not in payloads:
             file_exists_in_bucket = len(file_url) > 0 and StorageClient.exists(config('sourcemaps_bucket'), key)
             if len(file_url) > 0 and not file_exists_in_bucket:
-                print(f"{u['absPath']} sourcemap (key '{key}') doesn't exist in S3 looking in server")
+                logger.debug(f"{sanitize(u['absPath'])} sourcemap (key '{sanitize(key)}') doesn't exist in S3 looking in server")
                 if not file_url.endswith(".map"):
                     file_url += '.map'
                 file_exists_in_server = url_exists(file_url)
                 file_exists_in_bucket = file_exists_in_server
             all_exists = all_exists and file_exists_in_bucket
             if not file_exists_in_bucket and not file_exists_in_server:
-                print(f"{u['absPath']} sourcemap (key '{key}') doesn't exist in S3 nor server")
+                logger.debug(f"{sanitize(u['absPath'])} sourcemap (key '{sanitize(key)}') doesn't exist in S3 nor server")
                 payloads[key] = None
             else:
                 payloads[key] = []
@@ -155,25 +159,25 @@ def fetch_missed_contexts(frames):
             file_path = get_js_cache_path(file_abs_path)
             file = StorageClient.get_file(config('js_cache_bucket'), file_path)
             if file is None:
-                print(f"Missing abs_path: {file_abs_path}, file {file_path} not found in {config('js_cache_bucket')}")
+                logger.debug(f"Missing abs_path: {sanitize(file_abs_path)}, file {sanitize(file_path)} not found in {config('js_cache_bucket')}")
             source_cache[file_abs_path] = file
         if file is None:
             continue
         lines = file.split("\n")
 
         if frames[i]["lineNo"] is None:
-            print("no original-source found for frame in sourcemap results")
+            logger.debug("no original-source found for frame in sourcemap results")
             frames[i] = frames[i]["frame"]
             frames[i]["originalMapping"] = False
 
         l = frames[i]["lineNo"] - 1  # starts from 1
         c = frames[i]["colNo"] - 1  # starts from 1
         if len(lines) == 1:
-            print(f"minified asset")
+            logger.debug("minified asset")
             l = frames[i]["frame"]["lineNo"] - 1  # starts from 1
             c = frames[i]["frame"]["colNo"] - 1  # starts from 1
         elif l >= len(lines):
-            print(f"line number {l} greater than file length {len(lines)}")
+            logger.debug(f"line number {l} greater than file length {len(lines)}")
             continue
 
         line = lines[l]

--- a/api/chalicelib/core/webhook.py
+++ b/api/chalicelib/core/webhook.py
@@ -5,6 +5,7 @@ import requests
 import schemas
 from chalicelib.utils import pg_client, helper
 from chalicelib.utils.TimeUTC import TimeUTC
+from chalicelib.utils.log import sanitize
 from fastapi import HTTPException, status
 
 logger = logging.getLogger(__name__)
@@ -176,7 +177,7 @@ def __trigger(hook, data):
             logger.error("=======> webhook: something went wrong for:")
             logger.error(hook)
             logger.error(r.status_code)
-            logger.error(r.text)
+            logger.error(sanitize(r.text))
             return
         response = None
         try:

--- a/api/chalicelib/utils/captcha.py
+++ b/api/chalicelib/utils/captcha.py
@@ -4,6 +4,7 @@ import requests
 from decouple import config
 
 from chalicelib.utils import helper
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +21,8 @@ def is_valid(response):
     r = requests.post(url=url, data={"secret": secret, "response": response})
     if r.status_code != 200:
         logger.warning("something went wrong")
-        logger.error(r)
         logger.warning(r.status_code)
-        logger.warning(r.text)
+        logger.warning(sanitize(r.text))
         return
     r = r.json()
     logger.debug(r)

--- a/api/chalicelib/utils/log.py
+++ b/api/chalicelib/utils/log.py
@@ -1,0 +1,22 @@
+import re
+
+_NEWLINE_RE = re.compile(r"[\r\n]+")
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+_DEFAULT_MAX_LEN = 512
+
+
+def sanitize(value, max_length: int = _DEFAULT_MAX_LEN) -> str:
+    """Sanitize a value before interpolating it into a log message.
+
+    Strips CR/LF (prevents log forging), null bytes and ANSI/control
+    characters, then truncates. Use for any externally-sourced data:
+    request bodies, headers, URLs, JWT contents, third-party responses.
+    """
+    if value is None:
+        return ""
+    s = value if isinstance(value, str) else repr(value)
+    s = _NEWLINE_RE.sub(" ", s)
+    s = _CONTROL_CHARS_RE.sub("", s)
+    if len(s) > max_length:
+        s = s[:max_length] + "...(truncated)"
+    return s

--- a/api/or_dependencies.py
+++ b/api/or_dependencies.py
@@ -13,6 +13,7 @@ from starlette.responses import Response, JSONResponse
 
 import schemas
 from chalicelib.utils import helper
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ class ORRoute(APIRoute):
                 response: Response = await original_route_handler(request)
             except RequestValidationError as exc:
                 # 422 validation exception
-                logger.warning(f"!!! 422 exception when calling: {request.method} {request.url}")
+                logger.warning(f"!!! 422 exception when calling: {sanitize(request.method, max_length=16)} {sanitize(str(request.url))}")
                 logger.warning(exc.errors())
                 for e in exc.errors():
                     if e.get("msg", "").endswith("must be alphanumeric"):

--- a/ee/api/.gitignore
+++ b/ee/api/.gitignore
@@ -279,3 +279,4 @@ Pipfile.lock
 /chalicelib/utils/contextual_validators.py
 /routers/subs/product_analytics.py
 /schemas/product_analytics.py
+/chalicelib/utils/log.py

--- a/ee/api/app.py
+++ b/ee/api/app.py
@@ -19,6 +19,7 @@ from chalicelib.core import traces
 from chalicelib.utils import events_queue
 from chalicelib.utils import helper
 from chalicelib.utils import pg_client, ch_client
+from chalicelib.utils.log import sanitize
 from crons import core_crons, ee_crons, core_dynamic_crons
 from routers import core, core_dynamic
 from routers import ee
@@ -122,11 +123,11 @@ IGNORE_ENDPOINT_LOG = ["/"]
 
 @app.middleware("http")
 async def log_all_requests(request: Request, call_next):
-    method = request.method
-    endpoint = request.url.path
+    method = sanitize(request.method, max_length=16)
+    endpoint = sanitize(request.url.path)
     response: Response = await call_next(request)
     # Log all endpoints except health check
-    if endpoint not in IGNORE_ENDPOINT_LOG or response.status_code != 200:
+    if request.url.path not in IGNORE_ENDPOINT_LOG or response.status_code != 200:
         logger.info(f"{method}:{endpoint} {response.status_code}")
     return response
 
@@ -146,16 +147,16 @@ async def or_middleware(request: Request, call_next):
     try:
         response: StreamingResponse = await call_next(request)
     except:
-        logging.error(f"{request.method}: {request.url.path} FAILED!")
+        logging.error(f"{sanitize(request.method, max_length=16)}: {sanitize(request.url.path)} FAILED!")
         raise
     if response.status_code // 100 != 2:
-        logging.warning(f"{request.method}:{request.url.path} {response.status_code}!")
+        logging.warning(f"{sanitize(request.method, max_length=16)}:{sanitize(request.url.path)} {response.status_code}!")
     if helper.TRACK_TIME:
         now = time.time() - now
         if now > 2:
             now = round(now, 2)
             logging.warning(
-                f"Execution time: {now} s for {request.method}: {request.url.path}"
+                f"Execution time: {now} s for {sanitize(request.method, max_length=16)}: {sanitize(request.url.path)}"
             )
     response.headers["x-robots-tag"] = "noindex, nofollow"
     return response

--- a/ee/api/auth/auth_jwt.py
+++ b/ee/api/auth/auth_jwt.py
@@ -14,6 +14,13 @@ from chalicelib.core import authorizers, users, spot
 logger = logging.getLogger(__name__)
 
 
+def _get_jwt_leeway() -> datetime.timedelta:
+    days = config("JWT_LEEWAY_DAYS", default=None)
+    if days is not None:
+        return datetime.timedelta(days=int(days))
+    return datetime.timedelta(seconds=config("JWT_LEEWAY_S", cast=int, default=300))
+
+
 def _get_current_auth_context(request: Request, jwt_payload: dict) -> schemas.CurrentContext:
     user = users.get_user(user_id=jwt_payload.get("userId", -1), tenant_id=jwt_payload.get("tenantId", -1))
     if user is None:
@@ -107,9 +114,7 @@ class JWTAuth(HTTPBearer):
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                                     detail="Invalid authentication scheme.")
             old_jwt_payload = authorizers.jwt_authorizer(scheme=credentials.scheme, token=credentials.credentials,
-                                                         leeway=datetime.timedelta(
-                                                             days=config("JWT_LEEWAY_DAYS", cast=int, default=3)
-                                                         ))
+                                                         leeway=_get_jwt_leeway())
             if old_jwt_payload is None \
                     or old_jwt_payload.get("userId") is None \
                     or old_jwt_payload.get("userId") != jwt_payload.get("userId"):
@@ -124,7 +129,7 @@ class JWTAuth(HTTPBearer):
 
     async def __process_spot_refresh_call(self, request: Request) -> schemas.CurrentContext:
         if "spotRefreshToken" not in request.cookies:
-            logger.warning("Missing soptRefreshToken cookie.")
+            logger.warning("Missing spotRefreshToken cookie.")
             jwt_payload = None
         else:
             jwt_payload = authorizers.jwt_refresh_authorizer(scheme="Bearer", token=request.cookies["spotRefreshToken"])
@@ -147,9 +152,7 @@ class JWTAuth(HTTPBearer):
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                                     detail="Invalid spot-authentication scheme.")
             old_jwt_payload = authorizers.jwt_authorizer(scheme=credentials.scheme, token=credentials.credentials,
-                                                         leeway=datetime.timedelta(
-                                                             days=config("JWT_LEEWAY_DAYS", cast=int, default=3)
-                                                         ))
+                                                         leeway=_get_jwt_leeway())
             if old_jwt_payload is None \
                     or old_jwt_payload.get("userId") is None \
                     or old_jwt_payload.get("userId") != jwt_payload.get("userId"):

--- a/ee/api/auth/auth_project.py
+++ b/ee/api/auth/auth_project.py
@@ -6,6 +6,7 @@ from starlette.exceptions import HTTPException
 
 import schemas
 from chalicelib.core import projects
+from chalicelib.utils.log import sanitize
 from or_dependencies import OR_context
 
 logger = logging.getLogger(__name__)
@@ -37,7 +38,7 @@ class ProjectAuthorizer:
                 current_project = None
 
         if current_project is None:
-            logger.debug(f"unauthorized project {self.project_identifier}:{value}")
+            logger.debug(f"unauthorized project {self.project_identifier}:{sanitize(value)}")
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized project.")
         else:
             current_project = schemas.ProjectContext(projectId=current_project["projectId"],

--- a/ee/api/chalicelib/core/health.py
+++ b/ee/api/chalicelib/core/health.py
@@ -8,6 +8,7 @@ from decouple import config
 
 from chalicelib.utils import pg_client, ch_client
 from chalicelib.utils.TimeUTC import TimeUTC
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +88,7 @@ def __check_be_service(service_name):
                 logger.error(
                     f"!! issue with the {service_name}-health code:{results.status_code}"
                 )
-                logger.error(results.text)
+                logger.error(sanitize(results.text))
                 # fail_response["details"]["errors"].append(results.text)
                 logger.info("__check_be_service(%s): end", service_name)
                 return fail_response
@@ -100,7 +101,7 @@ def __check_be_service(service_name):
             logger.error(f"!! Issue getting {service_name}-health response")
             logger.exception(e)
             try:
-                logger.error(results.text)
+                logger.error(sanitize(results.text))
                 # fail_response["details"]["errors"].append(results.text)
             except Exception:
                 logger.error("couldn't get response")

--- a/ee/api/chalicelib/core/reset_password.py
+++ b/ee/api/chalicelib/core/reset_password.py
@@ -6,12 +6,13 @@ from fastapi import BackgroundTasks
 import schemas
 from chalicelib.core import users
 from chalicelib.utils import email_helper, captcha, helper, smtp
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
 
 def reset(data: schemas.ForgetPasswordPayloadSchema, background_tasks: BackgroundTasks):
-    logger.info(f"forget password request for: {data.email}")
+    logger.info(f"forget password request for: {sanitize(data.email)}")
     if helper.allow_captcha() and not captcha.is_valid(data.g_recaptcha_response):
         print("error: Invalid captcha.")
         return {"errors": ["Invalid captcha."]}
@@ -30,5 +31,5 @@ def reset(data: schemas.ForgetPasswordPayloadSchema, background_tasks: Backgroun
                                   recipient=data.email,
                                   invitation_link=invitation_link)
     else:
-        logger.warning(f"!!!invalid email address [{data.email}]")
+        logger.warning(f"!!!invalid email address [{sanitize(data.email)}]")
     return {"data": {"state": "A reset link will be sent if this email exists in our system."}}

--- a/ee/api/chalicelib/core/sessions/sessions_favorite/sessions_favorite_ee.py
+++ b/ee/api/chalicelib/core/sessions/sessions_favorite/sessions_favorite_ee.py
@@ -4,6 +4,7 @@ from decouple import config
 
 import schemas
 from chalicelib.core.sessions import sessions_mobs, sessions_devtool
+from chalicelib.utils.log import sanitize
 from chalicelib.utils.storage import extra
 from .sessions_favorite import add_favorite_session, remove_favorite_session, favorite_session_exists
 
@@ -22,8 +23,8 @@ def favorite_session(context: schemas.CurrentContext, project_id, session_id):
             try:
                 extra.tag_session(file_key=k, tag_value=tag)
             except Exception as e:
-                print(f"!!!Error while tagging: {k} to {tag} for removal")
-                print(str(e))
+                logger.warning(f"!!!Error while tagging: {sanitize(k)} to {sanitize(tag)} for removal")
+                logger.warning(sanitize(str(e)))
 
         return remove_favorite_session(context=context, project_id=project_id, session_id=session_id)
 
@@ -33,7 +34,7 @@ def favorite_session(context: schemas.CurrentContext, project_id, session_id):
         try:
             extra.tag_session(file_key=k, tag_value=tag)
         except Exception as e:
-            print(f"!!!Error while tagging: {k} to {tag} for vault")
-            print(str(e))
+            logger.warning(f"!!!Error while tagging: {sanitize(k)} to {sanitize(tag)} for vault")
+            logger.warning(sanitize(str(e)))
 
     return add_favorite_session(context=context, project_id=project_id, session_id=session_id)

--- a/ee/api/chalicelib/core/signup.py
+++ b/ee/api/chalicelib/core/signup.py
@@ -9,6 +9,7 @@ from chalicelib.utils import captcha, smtp
 from chalicelib.utils import helper
 from chalicelib.utils import pg_client
 from chalicelib.utils.TimeUTC import TimeUTC
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +21,7 @@ async def create_tenant(data: schemas.UserSignupSchema):
         return {"errors": ["tenants already registered"]}
 
     email = data.email
-    logger.debug(f"email: {email}")
+    logger.debug(f"email: {sanitize(email)}")
     password = data.password.get_secret_value()
     fullname = data.fullname
 
@@ -45,7 +46,7 @@ async def create_tenant(data: schemas.UserSignupSchema):
 
     if len(errors) > 0:
         logger.warning(
-            f"==> signup error for:\n email:{data.email}, fullname:{data.fullname}, organizationName:{data.organizationName}")
+            f"==> signup error for:\n email:{sanitize(data.email)}, fullname:{sanitize(data.fullname)}, organizationName:{sanitize(data.organizationName)}")
         logger.warning(errors)
         return {"errors": errors}
 

--- a/ee/api/chalicelib/core/unlock.py
+++ b/ee/api/chalicelib/core/unlock.py
@@ -7,6 +7,7 @@ from decouple import config
 
 from chalicelib.utils import helper
 from chalicelib.utils.TimeUTC import TimeUTC
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ def check():
                       json={"mid": __get_mid(), "license": get_license()})
     if r.status_code != 200 or "errors" in r.json() or not r.json()["data"].get("valid"):
         logger.warning("license validation failed")
-        logger.warning(r.text)
+        logger.warning(sanitize(r.text))
         environ["expiration"] = "-1"
     else:
         environ["expiration"] = str(r.json()["data"].get("expiration"))

--- a/ee/api/chalicelib/core/webhook.py
+++ b/ee/api/chalicelib/core/webhook.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException, status
 import schemas
 from chalicelib.utils import pg_client, helper
 from chalicelib.utils.TimeUTC import TimeUTC
+from chalicelib.utils.log import sanitize
 
 
 def get_by_id(webhook_id):
@@ -183,7 +184,7 @@ def __trigger(hook, data):
             logging.error("=======> webhook: something went wrong for:")
             logging.error(hook)
             logging.error(r.status_code)
-            logging.error(r.text)
+            logging.error(sanitize(r.text))
             return
         response = None
         try:

--- a/ee/api/clean-dev.sh
+++ b/ee/api/clean-dev.sh
@@ -101,3 +101,4 @@ rm -rf ./chalicelib/core/notes.py
 rm -rf ./chalicelib/utils/contextual_validators.py
 rm -rf ./routers/subs/product_analytics.py
 rm -rf ./schemas/product_analytics.py
+rm -rf ./chalicelib/utils/log.py

--- a/ee/api/or_dependencies.py
+++ b/ee/api/or_dependencies.py
@@ -15,6 +15,7 @@ from starlette.responses import Response, JSONResponse
 import schemas
 from chalicelib.core import traces
 from chalicelib.utils import helper
+from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ class ORRoute(APIRoute):
                 response: Response = await original_route_handler(request)
             except RequestValidationError as exc:
                 # 422 validation exception
-                logger.warning(f"!!! 422 exception when calling: {request.method} {request.url}")
+                logger.warning(f"!!! 422 exception when calling: {sanitize(request.method, max_length=16)} {sanitize(str(request.url))}")
                 logger.warning(exc.errors())
                 raise exc
             except HTTPException as e:


### PR DESCRIPTION
refactor(chalice): sanitized all logs, fixes #4647
refactor(chalice): fixed typo, fixes #4648
refactor(chalice): changed jwt-leeway, fixes #4649

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitized logging across API and EE to prevent leaking sensitive data and log forging, and made JWT leeway configurable with a safer default. Also cleaned up noisy prints/logs and fixed a small typo in a log message.

- **Refactors**
  - Added `chalicelib/utils/log.py` with `sanitize()` and applied it to request data, errors, third‑party responses, tokens, and emails.
  - Replaced `print` with structured `logger` calls; sanitized middleware request logs and external service responses.
  - Unified JWT leeway via `_get_jwt_leeway()`; corrected "spotRefreshToken" message typo.

- **Migration**
  - Default JWT leeway reduced from 3 days to 300 seconds.
  - To keep previous behavior, set `JWT_LEEWAY_DAYS=3` (or tune `JWT_LEEWAY_S`). No DB or API contract changes.

<sup>Written for commit 9cc58b68f6e6031c218540fbf118abc26865107f. Summary will update on new commits. <a href="https://cubic.dev/pr/openreplay/openreplay/pull/4657?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

