### PR TITLE
Assets code improvements

### DIFF
--- a/backend/cmd/assets/main.go
+++ b/backend/cmd/assets/main.go
@@ -179,6 +179,8 @@ func main() {
 			cacher.UpdateTimeouts()
 		default:
 			if !cacher.CanCache() {
+				// TODO: replace with a signal from the pool when a slot frees up.
+				time.Sleep(time.Millisecond)
 				continue
 			}
 			if err := msgConsumer.ConsumeNext(); err != nil {

--- a/backend/cmd/assets/main.go
+++ b/backend/cmd/assets/main.go
@@ -53,7 +53,7 @@ func main() {
 	if err != nil {
 		log.Fatal(ctx, "can't init object storage: %s", err)
 	}
-	cacher, err := cacher.NewCacher(cfg, objStore, assetMetrics)
+	cacher, err := cacher.NewCacher(log, cfg, objStore, assetMetrics)
 	if err != nil {
 		log.Fatal(ctx, "can't init cacher: %s", err)
 	}
@@ -175,8 +175,6 @@ func main() {
 			producer.Close(cfg.ProducerCloseTimeout)
 			msgConsumer.Close()
 			os.Exit(0)
-		case err := <-cacher.Errors:
-			log.Error(ctx, "Error while caching: %s", err)
 		case <-tick:
 			cacher.UpdateTimeouts()
 		default:

--- a/backend/cmd/assets/main.go
+++ b/backend/cmd/assets/main.go
@@ -89,7 +89,7 @@ func main() {
 			}
 
 			data := msg.Encode()
-			if data != nil && len(data) > 0 {
+			if len(data) > 0 {
 				if !messages.MessageHasSize(uint64(msg.TypeID())) {
 					buf.Write(data)
 				} else {

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -54,7 +54,7 @@ func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.Object
 	}
 
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
 	}
 
 	if cfg.ClientCertFilePath != "" && cfg.ClientKeyFilePath != "" && cfg.CaCertFilePath != "" {
@@ -75,7 +75,7 @@ func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.Object
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
 		tlsConfig = &tls.Config{
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: cfg.InsecureSkipVerify,
 			Certificates:       []tls.Certificate{cert},
 			RootCAs:            caCertPool,
 		}

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -141,7 +141,9 @@ func (c *cacher) cacheURL(t *Task) {
 	}
 	start := time.Now()
 	req, _ := http.NewRequest("GET", t.requestURL, nil)
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:98.0) Gecko/20100101 Firefox/98.0")
+	//req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:98.0) Gecko/20100101 Firefox/98.0")
+	// Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36")
 	for k, v := range c.requestHeaders {
 		req.Header.Set(k, v)
 	}

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -41,6 +41,7 @@ type cacher struct {
 	retryBase      time.Duration
 	retryCap       time.Duration
 	retryAfterCap  time.Duration
+	failureTTL     time.Duration
 	requestHeaders map[string]string
 	workers        *WorkerPool
 	scheduler      *scheduler
@@ -110,6 +111,7 @@ func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.Object
 		retryBase:      time.Duration(cfg.AssetsRetryBaseMs) * time.Millisecond,
 		retryCap:       time.Duration(cfg.AssetsRetryMaxMs) * time.Millisecond,
 		retryAfterCap:  time.Duration(cfg.AssetsRetryAfterCap) * time.Millisecond,
+		failureTTL:     time.Duration(cfg.AssetsFailureSuppMin) * time.Minute,
 		requestHeaders: cfg.AssetsRequestHeaders,
 		metrics:        metrics,
 		hosts:          newHostLimiter(cfg.AssetsPerHostLimit),
@@ -231,7 +233,7 @@ func (c *cacher) retry(ctx context.Context, t *Task, explicitDelay time.Duration
 	t.attempt++
 	if t.attempt >= c.maxAttempts {
 		// final try: drop, record, and evict the dedup entry so a future asset can re-trigger the download.
-		c.timeoutMap.delete(t.cachePath)
+		c.timeoutMap.addFor(t.cachePath, c.failureTTL)
 		c.metrics.IncreaseTerminalFailures(reason)
 		c.log.Error(ctx, "Error while caching (terminal, attempts=%d, reason=%s): %s", t.attempt, reason, errors.Wrap(cause, t.urlContext))
 		return

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -6,10 +6,13 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"math/rand"
 	"mime"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,6 +27,8 @@ import (
 
 const MAX_CACHE_DEPTH = 5
 
+const hostDeferDelay = 250 * time.Millisecond
+
 type cacher struct {
 	log            logger.Logger
 	timeoutMap     *timeoutMap                 // Concurrency implemented
@@ -32,9 +37,14 @@ type cacher struct {
 	rewriter       *assets.Rewriter            // Read only
 	metrics        metrics.Assets
 	sizeLimit      int
-	retries        int
+	maxAttempts    int
+	retryBase      time.Duration
+	retryCap       time.Duration
+	retryAfterCap  time.Duration
 	requestHeaders map[string]string
 	workers        *WorkerPool
+	scheduler      *scheduler
+	hosts          *hostLimiter
 }
 
 func (c *cacher) CanCache() bool {
@@ -96,11 +106,18 @@ func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.Object
 		},
 		rewriter:       rewriter,
 		sizeLimit:      cfg.AssetsSizeLimit,
-		retries:        cfg.AssetsRetries,
+		maxAttempts:    cfg.AssetsRetries,
+		retryBase:      time.Duration(cfg.AssetsRetryBaseMs) * time.Millisecond,
+		retryCap:       time.Duration(cfg.AssetsRetryMaxMs) * time.Millisecond,
+		retryAfterCap:  time.Duration(cfg.AssetsRetryAfterCap) * time.Millisecond,
 		requestHeaders: cfg.AssetsRequestHeaders,
 		metrics:        metrics,
+		hosts:          newHostLimiter(cfg.AssetsPerHostLimit),
 	}
 	c.workers = NewPool(cfg.AssetsWorkerCount, cfg.AssetsQueueSize, c.CacheFile)
+	c.scheduler = newScheduler(cfg.AssetsRetryHeapLimit, c.workers.tryAddTask, func(n int) {
+		c.metrics.RecordRetryQueueSize(float64(n))
+	})
 	return c, nil
 }
 
@@ -110,11 +127,18 @@ func (c *cacher) CacheFile(task *Task) {
 
 func (c *cacher) cacheURL(t *Task) {
 	ctx := context.WithValue(context.Background(), "sessionID", t.sessionID)
+
+	// Per-host throttle: this is NOT a retry — the attempt counter is untouched.
+	if !c.hosts.tryAcquire(t.host) {
+		c.scheduleThrottle(ctx, t)
+		return
+	}
+	defer c.hosts.release(t.host)
+
 	crTime := c.objStorage.GetCreationTime(t.cachePath)
 	if crTime != nil && crTime.After(time.Now().Add(-MAX_STORAGE_TIME)) {
 		return
 	}
-	t.retries--
 	start := time.Now()
 	req, _ := http.NewRequest("GET", t.requestURL, nil)
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:98.0) Gecko/20100101 Firefox/98.0")
@@ -123,32 +147,28 @@ func (c *cacher) cacheURL(t *Task) {
 	}
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		c.log.Error(ctx, "Error while caching: %s", errors.Wrap(err, t.urlContext))
+		c.retry(ctx, t, 0, "network", err)
 		return
 	}
 	c.metrics.RecordDownloadDuration(float64(time.Now().Sub(start).Milliseconds()), res.StatusCode)
 	defer res.Body.Close()
 	if res.StatusCode >= 400 {
-		printErr := true
-		// TODO: revisit with the retry mechanics rework — when the queue is full
-		// the retry is dropped and we fall through to logging the status code.
-		if (res.StatusCode == 403 || res.StatusCode == 503) && t.retries > 0 {
-			if c.workers.tryAddTask(t) {
-				printErr = false
-			}
-		}
-		if printErr {
-			c.log.Error(ctx, "Error while caching: %s", errors.Wrap(fmt.Errorf("Status code is %v, ", res.StatusCode), t.urlContext))
+		cause := fmt.Errorf("status code is %d", res.StatusCode)
+		reason := "status_" + strconv.Itoa(res.StatusCode)
+		if isRetryableStatus(res.StatusCode) {
+			c.retry(ctx, t, c.retryAfterDelay(res), reason, cause)
+		} else {
+			c.permanent(ctx, t, reason, cause)
 		}
 		return
 	}
 	data, err := io.ReadAll(io.LimitReader(res.Body, int64(c.sizeLimit+1)))
 	if err != nil {
-		c.log.Error(ctx, "Error while caching: %s", errors.Wrap(err, t.urlContext))
+		c.retry(ctx, t, 0, "read_body", err)
 		return
 	}
 	if len(data) > c.sizeLimit {
-		c.log.Error(ctx, "Error while caching: %s", errors.Wrap(errors.New("Maximum size exceeded"), t.urlContext))
+		c.permanent(ctx, t, "size_exceeded", errors.New("maximum size exceeded"))
 		return
 	}
 
@@ -160,15 +180,16 @@ func (c *cacher) cacheURL(t *Task) {
 
 	// Skip html file (usually it's a CDN mock for 404 error)
 	if strings.HasPrefix(contentType, "text/html") {
-		c.log.Error(ctx, "Error while caching: %s", errors.Wrap(fmt.Errorf("context type is text/html, sessID: %d", t.sessionID), t.urlContext))
+		c.permanent(ctx, t, "text_html", fmt.Errorf("content type is text/html"))
 		return
 	}
 
 	isCSS := strings.HasPrefix(contentType, "text/css")
 
 	strData := string(data)
+	var cssURLs []string
 	if isCSS {
-		strData = c.rewriter.RewriteCSS(t.sessionID, t.requestURL, strData) // TODO: one method for rewrite and return list
+		strData, cssURLs = c.rewriter.RewriteCSSAndExtract(t.sessionID, t.requestURL, strData)
 	}
 
 	// TODO: implement in streams
@@ -176,7 +197,7 @@ func (c *cacher) cacheURL(t *Task) {
 	err = c.objStorage.Upload(strings.NewReader(strData), t.cachePath, contentType, contentEncoding, objectstorage.NoCompression)
 	if err != nil {
 		c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), true)
-		c.log.Error(ctx, "Error while caching: %s", errors.Wrap(err, t.urlContext))
+		c.retry(ctx, t, 0, "upload", err)
 		return
 	}
 	c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), false)
@@ -184,7 +205,7 @@ func (c *cacher) cacheURL(t *Task) {
 
 	if isCSS {
 		if t.depth > 0 {
-			for _, extractedURL := range assets.ExtractURLsFromCSS(string(data)) {
+			for _, extractedURL := range cssURLs {
 				if fullURL, cachable := assets.GetFullCachableURL(t.requestURL, extractedURL); cachable {
 					// false: we are inside a worker, enqueue must be non-blocking
 					c.checkTask(&Task{
@@ -193,7 +214,6 @@ func (c *cacher) cacheURL(t *Task) {
 						depth:      t.depth - 1,
 						urlContext: t.urlContext + "\n  -> " + fullURL,
 						isJS:       false,
-						retries:    c.retries,
 					}, false)
 				}
 			}
@@ -203,6 +223,104 @@ func (c *cacher) cacheURL(t *Task) {
 		}
 	}
 	return
+}
+
+func (c *cacher) retry(ctx context.Context, t *Task, explicitDelay time.Duration, reason string, cause error) {
+	t.attempt++
+	if t.attempt >= c.maxAttempts {
+		// final try: drop, record, and evict the dedup entry so a future asset can re-trigger the download.
+		c.timeoutMap.delete(t.cachePath)
+		c.metrics.IncreaseTerminalFailures(reason)
+		c.log.Error(ctx, "Error while caching (terminal, attempts=%d, reason=%s): %s", t.attempt, reason, errors.Wrap(cause, t.urlContext))
+		return
+	}
+	delay := explicitDelay
+	if delay <= 0 {
+		delay = c.backoff(t.attempt)
+	}
+	if c.scheduler.schedule(t, time.Now().Add(delay)) {
+		c.metrics.IncreaseRetries()
+	} else {
+		// retry heap is full: shed load (the entry stays deduped for now)
+		c.metrics.IncreaseTerminalFailures("retry_queue_full")
+		c.log.Warn(ctx, "retry queue full, dropping asset: %s", errors.Wrap(cause, t.urlContext))
+	}
+}
+
+func (c *cacher) permanent(ctx context.Context, t *Task, reason string, cause error) {
+	c.metrics.IncreaseTerminalFailures(reason)
+	c.log.Error(ctx, "Error while caching (permanent, reason=%s): %s", reason, errors.Wrap(cause, t.urlContext))
+}
+
+func (c *cacher) scheduleThrottle(ctx context.Context, t *Task) {
+	delay := hostDeferDelay + time.Duration(rand.Int63n(int64(hostDeferDelay)))
+	if !c.scheduler.schedule(t, time.Now().Add(delay)) {
+		c.metrics.IncreaseTerminalFailures("throttle_queue_full")
+		c.log.Warn(ctx, "retry queue full, dropping throttled asset: %s", t.urlContext)
+	}
+}
+
+func (c *cacher) backoff(attempt int) time.Duration {
+	d := c.retryCap
+	if shift := attempt - 1; shift >= 0 && shift < 31 {
+		if scaled := c.retryBase << uint(shift); scaled > 0 && scaled < c.retryCap {
+			d = scaled
+		}
+	}
+	if d <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(d)))
+}
+
+func (c *cacher) retryAfterDelay(res *http.Response) time.Duration {
+	if res.StatusCode != http.StatusTooManyRequests && res.StatusCode != http.StatusServiceUnavailable {
+		return 0
+	}
+	d, ok := parseRetryAfter(res.Header.Get("Retry-After"))
+	if !ok {
+		return 0
+	}
+	if d > c.retryAfterCap {
+		d = c.retryAfterCap
+	}
+	return d
+}
+
+func isRetryableStatus(code int) bool {
+	switch code {
+	case http.StatusForbidden, http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return true
+	}
+	return code >= 500
+}
+
+func parseRetryAfter(h string) (time.Duration, bool) {
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(h); err == nil {
+		if secs < 0 {
+			return 0, false
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(h); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d, true
+		}
+		return 0, true
+	}
+	return 0, false
+}
+
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
 }
 
 // checkTask deduplicates and enqueues a task. blocking selects the enqueue
@@ -222,11 +340,12 @@ func (c *cacher) checkTask(newTask *Task, blocking bool) {
 	c.timeoutMap.add(cachePath)
 	// add new file in queue to download
 	newTask.cachePath = cachePath
+	newTask.host = hostOf(newTask.requestURL)
 	if blocking {
 		c.workers.AddTask(newTask)
 		return
 	}
-	// TODO: revisit with the retry mechanics rework — drop-on-full loses the task.
+
 	if !c.workers.tryAddTask(newTask) {
 		ctx := context.WithValue(context.Background(), "sessionID", newTask.sessionID)
 		c.log.Warn(ctx, "cacher queue full, dropping asset task: %s", newTask.requestURL)
@@ -240,7 +359,6 @@ func (c *cacher) CacheJSFile(sourceURL string) {
 		depth:      0,
 		urlContext: sourceURL,
 		isJS:       true,
-		retries:    c.retries,
 	}, true)
 }
 
@@ -251,7 +369,6 @@ func (c *cacher) CacheURL(sessionID uint64, fullURL string) {
 		depth:      MAX_CACHE_DEPTH,
 		urlContext: fullURL,
 		isJS:       false,
-		retries:    c.retries,
 	}, true)
 }
 
@@ -260,5 +377,6 @@ func (c *cacher) UpdateTimeouts() {
 }
 
 func (c *cacher) Stop() {
+	c.scheduler.stop()
 	c.workers.Stop()
 }

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -1,6 +1,7 @@
 package cacher
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	config "openreplay/backend/internal/config/assets"
+	"openreplay/backend/pkg/logger"
 	metrics "openreplay/backend/pkg/metrics/assets"
 	"openreplay/backend/pkg/objectstorage"
 	"openreplay/backend/pkg/url/assets"
@@ -23,12 +25,12 @@ import (
 const MAX_CACHE_DEPTH = 5
 
 type cacher struct {
+	log            logger.Logger
 	timeoutMap     *timeoutMap                 // Concurrency implemented
 	objStorage     objectstorage.ObjectStorage // AWS Docs: "These clients are safe to use concurrently."
 	httpClient     *http.Client                // Docs: "Clients are safe for concurrent use by multiple goroutines."
 	rewriter       *assets.Rewriter            // Read only
 	metrics        metrics.Assets
-	Errors         chan error
 	sizeLimit      int
 	requestHeaders map[string]string
 	workers        *WorkerPool
@@ -38,7 +40,7 @@ func (c *cacher) CanCache() bool {
 	return c.workers.CanAddTask()
 }
 
-func NewCacher(cfg *config.Config, store objectstorage.ObjectStorage, metrics metrics.Assets) (*cacher, error) {
+func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.ObjectStorage, metrics metrics.Assets) (*cacher, error) {
 	switch {
 	case cfg == nil:
 		return nil, errors.New("config is nil")
@@ -81,6 +83,7 @@ func NewCacher(cfg *config.Config, store objectstorage.ObjectStorage, metrics me
 	}
 
 	c := &cacher{
+		log:        log,
 		timeoutMap: newTimeoutMap(),
 		objStorage: store,
 		httpClient: &http.Client{
@@ -91,7 +94,6 @@ func NewCacher(cfg *config.Config, store objectstorage.ObjectStorage, metrics me
 			},
 		},
 		rewriter:       rewriter,
-		Errors:         make(chan error),
 		sizeLimit:      cfg.AssetsSizeLimit,
 		requestHeaders: cfg.AssetsRequestHeaders,
 		metrics:        metrics,
@@ -105,6 +107,7 @@ func (c *cacher) CacheFile(task *Task) {
 }
 
 func (c *cacher) cacheURL(t *Task) {
+	ctx := context.WithValue(context.Background(), "sessionID", t.sessionID)
 	t.retries--
 	start := time.Now()
 	req, _ := http.NewRequest("GET", t.requestURL, nil)
@@ -114,7 +117,7 @@ func (c *cacher) cacheURL(t *Task) {
 	}
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		c.Errors <- errors.Wrap(err, t.urlContext)
+		c.log.Error(ctx, "Error while caching: %s", errors.Wrap(err, t.urlContext))
 		return
 	}
 	c.metrics.RecordDownloadDuration(float64(time.Now().Sub(start).Milliseconds()), res.StatusCode)
@@ -127,17 +130,17 @@ func (c *cacher) cacheURL(t *Task) {
 			printErr = false
 		}
 		if printErr {
-			c.Errors <- errors.Wrap(fmt.Errorf("Status code is %v, ", res.StatusCode), t.urlContext)
+			c.log.Error(ctx, "Error while caching: %s", errors.Wrap(fmt.Errorf("Status code is %v, ", res.StatusCode), t.urlContext))
 		}
 		return
 	}
 	data, err := io.ReadAll(io.LimitReader(res.Body, int64(c.sizeLimit+1)))
 	if err != nil {
-		c.Errors <- errors.Wrap(err, t.urlContext)
+		c.log.Error(ctx, "Error while caching: %s", errors.Wrap(err, t.urlContext))
 		return
 	}
 	if len(data) > c.sizeLimit {
-		c.Errors <- errors.Wrap(errors.New("Maximum size exceeded"), t.urlContext)
+		c.log.Error(ctx, "Error while caching: %s", errors.Wrap(errors.New("Maximum size exceeded"), t.urlContext))
 		return
 	}
 
@@ -149,7 +152,7 @@ func (c *cacher) cacheURL(t *Task) {
 
 	// Skip html file (usually it's a CDN mock for 404 error)
 	if strings.HasPrefix(contentType, "text/html") {
-		c.Errors <- errors.Wrap(fmt.Errorf("context type is text/html, sessID: %d", t.sessionID), t.urlContext)
+		c.log.Error(ctx, "Error while caching: %s", errors.Wrap(fmt.Errorf("context type is text/html, sessID: %d", t.sessionID), t.urlContext))
 		return
 	}
 
@@ -165,7 +168,7 @@ func (c *cacher) cacheURL(t *Task) {
 	err = c.objStorage.Upload(strings.NewReader(strData), t.cachePath, contentType, contentEncoding, objectstorage.NoCompression)
 	if err != nil {
 		c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), true)
-		c.Errors <- errors.Wrap(err, t.urlContext)
+		c.log.Error(ctx, "Error while caching: %s", errors.Wrap(err, t.urlContext))
 		return
 	}
 	c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), false)
@@ -186,11 +189,11 @@ func (c *cacher) cacheURL(t *Task) {
 				}
 			}
 			if err != nil {
-				c.Errors <- errors.Wrap(err, t.urlContext)
+				c.log.Error(ctx, "Error while caching: %s", errors.Wrap(err, t.urlContext))
 				return
 			}
 		} else {
-			c.Errors <- errors.Wrap(errors.New("Maximum recursion cache depth exceeded"), t.urlContext)
+			c.log.Error(ctx, "Error while caching: %s", errors.Wrap(errors.New("Maximum recursion cache depth exceeded"), t.urlContext))
 			return
 		}
 	}

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -349,16 +349,16 @@ func (c *cacher) checkTask(newTask *Task, blocking bool) {
 	if c.timeoutMap.contains(cachePath) {
 		return
 	}
-	c.timeoutMap.add(cachePath)
-	// add new file in queue to download
 	newTask.cachePath = cachePath
 	newTask.host = hostOf(newTask.requestURL)
 	if blocking {
+		c.timeoutMap.add(cachePath)
 		c.workers.AddTask(newTask)
 		return
 	}
-
-	if !c.workers.tryAddTask(newTask) {
+	if c.workers.tryAddTask(newTask) {
+		c.timeoutMap.add(cachePath)
+	} else {
 		ctx := context.WithValue(context.Background(), "sessionID", newTask.sessionID)
 		c.log.Warn(ctx, "cacher queue full, dropping asset task: %s", newTask.requestURL)
 	}

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -124,10 +124,12 @@ func (c *cacher) cacheURL(t *Task) {
 	defer res.Body.Close()
 	if res.StatusCode >= 400 {
 		printErr := true
-		// Retry 403/503 errors
+		// TODO: revisit with the retry mechanics rework — when the queue is full
+		// the retry is dropped and we fall through to logging the status code.
 		if (res.StatusCode == 403 || res.StatusCode == 503) && t.retries > 0 {
-			c.workers.AddTask(t)
-			printErr = false
+			if c.workers.tryAddTask(t) {
+				printErr = false
+			}
 		}
 		if printErr {
 			c.log.Error(ctx, "Error while caching: %s", errors.Wrap(fmt.Errorf("Status code is %v, ", res.StatusCode), t.urlContext))
@@ -178,6 +180,7 @@ func (c *cacher) cacheURL(t *Task) {
 		if t.depth > 0 {
 			for _, extractedURL := range assets.ExtractURLsFromCSS(string(data)) {
 				if fullURL, cachable := assets.GetFullCachableURL(t.requestURL, extractedURL); cachable {
+					// false: we are inside a worker, enqueue must be non-blocking
 					c.checkTask(&Task{
 						requestURL: fullURL,
 						sessionID:  t.sessionID,
@@ -185,7 +188,7 @@ func (c *cacher) cacheURL(t *Task) {
 						urlContext: t.urlContext + "\n  -> " + fullURL,
 						isJS:       false,
 						retries:    setRetries(),
-					})
+					}, false)
 				}
 			}
 			if err != nil {
@@ -200,7 +203,10 @@ func (c *cacher) cacheURL(t *Task) {
 	return
 }
 
-func (c *cacher) checkTask(newTask *Task) {
+// checkTask deduplicates and enqueues a task. blocking selects the enqueue
+// strategy: external callers (consumer goroutine) pass true to apply backpressure,
+// worker-originated callers (CSS recursion) pass false to avoid deadlocking the pool.
+func (c *cacher) checkTask(newTask *Task, blocking bool) {
 	// check if file was recently uploaded
 	var cachePath string
 	if newTask.isJS {
@@ -218,7 +224,15 @@ func (c *cacher) checkTask(newTask *Task) {
 	}
 	// add new file in queue to download
 	newTask.cachePath = cachePath
-	c.workers.AddTask(newTask)
+	if blocking {
+		c.workers.AddTask(newTask)
+		return
+	}
+	// TODO: revisit with the retry mechanics rework — drop-on-full loses the task.
+	if !c.workers.tryAddTask(newTask) {
+		ctx := context.WithValue(context.Background(), "sessionID", newTask.sessionID)
+		c.log.Warn(ctx, "cacher queue full, dropping asset task: %s", newTask.requestURL)
+	}
 }
 
 func (c *cacher) CacheJSFile(sourceURL string) {
@@ -229,7 +243,7 @@ func (c *cacher) CacheJSFile(sourceURL string) {
 		urlContext: sourceURL,
 		isJS:       true,
 		retries:    setRetries(),
-	})
+	}, true)
 }
 
 func (c *cacher) CacheURL(sessionID uint64, fullURL string) {
@@ -240,7 +254,7 @@ func (c *cacher) CacheURL(sessionID uint64, fullURL string) {
 		urlContext: fullURL,
 		isJS:       false,
 		retries:    setRetries(),
-	})
+	}, true)
 }
 
 func (c *cacher) UpdateTimeouts() {

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/rand"
 	"mime"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -103,6 +104,15 @@ func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.Object
 			Transport: &http.Transport{
 				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: tlsConfig,
+				DialContext: (&net.Dialer{
+					Timeout:   5 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext,
+				TLSHandshakeTimeout: 5 * time.Second,
+				MaxConnsPerHost:     8,
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 4,
+				IdleConnTimeout:     30 * time.Second,
 			},
 		},
 		rewriter:       rewriter,

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -191,10 +191,6 @@ func (c *cacher) cacheURL(t *Task) {
 					}, false)
 				}
 			}
-			if err != nil {
-				c.log.Error(ctx, "Error while caching: %s", errors.Wrap(err, t.urlContext))
-				return
-			}
 		} else {
 			c.log.Error(ctx, "Error while caching: %s", errors.Wrap(errors.New("Maximum recursion cache depth exceeded"), t.urlContext))
 			return

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -108,6 +108,10 @@ func (c *cacher) CacheFile(task *Task) {
 
 func (c *cacher) cacheURL(t *Task) {
 	ctx := context.WithValue(context.Background(), "sessionID", t.sessionID)
+	crTime := c.objStorage.GetCreationTime(t.cachePath)
+	if crTime != nil && crTime.After(time.Now().Add(-MAX_STORAGE_TIME)) {
+		return
+	}
 	t.retries--
 	start := time.Now()
 	req, _ := http.NewRequest("GET", t.requestURL, nil)
@@ -214,10 +218,6 @@ func (c *cacher) checkTask(newTask *Task, blocking bool) {
 		return
 	}
 	c.timeoutMap.add(cachePath)
-	crTime := c.objStorage.GetCreationTime(cachePath)
-	if crTime != nil && crTime.After(time.Now().Add(-MAX_STORAGE_TIME)) {
-		return
-	}
 	// add new file in queue to download
 	newTask.cachePath = cachePath
 	if blocking {

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -346,19 +346,17 @@ func (c *cacher) checkTask(newTask *Task, blocking bool) {
 	} else {
 		cachePath = assets.GetCachePathForAssets(newTask.sessionID, newTask.requestURL)
 	}
-	if c.timeoutMap.contains(cachePath) {
+	if !c.timeoutMap.claim(cachePath) {
 		return
 	}
 	newTask.cachePath = cachePath
 	newTask.host = hostOf(newTask.requestURL)
 	if blocking {
-		c.timeoutMap.add(cachePath)
 		c.workers.AddTask(newTask)
 		return
 	}
-	if c.workers.tryAddTask(newTask) {
-		c.timeoutMap.add(cachePath)
-	} else {
+	if !c.workers.tryAddTask(newTask) {
+		c.timeoutMap.delete(cachePath)
 		ctx := context.WithValue(context.Background(), "sessionID", newTask.sessionID)
 		c.log.Warn(ctx, "cacher queue full, dropping asset task: %s", newTask.requestURL)
 	}

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -32,6 +32,7 @@ type cacher struct {
 	rewriter       *assets.Rewriter            // Read only
 	metrics        metrics.Assets
 	sizeLimit      int
+	retries        int
 	requestHeaders map[string]string
 	workers        *WorkerPool
 }
@@ -87,7 +88,7 @@ func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.Object
 		timeoutMap: newTimeoutMap(),
 		objStorage: store,
 		httpClient: &http.Client{
-			Timeout: time.Duration(6) * time.Second,
+			Timeout: time.Duration(cfg.AssetsHTTPTimeout) * time.Second,
 			Transport: &http.Transport{
 				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: tlsConfig,
@@ -95,10 +96,11 @@ func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.Object
 		},
 		rewriter:       rewriter,
 		sizeLimit:      cfg.AssetsSizeLimit,
+		retries:        cfg.AssetsRetries,
 		requestHeaders: cfg.AssetsRequestHeaders,
 		metrics:        metrics,
 	}
-	c.workers = NewPool(64, c.CacheFile)
+	c.workers = NewPool(cfg.AssetsWorkerCount, cfg.AssetsQueueSize, c.CacheFile)
 	return c, nil
 }
 
@@ -191,7 +193,7 @@ func (c *cacher) cacheURL(t *Task) {
 						depth:      t.depth - 1,
 						urlContext: t.urlContext + "\n  -> " + fullURL,
 						isJS:       false,
-						retries:    setRetries(),
+						retries:    c.retries,
 					}, false)
 				}
 			}
@@ -238,7 +240,7 @@ func (c *cacher) CacheJSFile(sourceURL string) {
 		depth:      0,
 		urlContext: sourceURL,
 		isJS:       true,
-		retries:    setRetries(),
+		retries:    c.retries,
 	}, true)
 }
 
@@ -249,7 +251,7 @@ func (c *cacher) CacheURL(sessionID uint64, fullURL string) {
 		depth:      MAX_CACHE_DEPTH,
 		urlContext: fullURL,
 		isJS:       false,
-		retries:    setRetries(),
+		retries:    c.retries,
 	}, true)
 }
 
@@ -259,8 +261,4 @@ func (c *cacher) UpdateTimeouts() {
 
 func (c *cacher) Stop() {
 	c.workers.Stop()
-}
-
-func setRetries() int {
-	return 10
 }

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -153,8 +153,6 @@ func (c *cacher) cacheURL(t *Task) {
 	}
 	start := time.Now()
 	req, _ := http.NewRequest("GET", t.requestURL, nil)
-	//req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:98.0) Gecko/20100101 Firefox/98.0")
-	// Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36")
 	for k, v := range c.requestHeaders {
 		req.Header.Set(k, v)

--- a/backend/internal/assets/cacher/hostlimiter.go
+++ b/backend/internal/assets/cacher/hostlimiter.go
@@ -1,0 +1,41 @@
+package cacher
+
+import "sync"
+
+type hostLimiter struct {
+	mu       sync.Mutex
+	inflight map[string]int
+	limit    int
+}
+
+func newHostLimiter(limit int) *hostLimiter {
+	return &hostLimiter{
+		inflight: make(map[string]int),
+		limit:    limit,
+	}
+}
+
+func (l *hostLimiter) tryAcquire(host string) bool {
+	if l.limit <= 0 {
+		return true
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.inflight[host] >= l.limit {
+		return false
+	}
+	l.inflight[host]++
+	return true
+}
+
+func (l *hostLimiter) release(host string) {
+	if l.limit <= 0 {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.inflight[host]--
+	if l.inflight[host] <= 0 {
+		delete(l.inflight, host) // keep the map bounded to currently-active hosts
+	}
+}

--- a/backend/internal/assets/cacher/pool.go
+++ b/backend/internal/assets/cacher/pool.go
@@ -32,9 +32,9 @@ func (p *WorkerPool) CanAddTask() bool {
 
 type Job func(task *Task)
 
-func NewPool(size int, job Job) *WorkerPool {
+func NewPool(size, queueSize int, job Job) *WorkerPool {
 	newPool := &WorkerPool{
-		tasks: make(chan *Task, 128),
+		tasks: make(chan *Task, queueSize),
 		done:  make(chan struct{}),
 		size:  size,
 		job:   job,

--- a/backend/internal/assets/cacher/pool.go
+++ b/backend/internal/assets/cacher/pool.go
@@ -6,12 +6,13 @@ import (
 
 type Task struct {
 	requestURL string
+	host       string
 	sessionID  uint64
 	depth      byte
 	urlContext string
 	isJS       bool
 	cachePath  string
-	retries    int
+	attempt    int
 }
 
 type WorkerPool struct {
@@ -62,18 +63,13 @@ func (p *WorkerPool) worker() {
 	}
 }
 
+// AddTask blocking func; use only from the consumer where backpressure is desired
 func (p *WorkerPool) AddTask(task *Task) {
-	if task.retries <= 0 {
-		return
-	}
 	p.tasks <- task
 }
 
-// TODO: revisit together with the retry mechanics rework
+// tryAddTask enqueues without blocking; use from inside workers (CSS recursion) and by the retry scheduler.
 func (p *WorkerPool) tryAddTask(task *Task) bool {
-	if task.retries <= 0 {
-		return true
-	}
 	select {
 	case p.tasks <- task:
 		return true

--- a/backend/internal/assets/cacher/pool.go
+++ b/backend/internal/assets/cacher/pool.go
@@ -69,6 +69,19 @@ func (p *WorkerPool) AddTask(task *Task) {
 	p.tasks <- task
 }
 
+// TODO: revisit together with the retry mechanics rework
+func (p *WorkerPool) tryAddTask(task *Task) bool {
+	if task.retries <= 0 {
+		return true
+	}
+	select {
+	case p.tasks <- task:
+		return true
+	default:
+		return false
+	}
+}
+
 func (p *WorkerPool) Stop() {
 	p.term.Do(func() {
 		close(p.done)

--- a/backend/internal/assets/cacher/scheduler.go
+++ b/backend/internal/assets/cacher/scheduler.go
@@ -1,0 +1,129 @@
+package cacher
+
+import (
+	"container/heap"
+	"sync"
+	"time"
+)
+
+const poolFullRetryDelay = 50 * time.Millisecond
+
+type scheduledTask struct {
+	task *Task
+	at   time.Time
+}
+
+type taskHeap []*scheduledTask
+
+func (h taskHeap) Len() int           { return len(h) }
+func (h taskHeap) Less(i, j int) bool { return h[i].at.Before(h[j].at) }
+func (h taskHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+func (h *taskHeap) Push(x any) { *h = append(*h, x.(*scheduledTask)) }
+
+func (h *taskHeap) Pop() any {
+	old := *h
+	n := len(old)
+	it := old[n-1]
+	old[n-1] = nil
+	*h = old[:n-1]
+	return it
+}
+
+type scheduler struct {
+	mu       sync.Mutex
+	heap     taskHeap
+	limit    int
+	tryAdd   func(*Task) bool
+	onSize   func(int)
+	wakeup   chan struct{}
+	done     chan struct{}
+	stopOnce sync.Once
+}
+
+func newScheduler(limit int, tryAdd func(*Task) bool, onSize func(int)) *scheduler {
+	s := &scheduler{
+		limit:  limit,
+		tryAdd: tryAdd,
+		onSize: onSize,
+		wakeup: make(chan struct{}, 1),
+		done:   make(chan struct{}),
+	}
+	go s.run()
+	return s
+}
+
+func (s *scheduler) schedule(task *Task, t time.Time) bool {
+	s.mu.Lock()
+	if s.limit > 0 && len(s.heap) >= s.limit {
+		s.mu.Unlock()
+		return false
+	}
+	heap.Push(&s.heap, &scheduledTask{task: task, at: t})
+	size := len(s.heap)
+	s.mu.Unlock()
+	if s.onSize != nil {
+		s.onSize(size)
+	}
+	select {
+	case s.wakeup <- struct{}{}:
+	default:
+	}
+	return true
+}
+
+func (s *scheduler) run() {
+	timer := time.NewTimer(time.Hour)
+	defer timer.Stop()
+	for {
+		s.mu.Lock()
+		now := time.Now()
+		poolFull := false
+		for len(s.heap) > 0 && !s.heap[0].at.After(now) {
+			st := heap.Pop(&s.heap).(*scheduledTask)
+			if !s.tryAdd(st.task) {
+				// pool is full: put it back shortly and back off so we don't spin
+				st.at = now.Add(poolFullRetryDelay)
+				heap.Push(&s.heap, st)
+				poolFull = true
+				break
+			}
+		}
+		var wait time.Duration
+		if len(s.heap) > 0 {
+			wait = s.heap[0].at.Sub(now)
+			if wait < 0 {
+				wait = 0
+			}
+		} else {
+			wait = time.Hour
+		}
+		if poolFull && wait < poolFullRetryDelay {
+			wait = poolFullRetryDelay
+		}
+		size := len(s.heap)
+		s.mu.Unlock()
+		if s.onSize != nil {
+			s.onSize(size)
+		}
+
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(wait)
+
+		select {
+		case <-s.done:
+			return
+		case <-s.wakeup:
+		case <-timer.C:
+		}
+	}
+}
+
+func (s *scheduler) stop() {
+	s.stopOnce.Do(func() { close(s.done) })
+}

--- a/backend/internal/assets/cacher/timeoutMap.go
+++ b/backend/internal/assets/cacher/timeoutMap.go
@@ -7,8 +7,6 @@ import (
 
 const MAX_STORAGE_TIME = 24 * time.Hour
 
-// If problem with cache contention (>=4 core) look at sync.Map
-
 type timeoutMap struct {
 	mx sync.RWMutex
 	m  map[string]time.Time
@@ -31,6 +29,12 @@ func (tm *timeoutMap) contains(key string) bool {
 	defer tm.mx.RUnlock()
 	_, ok := tm.m[key]
 	return ok
+}
+
+func (tm *timeoutMap) delete(key string) {
+	tm.mx.Lock()
+	defer tm.mx.Unlock()
+	delete(tm.m, key)
 }
 
 func (tm *timeoutMap) deleteOutdated() {

--- a/backend/internal/assets/cacher/timeoutMap.go
+++ b/backend/internal/assets/cacher/timeoutMap.go
@@ -18,21 +18,26 @@ func newTimeoutMap() *timeoutMap {
 	}
 }
 
-func (tm *timeoutMap) add(key string) {
-	tm.addFor(key, MAX_STORAGE_TIME)
-}
-
 func (tm *timeoutMap) addFor(key string, ttl time.Duration) {
 	tm.mx.Lock()
 	defer tm.mx.Unlock()
 	tm.m[key] = time.Now().Add(ttl)
 }
 
-func (tm *timeoutMap) contains(key string) bool {
-	tm.mx.RLock()
-	defer tm.mx.RUnlock()
-	exp, ok := tm.m[key]
-	return ok && time.Now().Before(exp)
+func (tm *timeoutMap) claim(key string) bool {
+	tm.mx.Lock()
+	defer tm.mx.Unlock()
+	if exp, ok := tm.m[key]; ok && time.Now().Before(exp) {
+		return false
+	}
+	tm.m[key] = time.Now().Add(MAX_STORAGE_TIME)
+	return true
+}
+
+func (tm *timeoutMap) delete(key string) {
+	tm.mx.Lock()
+	defer tm.mx.Unlock()
+	delete(tm.m, key)
 }
 
 func (tm *timeoutMap) deleteOutdated() {

--- a/backend/internal/assets/cacher/timeoutMap.go
+++ b/backend/internal/assets/cacher/timeoutMap.go
@@ -9,7 +9,7 @@ const MAX_STORAGE_TIME = 24 * time.Hour
 
 type timeoutMap struct {
 	mx sync.RWMutex
-	m  map[string]time.Time
+	m  map[string]time.Time // key -> expiry time
 }
 
 func newTimeoutMap() *timeoutMap {
@@ -19,30 +19,28 @@ func newTimeoutMap() *timeoutMap {
 }
 
 func (tm *timeoutMap) add(key string) {
+	tm.addFor(key, MAX_STORAGE_TIME)
+}
+
+func (tm *timeoutMap) addFor(key string, ttl time.Duration) {
 	tm.mx.Lock()
 	defer tm.mx.Unlock()
-	tm.m[key] = time.Now()
+	tm.m[key] = time.Now().Add(ttl)
 }
 
 func (tm *timeoutMap) contains(key string) bool {
 	tm.mx.RLock()
 	defer tm.mx.RUnlock()
-	_, ok := tm.m[key]
-	return ok
-}
-
-func (tm *timeoutMap) delete(key string) {
-	tm.mx.Lock()
-	defer tm.mx.Unlock()
-	delete(tm.m, key)
+	exp, ok := tm.m[key]
+	return ok && time.Now().Before(exp)
 }
 
 func (tm *timeoutMap) deleteOutdated() {
 	now := time.Now()
 	tm.mx.Lock()
 	defer tm.mx.Unlock()
-	for key, t := range tm.m {
-		if now.Sub(t) > MAX_STORAGE_TIME {
+	for key, exp := range tm.m {
+		if now.After(exp) {
 			delete(tm.m, key)
 		}
 	}

--- a/backend/internal/config/assets/config.go
+++ b/backend/internal/config/assets/config.go
@@ -25,7 +25,12 @@ type Config struct {
 	AssetsOrigin         string            `env:"ASSETS_ORIGIN,required"`
 	AssetsSizeLimit      int               `env:"ASSETS_SIZE_LIMIT,required"`
 	AssetsRequestHeaders map[string]string `env:"ASSETS_REQUEST_HEADERS"`
-	AssetsRetries        int               `env:"ASSETS_RETRIES,default=10"`
+	AssetsRetries        int               `env:"ASSETS_RETRIES,default=5"`
+	AssetsRetryBaseMs    int               `env:"ASSETS_RETRY_BASE_MS,default=2000"`
+	AssetsRetryMaxMs     int               `env:"ASSETS_RETRY_MAX_MS,default=60000"`
+	AssetsRetryAfterCap  int               `env:"ASSETS_RETRY_AFTER_CAP_MS,default=60000"`
+	AssetsRetryHeapLimit int               `env:"ASSETS_RETRY_HEAP_LIMIT,default=100000"`
+	AssetsPerHostLimit   int               `env:"ASSETS_PER_HOST_LIMIT,default=8"`
 	AssetsWorkerCount    int               `env:"ASSETS_WORKER_COUNT,default=64"`
 	AssetsHTTPTimeout    int               `env:"ASSETS_HTTP_TIMEOUT,default=6"` // seconds
 	AssetsQueueSize      int               `env:"ASSETS_QUEUE_SIZE,default=128"`

--- a/backend/internal/config/assets/config.go
+++ b/backend/internal/config/assets/config.go
@@ -25,6 +25,10 @@ type Config struct {
 	AssetsOrigin         string            `env:"ASSETS_ORIGIN,required"`
 	AssetsSizeLimit      int               `env:"ASSETS_SIZE_LIMIT,required"`
 	AssetsRequestHeaders map[string]string `env:"ASSETS_REQUEST_HEADERS"`
+	AssetsRetries        int               `env:"ASSETS_RETRIES,default=10"`
+	AssetsWorkerCount    int               `env:"ASSETS_WORKER_COUNT,default=64"`
+	AssetsHTTPTimeout    int               `env:"ASSETS_HTTP_TIMEOUT,default=6"` // seconds
+	AssetsQueueSize      int               `env:"ASSETS_QUEUE_SIZE,default=128"`
 	InsecureSkipVerify   bool              `env:"INSECURE_SKIP_VERIFY,default=true"`
 	ProducerCloseTimeout int               `env:"PRODUCER_CLOSE_TIMEOUT,default=15000"`
 	UseProfiler          bool              `env:"PROFILER_ENABLED,default=false"`

--- a/backend/internal/config/assets/config.go
+++ b/backend/internal/config/assets/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	AssetsOrigin         string            `env:"ASSETS_ORIGIN,required"`
 	AssetsSizeLimit      int               `env:"ASSETS_SIZE_LIMIT,required"`
 	AssetsRequestHeaders map[string]string `env:"ASSETS_REQUEST_HEADERS"`
+	InsecureSkipVerify   bool              `env:"INSECURE_SKIP_VERIFY,default=true"`
 	ProducerCloseTimeout int               `env:"PRODUCER_CLOSE_TIMEOUT,default=15000"`
 	UseProfiler          bool              `env:"PROFILER_ENABLED,default=false"`
 	ClientKeyFilePath    string            `env:"CLIENT_KEY_FILE_PATH"`

--- a/backend/internal/config/assets/config.go
+++ b/backend/internal/config/assets/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	AssetsRetryMaxMs     int               `env:"ASSETS_RETRY_MAX_MS,default=60000"`
 	AssetsRetryAfterCap  int               `env:"ASSETS_RETRY_AFTER_CAP_MS,default=60000"`
 	AssetsRetryHeapLimit int               `env:"ASSETS_RETRY_HEAP_LIMIT,default=100000"`
+	AssetsFailureSuppMin int               `env:"ASSETS_FAILURE_SUPPRESS_MIN,default=60"`
 	AssetsPerHostLimit   int               `env:"ASSETS_PER_HOST_LIMIT,default=8"`
 	AssetsWorkerCount    int               `env:"ASSETS_WORKER_COUNT,default=64"`
 	AssetsHTTPTimeout    int               `env:"ASSETS_HTTP_TIMEOUT,default=6"` // seconds

--- a/backend/internal/sink/assetscache/assets.go
+++ b/backend/internal/sink/assetscache/assets.go
@@ -180,15 +180,19 @@ func (e *AssetsCache) sendAssetForCache(sessionID uint64, baseURL string, relati
 	}
 }
 
-func (e *AssetsCache) rewriteAndQueue(sessionID uint64, baseURL string, css string) string {
+func (e *AssetsCache) rewriteCSS(sessionID uint64, baseURL string, css string) (string, []string) {
 	if !e.cfg.CacheAssets {
-		return assets.ResolveCSS(baseURL, css)
+		return assets.ResolveCSS(baseURL, css), nil
 	}
-	rewritten, urls := e.rewriter.RewriteCSSAndExtract(sessionID, baseURL, css)
+	return e.rewriter.RewriteCSSAndExtract(sessionID, baseURL, css)
+}
+
+func (e *AssetsCache) rewriteAndQueue(sessionID uint64, baseURL string, css string) string {
+	res, urls := e.rewriteCSS(sessionID, baseURL, css)
 	for _, u := range urls {
 		e.sendAssetForCache(sessionID, baseURL, u)
 	}
-	return rewritten
+	return res
 }
 
 func (e *AssetsCache) handleURL(sessionID uint64, baseURL string, urlVal string) string {
@@ -235,8 +239,11 @@ func (e *AssetsCache) handleCSS(sessionID uint64, baseURL string, css string) st
 	}
 	// Rewrite the CSS and queue its referenced assets for download in one pass.
 	start := time.Now()
-	res := e.rewriteAndQueue(sessionID, baseURL, css)
+	res, urls := e.rewriteCSS(sessionID, baseURL, css)
 	duration := time.Now().Sub(start).Milliseconds()
+	for _, u := range urls {
+		e.sendAssetForCache(sessionID, baseURL, u)
+	}
 	e.metrics.RecordAssetSize(float64(len(res)))
 	e.metrics.RecordProcessAssetDuration(float64(duration))
 	// Save asset to cache if we spent more than threshold

--- a/backend/internal/sink/assetscache/assets.go
+++ b/backend/internal/sink/assetscache/assets.go
@@ -180,10 +180,15 @@ func (e *AssetsCache) sendAssetForCache(sessionID uint64, baseURL string, relati
 	}
 }
 
-func (e *AssetsCache) sendAssetsForCacheFromCSS(sessionID uint64, baseURL string, css string) {
-	for _, u := range assets.ExtractURLsFromCSS(css) { // TODO: in one shot with rewriting
+func (e *AssetsCache) rewriteAndQueue(sessionID uint64, baseURL string, css string) string {
+	if !e.cfg.CacheAssets {
+		return assets.ResolveCSS(baseURL, css)
+	}
+	rewritten, urls := e.rewriter.RewriteCSSAndExtract(sessionID, baseURL, css)
+	for _, u := range urls {
 		e.sendAssetForCache(sessionID, baseURL, u)
 	}
+	return rewritten
 }
 
 func (e *AssetsCache) handleURL(sessionID uint64, baseURL string, urlVal string) string {
@@ -212,10 +217,7 @@ func (e *AssetsCache) handleCSS(sessionID uint64, baseURL string, css string) st
 	if err != nil {
 		ctx := context.WithValue(context.Background(), "sessionID", sessionID)
 		e.log.Error(ctx, "can't parse url: %s, err: %s", baseURL, err)
-		if e.cfg.CacheAssets {
-			e.sendAssetsForCacheFromCSS(sessionID, baseURL, css)
-		}
-		return e.getRewrittenCSS(sessionID, baseURL, css)
+		return e.rewriteAndQueue(sessionID, baseURL, css)
 	}
 	// Calculate hash sum of url + css
 	io.WriteString(h, justUrl)
@@ -231,13 +233,9 @@ func (e *AssetsCache) handleCSS(sessionID uint64, baseURL string, css string) st
 			return cachedAsset.msg
 		}
 	}
-	// Send asset to download in assets service
-	if e.cfg.CacheAssets {
-		e.sendAssetsForCacheFromCSS(sessionID, baseURL, css)
-	}
-	// Rewrite asset
+	// Rewrite the CSS and queue its referenced assets for download in one pass.
 	start := time.Now()
-	res := e.getRewrittenCSS(sessionID, baseURL, css)
+	res := e.rewriteAndQueue(sessionID, baseURL, css)
 	duration := time.Now().Sub(start).Milliseconds()
 	e.metrics.RecordAssetSize(float64(len(res)))
 	e.metrics.RecordProcessAssetDuration(float64(duration))
@@ -253,12 +251,4 @@ func (e *AssetsCache) handleCSS(sessionID uint64, baseURL string, css string) st
 	}
 	// Return rewritten asset
 	return res
-}
-
-func (e *AssetsCache) getRewrittenCSS(sessionID uint64, url, css string) string {
-	if e.cfg.CacheAssets {
-		return e.rewriter.RewriteCSS(sessionID, url, css)
-	} else {
-		return assets.ResolveCSS(url, css)
-	}
 }

--- a/backend/internal/sink/assetscache/assets.go
+++ b/backend/internal/sink/assetscache/assets.go
@@ -88,16 +88,24 @@ func (e *AssetsCache) shouldSkipAsset(baseURL string) bool {
 	if len(e.blackList) == 0 {
 		return false
 	}
-	host, err := parseHost(baseURL)
+	u, err := url.Parse(baseURL)
 	if err != nil {
 		return false
 	}
+	host := u.Hostname()
 	for _, blackHost := range e.blackList {
-		if strings.Contains(host, blackHost) {
+		if matchesBlackHost(host, blackHost) {
 			return true
 		}
 	}
 	return false
+}
+
+func matchesBlackHost(host, blackHost string) bool {
+	if strings.HasPrefix(blackHost, ".") {
+		return strings.HasSuffix(host, blackHost)
+	}
+	return host == blackHost || strings.HasSuffix(host, "."+blackHost)
 }
 
 func (e *AssetsCache) ParseAssets(msg messages.Message) messages.Message {

--- a/backend/pkg/metrics/assets/metrics.go
+++ b/backend/pkg/metrics/assets/metrics.go
@@ -9,6 +9,9 @@ type Assets interface {
 	IncreaseSavedSessions()
 	RecordDownloadDuration(durMillis float64, code int)
 	RecordUploadDuration(durMillis float64, isFailed bool)
+	IncreaseRetries()
+	IncreaseTerminalFailures(reason string)
+	RecordRetryQueueSize(size float64)
 	List() []prometheus.Collector
 }
 
@@ -21,3 +24,6 @@ func (a *assetsImpl) IncreaseProcessesSessions()                            {}
 func (a *assetsImpl) IncreaseSavedSessions()                                {}
 func (a *assetsImpl) RecordDownloadDuration(durMillis float64, code int)    {}
 func (a *assetsImpl) RecordUploadDuration(durMillis float64, isFailed bool) {}
+func (a *assetsImpl) IncreaseRetries()                                      {}
+func (a *assetsImpl) IncreaseTerminalFailures(reason string)                {}
+func (a *assetsImpl) RecordRetryQueueSize(size float64)                     {}

--- a/backend/pkg/url/assets/css.go
+++ b/backend/pkg/url/assets/css.go
@@ -19,7 +19,7 @@ func cssUrlsIndex(css string) [][]int {
 		idxs = append(idxs, match[2:])
 	}
 	sort.Slice(idxs, func(i, j int) bool {
-		return idxs[i][0] > idxs[j][0]
+		return idxs[i][0] < idxs[j][0]
 	})
 	return idxs
 }
@@ -38,64 +38,64 @@ func unquote(str string) (string, string) {
 	return str, ""
 }
 
-func ExtractURLsFromCSS(css string) []string {
+func rewriteAndCollect(css string, rewrite func(rawurl string) string, collect bool) (string, []string) {
 	indexes := cssUrlsIndex(css)
-	urls := make([]string, 0, len(indexes))
+	if len(indexes) == 0 {
+		return rewritePseudoclasses(css), nil
+	}
+
+	var b strings.Builder
+	b.Grow(len(css))
+	var urls []string
+	if collect {
+		urls = make([]string, 0, len(indexes))
+	}
+	last := 0
 	for _, idx := range indexes {
-
 		f := idx[0]
 		t := idx[1]
-		rawurl, _ := unquote(css[f:t])
-		urls = append(urls, rawurl)
-	}
-	return urls
-}
-
-func rewriteLinks(css string, rewrite func(rawurl string) string) string {
-	for _, idx := range cssUrlsIndex(css) {
-		f := idx[0]
-		t := idx[1]
+		if f < last { // skip overlapping/nested matches
+			continue
+		}
 		rawurl, q := unquote(css[f:t])
-		// why exactly quote back?
-		css = css[:f] + q + rewrite(rawurl) + q + css[t:]
+		if collect {
+			urls = append(urls, rawurl)
+		}
+		b.WriteString(css[last:f])
+		b.WriteString(q)
+		b.WriteString(rewrite(rawurl))
+		b.WriteString(q)
+		last = t
 	}
-	return css
+	b.WriteString(css[last:])
+	return rewritePseudoclasses(b.String()), urls
 }
 
 func ResolveCSS(baseURL string, css string) string {
-	css = rewriteLinks(css, func(rawurl string) string {
+	out, _ := rewriteAndCollect(css, func(rawurl string) string {
 		return ResolveURL(baseURL, rawurl)
-	})
-	return rewritePseudoclasses(css)
+	}, false)
+	return out
 }
 
 func (r *Rewriter) RewriteCSS(sessionID uint64, baseurl string, css string) string {
-	css = rewriteLinks(css, func(rawurl string) string {
+	out, _ := rewriteAndCollect(css, func(rawurl string) string {
 		return r.RewriteURL(sessionID, baseurl, rawurl)
-	})
-	return rewritePseudoclasses(css)
+	}, false)
+	return out
 }
 
 // RewriteCSSAndExtract scans the CSS a single time: it rewrites each url()/@import
 // target via the rewriter and collects the raw (pre-rewrite) URLs it found, so
 // callers that need both don't have to run the regex twice (extract + rewrite).
 func (r *Rewriter) RewriteCSSAndExtract(sessionID uint64, baseurl string, css string) (string, []string) {
-	// cssUrlsIndex returns matches sorted by descending start offset, so rewriting
-	// in place from the end keeps earlier offsets valid.
-	indexes := cssUrlsIndex(css)
-	urls := make([]string, 0, len(indexes))
-	for _, idx := range indexes {
-		f := idx[0]
-		t := idx[1]
-		rawurl, q := unquote(css[f:t])
-		urls = append(urls, rawurl)
-		css = css[:f] + q + r.RewriteURL(sessionID, baseurl, rawurl) + q + css[t:]
-	}
-	return rewritePseudoclasses(css), urls
+	return rewriteAndCollect(css, func(rawurl string) string {
+		return r.RewriteURL(sessionID, baseurl, rawurl)
+	}, true)
 }
 
 func rewritePseudoclasses(css string) string {
-	css = strings.Replace(css, ":hover", ".-openreplay-hover", -1)
-	css = strings.Replace(css, ":focus", ".-openreplay-focus", -1)
+	css = strings.ReplaceAll(css, ":hover", ".-openreplay-hover")
+	css = strings.ReplaceAll(css, ":focus", ".-openreplay-focus")
 	return css
 }

--- a/backend/pkg/url/assets/css.go
+++ b/backend/pkg/url/assets/css.go
@@ -10,6 +10,11 @@ import (
 var cssURLs = regexp.MustCompile(`url\(("[^"]*"|'[^']*'|[^)]*)\)`)
 var cssImports = regexp.MustCompile(`@import "(.*?)"`)
 
+var pseudoReplacer = strings.NewReplacer(
+	":hover", ".-openreplay-hover",
+	":focus", ".-openreplay-focus",
+)
+
 func cssUrlsIndex(css string) [][]int {
 	var idxs [][]int
 	for _, match := range cssURLs.FindAllStringSubmatchIndex(css, -1) {
@@ -85,9 +90,6 @@ func (r *Rewriter) RewriteCSS(sessionID uint64, baseurl string, css string) stri
 	return out
 }
 
-// RewriteCSSAndExtract scans the CSS a single time: it rewrites each url()/@import
-// target via the rewriter and collects the raw (pre-rewrite) URLs it found, so
-// callers that need both don't have to run the regex twice (extract + rewrite).
 func (r *Rewriter) RewriteCSSAndExtract(sessionID uint64, baseurl string, css string) (string, []string) {
 	return rewriteAndCollect(css, func(rawurl string) string {
 		return r.RewriteURL(sessionID, baseurl, rawurl)
@@ -95,7 +97,8 @@ func (r *Rewriter) RewriteCSSAndExtract(sessionID uint64, baseurl string, css st
 }
 
 func rewritePseudoclasses(css string) string {
-	css = strings.ReplaceAll(css, ":hover", ".-openreplay-hover")
-	css = strings.ReplaceAll(css, ":focus", ".-openreplay-focus")
-	return css
+	if !strings.Contains(css, ":hover") && !strings.Contains(css, ":focus") {
+		return css
+	}
+	return pseudoReplacer.Replace(css)
 }

--- a/backend/pkg/url/assets/css.go
+++ b/backend/pkg/url/assets/css.go
@@ -76,6 +76,24 @@ func (r *Rewriter) RewriteCSS(sessionID uint64, baseurl string, css string) stri
 	return rewritePseudoclasses(css)
 }
 
+// RewriteCSSAndExtract scans the CSS a single time: it rewrites each url()/@import
+// target via the rewriter and collects the raw (pre-rewrite) URLs it found, so
+// callers that need both don't have to run the regex twice (extract + rewrite).
+func (r *Rewriter) RewriteCSSAndExtract(sessionID uint64, baseurl string, css string) (string, []string) {
+	// cssUrlsIndex returns matches sorted by descending start offset, so rewriting
+	// in place from the end keeps earlier offsets valid.
+	indexes := cssUrlsIndex(css)
+	urls := make([]string, 0, len(indexes))
+	for _, idx := range indexes {
+		f := idx[0]
+		t := idx[1]
+		rawurl, q := unquote(css[f:t])
+		urls = append(urls, rawurl)
+		css = css[:f] + q + r.RewriteURL(sessionID, baseurl, rawurl) + q + css[t:]
+	}
+	return rewritePseudoclasses(css), urls
+}
+
 func rewritePseudoclasses(css string) string {
 	css = strings.Replace(css, ":hover", ".-openreplay-hover", -1)
 	css = strings.Replace(css, ":focus", ".-openreplay-focus", -1)

--- a/backend/pkg/url/assets/css.go
+++ b/backend/pkg/url/assets/css.go
@@ -40,7 +40,7 @@ func unquote(str string) (string, string) {
 
 func ExtractURLsFromCSS(css string) []string {
 	indexes := cssUrlsIndex(css)
-	urls := make([]string, len(indexes))
+	urls := make([]string, 0, len(indexes))
 	for _, idx := range indexes {
 
 		f := idx[0]

--- a/ee/backend/pkg/kafka/consumer.go
+++ b/ee/backend/pkg/kafka/consumer.go
@@ -57,8 +57,8 @@ func NewConsumer(
 		"go.application.rebalance.enable": true,
 		"max.poll.interval.ms":            env.Int("KAFKA_MAX_POLL_INTERVAL_MS"),
 		"max.partition.fetch.bytes":       messageSizeLimit,
-		"queued.max.messages.kbytes":      131072, // 128 MiB total prefetch cap (default 1 GiB)
-		"queued.min.messages":             50000,  // prefetch target (default 100000 per partition)
+		"queued.max.messages.kbytes":      65536, // 64 MiB prefetch cap (= librdkafka default)
+		"queued.min.messages":             50000, // prefetch target (librdkafka default 100000 per partition)
 		"go.logs.channel.enable":          true,
 	}
 

--- a/ee/backend/pkg/kafka/consumer.go
+++ b/ee/backend/pkg/kafka/consumer.go
@@ -57,6 +57,8 @@ func NewConsumer(
 		"go.application.rebalance.enable": true,
 		"max.poll.interval.ms":            env.Int("KAFKA_MAX_POLL_INTERVAL_MS"),
 		"max.partition.fetch.bytes":       messageSizeLimit,
+		"queued.max.messages.kbytes":      131072, // 128 MiB total prefetch cap (default 1 GiB)
+		"queued.min.messages":             50000,  // prefetch target (default 100000 per partition)
 		"go.logs.channel.enable":          true,
 	}
 

--- a/ee/backend/pkg/kafka/producer.go
+++ b/ee/backend/pkg/kafka/producer.go
@@ -30,8 +30,8 @@ func NewProducer(messageSizeLimit int, useBatch bool) *Producer {
 		"linger.ms":                             1000,
 		"queue.buffering.max.ms":                1000,
 		"batch.num.messages":                    1000,
-		"queue.buffering.max.messages":          100000,
-		"queue.buffering.max.kbytes":            1048576,
+		"queue.buffering.max.messages":          50000,
+		"queue.buffering.max.kbytes":            131072, // 128 MiB un-acked buffer cap (default 1 GiB)
 		"retries":                               3,
 		"retry.backoff.ms":                      100,
 		"max.in.flight.requests.per.connection": 1,

--- a/ee/backend/pkg/metrics/assets/metrics.go
+++ b/ee/backend/pkg/metrics/assets/metrics.go
@@ -13,6 +13,9 @@ type Assets interface {
 	IncreaseSavedSessions()
 	RecordDownloadDuration(durMillis float64, code int)
 	RecordUploadDuration(durMillis float64, isFailed bool)
+	IncreaseRetries()
+	IncreaseTerminalFailures(reason string)
+	RecordRetryQueueSize(size float64)
 	List() []prometheus.Collector
 }
 
@@ -21,6 +24,9 @@ type assetsImpl struct {
 	assetsSavedSessions     prometheus.Counter
 	assetsDownloadDuration  *prometheus.HistogramVec
 	assetsUploadDuration    *prometheus.HistogramVec
+	assetsRetries           prometheus.Counter
+	assetsTerminalFailures  *prometheus.CounterVec
+	assetsRetryQueueSize    prometheus.Gauge
 }
 
 func New(serviceName string) Assets {
@@ -29,6 +35,9 @@ func New(serviceName string) Assets {
 		assetsSavedSessions:     newSavedSessions(serviceName),
 		assetsDownloadDuration:  newDownloadDuration(serviceName),
 		assetsUploadDuration:    newUploadDuration(serviceName),
+		assetsRetries:           newRetries(serviceName),
+		assetsTerminalFailures:  newTerminalFailures(serviceName),
+		assetsRetryQueueSize:    newRetryQueueSize(serviceName),
 	}
 }
 
@@ -38,6 +47,9 @@ func (a *assetsImpl) List() []prometheus.Collector {
 		a.assetsSavedSessions,
 		a.assetsDownloadDuration,
 		a.assetsUploadDuration,
+		a.assetsRetries,
+		a.assetsTerminalFailures,
+		a.assetsRetryQueueSize,
 	}
 }
 
@@ -103,4 +115,47 @@ func (a *assetsImpl) RecordUploadDuration(durMillis float64, isFailed bool) {
 		failed = "true"
 	}
 	a.assetsUploadDuration.WithLabelValues(failed).Observe(durMillis / 1000.0)
+}
+
+func newRetries(serviceName string) prometheus.Counter {
+	return prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "retries_total",
+			Help:      "A counter displaying the total number of scheduled asset download retries.",
+		},
+	)
+}
+
+func (a *assetsImpl) IncreaseRetries() {
+	a.assetsRetries.Inc()
+}
+
+func newTerminalFailures(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "terminal_failures_total",
+			Help:      "A counter displaying the total number of assets that permanently failed to cache, by reason.",
+		},
+		[]string{"reason"},
+	)
+}
+
+func (a *assetsImpl) IncreaseTerminalFailures(reason string) {
+	a.assetsTerminalFailures.WithLabelValues(reason).Inc()
+}
+
+func newRetryQueueSize(serviceName string) prometheus.Gauge {
+	return prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: serviceName,
+			Name:      "retry_queue_size",
+			Help:      "A gauge displaying the current number of pending asset download retries.",
+		},
+	)
+}
+
+func (a *assetsImpl) RecordRetryQueueSize(size float64) {
+	a.assetsRetryQueueSize.Set(size)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves asset caching reliability and throughput with a robust retry scheduler, per-host throttling, and richer metrics, all configurable via env vars. CSS rewriting now extracts and queues asset URLs in one pass and runs faster; a race in task deduplication is fixed.

- **New Features**
  - Added a retry scheduler with jittered exponential backoff, `Retry-After` support, and a heap-limited queue; records retries, terminal failures (by reason), and queue size.
  - Introduced per-host concurrency limiting and short deferred retries to prevent hot-host overload.
  - Replaced error channel with structured logging and context; `NewCacher` now accepts a logger.
  - Tuned HTTP client (timeouts, connection limits), made TLS `InsecureSkipVerify` configurable, and updated the default User-Agent to a modern Chrome UA.
  - Worker pool now has configurable size and queue, plus non-blocking `tryAddTask`; dedup now atomically claims tasks and rolls back if the queue is full to avoid drops (race condition fixed); micro-sleeps when full.
  - CSS: single-pass rewrite + URL extraction (`RewriteCSSAndExtract`), faster pseudo-class replacement, and stricter blacklist matching.
  - Metrics extended: retries, terminal failures by reason, and retry queue size; recorded on scheduling and queue updates.
  - Kafka: producer buffer caps and consumer prefetch limits to lower memory pressure.

- **Migration**
  - New/updated env vars (defaults): `ASSETS_RETRIES`, `ASSETS_RETRY_BASE_MS`, `ASSETS_RETRY_MAX_MS`, `ASSETS_RETRY_AFTER_CAP_MS`, `ASSETS_RETRY_HEAP_LIMIT`, `ASSETS_FAILURE_SUPPRESS_MIN`, `ASSETS_PER_HOST_LIMIT`, `ASSETS_WORKER_COUNT`, `ASSETS_HTTP_TIMEOUT`, `ASSETS_QUEUE_SIZE`, `INSECURE_SKIP_VERIFY`.
  - Metrics dashboards: add panels for `retries_total`, `terminal_failures_total{reason=...}`, and `retry_queue_size`.

<sup>Written for commit 9af3655e576dd99ea04f2959538fb5e765a487f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

