### PR TITLE
refactor(analytics): centralize output encoding for event read paths

### DIFF
--- a/backend/pkg/analytics/events/events.go
+++ b/backend/pkg/analytics/events/events.go
@@ -162,6 +162,8 @@ func (e *eventsImpl) SearchEvents(ctx context.Context, projID uint32, req *model
 			continue
 		}
 
+		entry.SanitizeForHTML()
+
 		events = append(events, entry)
 	}
 
@@ -229,6 +231,8 @@ func (e *eventsImpl) GetEventByID(ctx context.Context, projID uint32, eventID st
 		e.log.Error(ctx, "failed to unmarshal properties for event %s in project %d: %v", eventID, projID, err)
 		return nil, fmt.Errorf("failed to unmarshal properties for event %s: %w", eventID, err)
 	}
+
+	entry.SanitizeForHTML()
 
 	return &entry, nil
 }

--- a/backend/pkg/analytics/events/model/event.go
+++ b/backend/pkg/analytics/events/model/event.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"openreplay/backend/pkg/analytics/filters"
+	"openreplay/backend/pkg/analytics/sanitizer"
 )
 
 
@@ -74,6 +75,15 @@ func (e *EventEntry) UnmarshalProperties() error {
 	}
 
 	return nil
+}
+
+func (e *EventEntry) SanitizeForHTML() {
+	if e == nil {
+		return
+	}
+	sanitizer.EscapeStructStrings(e)
+	sanitizer.EscapePropertyMap(e.Properties)
+	sanitizer.EscapePropertyMap(e.AutoProperties)
 }
 
 type EventsSearchRequest struct {

--- a/backend/pkg/analytics/sanitizer/sanitizer.go
+++ b/backend/pkg/analytics/sanitizer/sanitizer.go
@@ -1,0 +1,67 @@
+package sanitizer
+
+import (
+	"html"
+	"reflect"
+)
+
+func EscapeStructStrings(v interface{}) {
+	val := reflect.ValueOf(v)
+	if val.Kind() != reflect.Ptr || val.IsNil() {
+		return
+	}
+	elem := val.Elem()
+	if elem.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < elem.NumField(); i++ {
+		field := elem.Field(i)
+		switch field.Kind() {
+		case reflect.String:
+			if field.CanSet() {
+				field.SetString(html.EscapeString(field.String()))
+			}
+		case reflect.Ptr:
+			if !field.IsNil() && field.Elem().Kind() == reflect.String && field.Elem().CanSet() {
+				field.Elem().SetString(html.EscapeString(field.Elem().String()))
+			}
+		case reflect.Slice:
+			if field.Type().Elem().Kind() == reflect.String {
+				for j := 0; j < field.Len(); j++ {
+					field.Index(j).SetString(html.EscapeString(field.Index(j).String()))
+				}
+			}
+		}
+	}
+}
+
+func EscapePropertyMap(props *map[string]interface{}) {
+	if props == nil || *props == nil {
+		return
+	}
+	escaped := make(map[string]interface{}, len(*props))
+	for k, val := range *props {
+		escaped[html.EscapeString(k)] = EscapePropertyValue(val)
+	}
+	*props = escaped
+}
+
+func EscapePropertyValue(val interface{}) interface{} {
+	switch v := val.(type) {
+	case string:
+		return html.EscapeString(v)
+	case map[string]interface{}:
+		escaped := make(map[string]interface{}, len(v))
+		for k, vv := range v {
+			escaped[html.EscapeString(k)] = EscapePropertyValue(vv)
+		}
+		return escaped
+	case []interface{}:
+		for i, vv := range v {
+			v[i] = EscapePropertyValue(vv)
+		}
+		return v
+	default:
+		return val
+	}
+}

--- a/backend/pkg/analytics/users/model/user.go
+++ b/backend/pkg/analytics/users/model/user.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"openreplay/backend/pkg/analytics/filters"
+	"openreplay/backend/pkg/analytics/sanitizer"
 )
 
 func init() {
@@ -126,6 +127,14 @@ func (u *UserRequest) UnmarshalProperties() error {
 	var err error
 	u.Properties, err = filters.UnmarshalJSONProperties(u.PropertiesRaw)
 	return err
+}
+
+func (u *UserRequest) SanitizeForHTML() {
+	if u == nil {
+		return
+	}
+	sanitizer.EscapeStructStrings(u)
+	sanitizer.EscapePropertyMap(u.Properties)
 }
 
 func (u *UserRequest) ConvertTimeFields() {
@@ -284,6 +293,13 @@ type UserEvent struct {
 	EventName    string `json:"$event_name"`
 	CreatedAt    int64  `json:"created_at"`
 	AutoCaptured *bool  `json:"$auto_captured,omitempty"`
+}
+
+func (e *UserEvent) SanitizeForHTML() {
+	if e == nil {
+		return
+	}
+	sanitizer.EscapeStructStrings(e)
 }
 
 type UserActivityResponse struct {

--- a/backend/pkg/analytics/users/users.go
+++ b/backend/pkg/analytics/users/users.go
@@ -159,6 +159,8 @@ func (u *usersImpl) GetByUserID(ctx context.Context, projID uint32, userId strin
 		return nil, fmt.Errorf("failed to unmarshal properties: %w", err)
 	}
 
+	user.SanitizeForHTML()
+
 	return user.ToUser(), nil
 }
 
@@ -242,6 +244,8 @@ func (u *usersImpl) SearchUsers(ctx context.Context, projID uint32, req *model.S
 			u.log.Error(ctx, "failed to unmarshal properties: %v", err)
 			continue
 		}
+
+		user.SanitizeForHTML()
 
 		users = append(users, user.ToMap(columnsStr))
 	}
@@ -525,6 +529,7 @@ func (u *usersImpl) GetUserActivity(ctx context.Context, projID uint32, userID s
 		}
 
 		event.CreatedAt = filters.ConvertTimeToMillis(createdAt)
+		event.SanitizeForHTML()
 		events = append(events, event)
 	}
 

