### PR TITLE
fix(chalice): returned used endpoint

### DIFF
--- a/api/chalicelib/core/metrics/custom_metrics.py
+++ b/api/chalicelib/core/metrics/custom_metrics.py
@@ -1,0 +1,26 @@
+from chalicelib.utils import helper, pg_client
+
+
+def get_series_for_alert(project_id, user_id):
+    with pg_client.PostgresClient() as cur:
+        cur.execute(
+            cur.mogrify(
+                """SELECT series_id AS value,
+                       metrics.name || '.' || (COALESCE(metric_series.name, 'series ' || index)) || '.count' AS name,
+                       'count' AS unit,
+                       FALSE AS predefined,
+                       metric_id,
+                       series_id
+                   FROM metric_series
+                       INNER JOIN metrics USING (metric_id)
+                   WHERE metrics.deleted_at ISNULL
+                     AND metrics.project_id = %(project_id)s
+                     AND metrics.metric_type = 'timeseries'
+                     AND (user_id = %(user_id)s
+                      OR is_public)
+                   ORDER BY name;""",
+                {"project_id": project_id, "user_id": user_id}
+            )
+        )
+        rows = cur.fetchall()
+    return helper.list_to_camel_case(rows)

--- a/api/routers/core.py
+++ b/api/routers/core.py
@@ -8,6 +8,7 @@ import schemas
 from chalicelib.core import projects, metadata, reset_password, log_tools, \
     announcements, weekly_report, assist, mobile, tenants, boarding, notifications, webhook, users, tags
 from chalicelib.core.alerts import alerts
+from chalicelib.core.metrics import custom_metrics
 from chalicelib.core.collaborations.collaboration_msteams import MSTeams
 from chalicelib.core.collaborations.collaboration_slack import Slack
 from chalicelib.core.issue_tracking import github, integrations_global, integrations_manager, \
@@ -502,6 +503,12 @@ def create_alert(projectId: int, data: schemas.AlertSchema = Body(...),
 @app.get('/{projectId}/alerts', tags=["alerts"])
 def get_all_alerts(projectId: int, context: schemas.CurrentContext = Depends(OR_context)):
     return {"data": alerts.get_all(project_id=projectId)}
+
+
+@app.get('/{projectId}/alerts/triggers', tags=["alerts", "customMetrics"])
+def get_alerts_triggers(projectId: int, context: schemas.CurrentContext = Depends(OR_context)):
+    return {"data": alerts.get_predefined_values()
+                    + custom_metrics.get_series_for_alert(project_id=projectId, user_id=context.user_id)}
 
 
 @app.get('/{projectId}/alerts/{alertId}', tags=["alerts"])


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restored the alerts triggers endpoint and extended it to include user-accessible custom metric series, so the UI can build alert conditions without extra calls.

- **Bug Fixes**
  - Re-added GET `/{projectId}/alerts/triggers`.
  - Response merges predefined triggers with custom timeseries from `metrics`/`metric_series`.
  - Added `chalicelib.core.metrics.custom_metrics.get_series_for_alert` to fetch user-owned or public series and return them in camelCase.

<sup>Written for commit e67cc347948aa8f03f4c8df2deb9ae387eaade86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

