### PR TITLE
fix(helm): emit empty AWS_ENDPOINT in IRSA mode so S3 uploads work on EKS

### DIFF
--- a/scripts/helmcharts/openreplay/templates/_helpers.tpl
+++ b/scripts/helmcharts/openreplay/templates/_helpers.tpl
@@ -35,11 +35,15 @@ ingress-nginx: &ingress-nginx
   {{- else -}}
     {{-  .Values.global.s3.endpoint -}}
   {{- end -}}
-{{/* Endpoint wil be empty if used with aws iam roles*/}}
 {{- else if and .Values.global.s3.accessKey .Values.global.s3.secretKey -}}
   {{- printf "https://s3.%s.amazonaws.com" .Values.global.s3.region -}}
-{{- else -}}
-  {{- printf "https://s3.%s.amazonaws.com" .Values.global.s3.region -}}
+{{/* IRSA / instance-role mode: emit an empty endpoint so the AWS SDK
+     falls back to its default virtual-hosted endpoint resolver over
+     HTTPS. The backend Go S3 client (backend/pkg/objectstorage/s3/s3.go)
+     interprets any non-empty AWS_ENDPOINT as MinIO / S3-compatible mode
+     and sets DisableSSL=true + S3ForcePathStyle=true, which silently
+     breaks PutObject against AWS S3's public endpoint (HTTP -> HTTPS
+     redirect on a PUT body is not followed by aws-sdk-go v1). */}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
## Problem

When deploying the chart with IRSA (or any AWS instance-role
authentication) — i.e. `global.s3.endpoint` empty *and* no
`global.s3.accessKey` / `global.s3.secretKey` — the
`openreplay.s3Endpoint` helper still emits
`https://s3.<region>.amazonaws.com` as the endpoint, despite the
inline comment claiming otherwise:

```
{{/* Endpoint wil be empty if used with aws iam roles*/}}
{{- else if and .Values.global.s3.accessKey .Values.global.s3.secretKey -}}
  {{- printf "https://s3.%s.amazonaws.com" .Values.global.s3.region -}}
{{- else -}}
  {{- printf "https://s3.%s.amazonaws.com" .Values.global.s3.region -}}  ← same value as static-keys branch
{{- end -}}
```

That non-empty `AWS_ENDPOINT` propagates to every S3-touching
component (storage, sink, http, alerts, assets, canvases, images,
integrations, spot) and trips the backend Go S3 client into
MinIO-compatible mode:

```go
// backend/pkg/objectstorage/s3/s3.go:45-48
if cfg.AWSEndpoint != "" {
    config.Endpoint = aws.String(cfg.AWSEndpoint)
    config.DisableSSL = aws.Bool(true)
    config.S3ForcePathStyle = aws.Bool(true)
    ...
}
```

Against AWS S3's real endpoint this silently breaks `PutObject`: the
SDK issues `http://s3.<region>.amazonaws.com/<bucket>/<key>`, S3
308-redirects HTTP→HTTPS, and `aws-sdk-go` v1 doesn't follow the
redirect on a request with a body. The storage worker then compounds
the issue by only logging upload errors when **both** the `s` and `e`
mob uploads fail simultaneously
(`backend/pkg/storage/storage.go:188`), so in practice the storage
pod just emits `count: N` heartbeats while every session payload
silently fails to land in S3.

## User-visible symptoms

- OpenReplay UI lists sessions normally (ClickHouse metadata is fine).
- Clicking **Play** on any session returns no data / blank player.
- Recordings bucket stays empty regardless of how much traffic flows
  through.
- No errors in any pod log; the storage worker's only output is
  `count: N` heartbeats.

## Fix

Drop the bogus endpoint emission from the third branch so the helper
renders to an empty string in IRSA mode. The AWS SDK's default
virtual-hosted endpoint resolver then takes over and uploads work
without any code change to the Go clients. The minio path and the
static-keys path are unchanged.

## Verification

Verified with `helm template` across all three modes:

| Values | Before | After |
|---|---|---|
| `endpoint: ""` (no keys) | `https://s3.us-east-1.amazonaws.com` | `''` |
| `endpoint: ""` + `accessKey` + `secretKey` | `https://s3.us-east-1.amazonaws.com` | `https://s3.us-east-1.amazonaws.com` (unchanged) |
| `endpoint: "https://minio.example.com"` | `http://<domain>` | `http://<domain>` (unchanged) |

End-to-end reproduced and verified on a v1.27.0 deployment running
on EKS + IRSA: live-patching `AWS_ENDPOINT-` on the storage pod made
a previously-stuck portal session upload to S3 within ~3 seconds.
After applying this chart fix, no per-pod patches are needed and the
upload pipeline runs cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Helm `openreplay.s3Endpoint` helper to emit an empty `AWS_ENDPOINT` in IRSA/instance-role mode so AWS S3 uploads work on EKS. Prevents the backend from switching to MinIO-compatible mode that broke `PutObject`.

- **Bug Fixes**
  - IRSA mode (no `global.s3.endpoint`, no `global.s3.accessKey`/`secretKey`) now returns `''`, letting `aws-sdk-go` use its default HTTPS virtual-hosted S3 endpoint.
  - Static-keys path still emits `https://s3.<region>.amazonaws.com`; MinIO/custom endpoints unchanged.
  - Verified via `helm template` and on EKS + IRSA: uploads succeed and sessions play as expected.

<sup>Written for commit d7ae055a22bf8f0453b67c4fb7f166616cb979a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4660?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

