### PR TITLE
New UI patches

### DIFF
--- a/frontend/app/components/Session_/Subheader.tsx
+++ b/frontend/app/components/Session_/Subheader.tsx
@@ -185,7 +185,7 @@ function SubHeader(props: any) {
       onClick: showKbHelp,
     },
   ];
-  if (account.hasVideoExport) {
+  if (isEnterprise) {
     dropdownItems.push({
       key: '5',
       label: (

--- a/frontend/app/layout/SideMenu/index.tsx
+++ b/frontend/app/layout/SideMenu/index.tsx
@@ -1,11 +1,11 @@
 import { Button, Drawer } from 'antd';
-import React from 'react';
-import { useLocation, useNavigate } from 'App/routing';
+import { Menu, X } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
-
-import MenuContent from './MenuContent';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import SupportModal from 'App/layout/SupportModal';
+import { useStore } from 'App/mstore';
 import * as routes from 'App/routes';
 import {
   CLIENT_DEFAULT_TAB,
@@ -13,20 +13,19 @@ import {
   client,
   withSiteId,
 } from 'App/routes';
-import { MODULES } from 'Components/Client/Modules/extra';
-import { hasAi } from 'App/utils/split-utils';
+import { useLocation, useNavigate } from 'App/routing';
 // added: util-based mobile detection
 import { mobileScreen } from 'App/utils/isMobile';
-import { useStore } from 'App/mstore';
+import { MODULES } from 'Components/Client/Modules/extra';
+
 import {
   MENU,
   PREFERENCES_MENU,
   categories as main_menu,
   preferences,
 } from '../data';
-import { useTranslation } from 'react-i18next';
 import { extraRoutes } from '../menuRoutes';
-import { Menu, X } from 'lucide-react';
+import MenuContent from './MenuContent';
 
 interface Props {
   isCollapsed?: boolean;
@@ -75,9 +74,7 @@ function SideMenu(props: Props) {
           item.key === MENU.ALERTS && modules.includes(MODULES.ALERTS),
           item.isAdmin && !isAdmin,
           item.isEnterprise && !isEnterprise,
-          item.key === MENU.KAI && !hasAi,
-          item.key === PREFERENCES_MENU.EXPORTED_VIDEOS &&
-            !account.hasVideoExport,
+          item.key === PREFERENCES_MENU.EXPORTED_VIDEOS && !isEnterprise,
         ].some(Boolean);
 
         return { ...item, hidden: isHidden };
@@ -120,7 +117,6 @@ function SideMenu(props: Props) {
     [PREFERENCES_MENU.BILLING]: () => client(CLIENT_TABS.BILLING),
     [PREFERENCES_MENU.MODULES]: () => client(CLIENT_TABS.MODULES),
     [MENU.HIGHLIGHTS]: () => withSiteId(routes.highlights(), siteId),
-    [MENU.KAI]: () => withSiteId(routes.kai(), siteId),
     [PREFERENCES_MENU.EXPORTED_VIDEOS]: () => client(CLIENT_TABS.VIDEOS),
     [MENU.ACTIVITY]: () => withSiteId(routes.dataManagement.activity(), siteId),
     [MENU.USERS]: () => withSiteId(routes.dataManagement.usersList(), siteId),

--- a/frontend/app/mstore/roleStore.ts
+++ b/frontend/app/mstore/roleStore.ts
@@ -11,7 +11,6 @@ const permissions = (t: TFunction) => [
   { text: t('Dashboard'), value: 'METRICS' },
   { text: t('Assist (Live)'), value: 'ASSIST_LIVE' },
   { text: t('Assist (Call)'), value: 'ASSIST_CALL' },
-  { text: t('Feature Flags'), value: 'FEATURE_FLAGS' },
   { text: t('Spots'), value: 'SPOT' },
   { text: t('Change Spot Visibility'), value: 'SPOT_PUBLIC' },
   { text: t('Data Management'), value: 'DATA_MANAGEMENT' },

--- a/frontend/app/player/web/Screen/Cursor.ts
+++ b/frontend/app/player/web/Screen/Cursor.ts
@@ -1,18 +1,14 @@
-import type { Point } from './types';
 import styles from './cursor.module.css';
+import type { Point } from './types';
 
 export default class Cursor {
   private readonly isMobile: boolean;
-
   private readonly cursor: HTMLDivElement;
-
   private tagElement: HTMLDivElement;
-
   private coords = { x: 0, y: 0 };
-
   private isMoving = false;
-
   private onClick: () => void;
+  private highlightCursor = false;
 
   constructor(overlay: HTMLDivElement, isMobile: boolean) {
     this.cursor = document.createElement('div');
@@ -20,6 +16,8 @@ export default class Cursor {
     if (isMobile) this.cursor.style.backgroundImage = 'unset';
     overlay.appendChild(this.cursor);
     this.isMobile = isMobile;
+    this.highlightCursor =
+      new URLSearchParams(window.location.search).get('timer') === 'true';
   }
 
   toggle(flag: boolean) {
@@ -79,6 +77,15 @@ export default class Cursor {
   }
 
   click() {
+    if (this.highlightCursor) {
+      const styleList = styles.timerClicked;
+      this.cursor.classList.add(styleList);
+      this.onClick?.();
+      setTimeout(() => {
+        this.cursor.classList.remove(styleList);
+      }, 510);
+      return;
+    }
     const styleList = styles.clicked;
     this.cursor.classList.add(styleList);
     this.onClick?.();

--- a/frontend/app/player/web/Screen/cursor.module.css
+++ b/frontend/app/player/web/Screen/cursor.module.css
@@ -68,6 +68,23 @@
   }
 }
 
+/* timer mode: static red ring so a click is captured by at least one 2fps frame */
+.timerClicked::after {
+  box-sizing: border-box;
+  position: absolute;
+  margin: -30px 0 0 -30px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 3px solid #cc0000;
+  /* white ring inside and outside the red so it stays visible on any background */
+  box-shadow: 0 0 0 1.5px #fff, inset 0 0 0 1.5px #fff;
+  content: '';
+  opacity: 1;
+  pointer-events: none;
+  user-select: none;
+}
+
 .mobileTouch {
     width: 25px;
     height: 25px;

--- a/frontend/app/types/account/account.ts
+++ b/frontend/app/types/account/account.ts
@@ -74,18 +74,10 @@ export default class Account {
     makeAutoObservable(this);
   }
 
-  get hasVideoExport() {
-    if (!this.settings || !this.settings.modules) {
-      return false;
-    }
-    const hasModule = this.settings.modules?.includes('replay-export');
-    return hasModule;
-  }
-
   get hasExportPermission() {
     const hasPermission = this.permissions.includes('SESSION_EXPORT');
     const isAdmin = this.admin || this.superAdmin;
-    return this.hasVideoExport && (hasPermission || isAdmin);
+    return hasPermission || isAdmin;
   }
 
   toData = () => ({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves replay export UX with visible click highlights in timer mode and simplifies export access by removing module gating. Also cleans up the side menu (no KAI; Exported Videos is enterprise-only).

- **New Features**
  - Timer mode for player: add `?timer=true` to the URL to show a static red ring on clicks, ensuring they’re captured in low‑fps exports.

- **Refactors**
  - Removed module checks for recording export; UI gates by `isEnterprise`; `hasExportPermission` now checks only permission or admin.
  - Side menu: hide Exported Videos for non‑enterprise; removed KAI item and route.
  - Dropped Feature Flags from role permissions UI.

<sup>Written for commit f1ca52950a8517d391d64460840006129e30bc18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

