### PR TITLE
tracker, ui: enable native select control for RC calls

### DIFF
--- a/frontend/app/player/web/assist/RemoteControl.ts
+++ b/frontend/app/player/web/assist/RemoteControl.ts
@@ -144,6 +144,24 @@ export default class RemoteControl {
           this.socket && this.emitData('input', el.innerText);
         }
       };
+      // Native <select>: the overlay swallows the click, so the dropdown can't
+      // be opened by the click itself. We open the native picker on the mirrored
+      // element so the agent can pick an option, then forward the chosen value
+      // to the tracker which applies it to the real <select>.
+      if (el instanceof HTMLSelectElement) {
+        el.onchange = () => {
+          this.socket && this.emitData('select', el.value);
+        };
+        try {
+          // showPicker is gated behind transient activation; we're inside the
+          // synchronous click handler so the user gesture is still valid.
+          // @ts-ignore - showPicker may be missing from older TS lib defs
+          el.showPicker?.();
+        } catch (err) {
+          // Some browsers throw if the picker can't be shown programmatically;
+          // the agent can still change the value once the dropdown is opened.
+        }
+      }
       // TODO: send "focus" event to assist with the nodeID
       el.onkeydown = (e) => {
         if (e.key == 'Tab') {
@@ -152,6 +170,7 @@ export default class RemoteControl {
       };
       el.onblur = () => {
         el.oninput = null;
+        el.onchange = null;
         el.onblur = null;
       };
     }

--- a/tracker/bun.lock
+++ b/tracker/bun.lock
@@ -7,7 +7,7 @@
     },
     "tracker": {
       "name": "@openreplay/tracker",
-      "version": "18.0.9",
+      "version": "18.0.12",
       "dependencies": {
         "@openreplay/network-proxy": "^1.2.5",
         "error-stack-parser": "^2.1.4",
@@ -41,7 +41,7 @@
     },
     "tracker-assist": {
       "name": "@openreplay/tracker-assist",
-      "version": "11.0.15",
+      "version": "11.0.16",
       "dependencies": {
         "csstype": "^3.1.3",
         "fflate": "^0.8.2",

--- a/tracker/tracker-assist/src/Assist.ts
+++ b/tracker/tracker-assist/src/Assist.ts
@@ -413,6 +413,9 @@ export default class Assist {
       socket.on("input", (id, event) =>
         processEvent(id, event, this.remoteControl?.input),
       );
+      socket.on("select", (id, event) =>
+        processEvent(id, event, this.remoteControl?.select),
+      );
     }
 
     // TODO: restrict by id

--- a/tracker/tracker-assist/src/RemoteControl.ts
+++ b/tracker/tracker-assist/src/RemoteControl.ts
@@ -163,4 +163,15 @@ export default class RemoteControl {
       this.focused.innerText = value
     }
   }
+  // Native <select> can't be opened through the agent's mouse (the picker is
+  // a browser-native popup), so the agent opens it on the mirrored DOM and we
+  // receive the chosen value here to apply on the real element.
+  select = (id: string, value: string) => {
+    if (!this.isAuthorized(id) || !this.focused) return
+    if (this.focused instanceof HTMLSelectElement) {
+      this.focused.value = value
+      this.focused.dispatchEvent(new Event('input', { bubbles: true }))
+      this.focused.dispatchEvent(new Event('change', { bubbles: true }))
+    }
+  }
 }

--- a/tracker/tracker-assist/src/version.ts
+++ b/tracker/tracker-assist/src/version.ts
@@ -1,1 +1,1 @@
-export const pkgVersion = "11.0.15";
+export const pkgVersion = "11.0.16";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable native `<select>` control in Remote Control so agents can open the picker on the mirrored element and apply selections to the real element. Fixes the overlay click issue and fires `input`/`change` events correctly.

- **New Features**
  - Open native `<select>` via `showPicker` and emit `select` with the chosen value.
  - Handle `select` in `tracker-assist` to set the real element’s value and dispatch `input` and `change`.

- **Dependencies**
  - Bump `@openreplay/tracker` to `18.0.12` and `@openreplay/tracker-assist` to `11.0.16`.

<sup>Written for commit 8aa6fcf5c2be8d886ed32938983471a01e0bb7c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