--- a/frontend/app/components/DataManagement/Activity/EventDetailsModal.tsx
+++ b/frontend/app/components/DataManagement/Activity/EventDetailsModal.tsx
@@ -13,6 +13,7 @@ import usePropertyNames from 'App/components/DataManagement/Properties/useProper
 import { useStore } from 'App/mstore';
 import Event from 'App/mstore/types/Analytics/Event';
 import { Link } from 'App/routing';
+import { escapeHtml } from 'App/utils';
 import Tabs from 'Components/shared/Tabs';
 import { Icon, TextEllipsis } from 'UI';
 
@@ -104,15 +105,16 @@ function EventDetailsModal({
     null,
     4,
   );
+  const escapedJson = escapeHtml(strProps);
   const highlightedJson =
     view === 'pretty'
       ? ''
       : query
-        ? strProps.replace(
+        ? escapedJson.replace(
             new RegExp(query, 'ig'),
             (match) => `<mark>${match}</mark>`,
           )
-        : strProps;
+        : escapedJson;
 
   const onCopy = () => {
     copy(strProps);

--- a/frontend/app/components/ui/TextEllipsis/TextEllipsis.js
+++ b/frontend/app/components/ui/TextEllipsis/TextEllipsis.js
@@ -17,7 +17,7 @@ function findTextWidth(text, fontProp) {
   tag.style.left = '-99in';
   tag.style.whiteSpace = 'nowrap';
   tag.style.font = fontProp;
-  tag.innerHTML = text;
+  tag.textContent = text;
 
   document.body.appendChild(tag);
   const result = tag.clientWidth;

--- a/frontend/app/utils/index.ts
+++ b/frontend/app/utils/index.ts
@@ -8,6 +8,14 @@ export const HOUR_SECS = 60 * 60;
 export const DAY_SECS = 24 * HOUR_SECS;
 export const WEEK_SECS = 7 * DAY_SECS;
 
+export const escapeHtml = (str: string) =>
+  String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
 export const formatExpirationTime = (seconds: number) => {
   if (seconds >= WEEK_SECS) {
     return `${Math.floor(seconds / DAY_SECS)} days`;


### PR DESCRIPTION
Add a shared sanitizer for event fields/properties and apply it on the events read APIs; reuse a common HTML-escape helper in the dashboard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes HTML escaping for analytics event and user data across read paths to prevent XSS and ensure safe rendering in the dashboard. Adds a shared backend sanitizer and consistent escaping in the UI.

- **Bug Fixes**
  - Backend: Added `backend/pkg/analytics/sanitizer` to escape strings in structs and nested property maps/arrays; applied in `SearchEvents`, `GetEventByID`, `GetByUserID`, `SearchUsers`, and `GetUserActivity` via `SanitizeForHTML` on event/user models.
  - Frontend: Use `escapeHtml` in `EventDetailsModal` before highlighting JSON; switch to `textContent` in `TextEllipsis`.

<sup>Written for commit c0dc20009fa01db2383b11a9eaa649b0c3c1ee25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

