### PR TITLE
Tracking imprs

### DIFF
--- a/frontend/app/player/web/assist/RemoteControl.ts
+++ b/frontend/app/player/web/assist/RemoteControl.ts
@@ -144,6 +144,24 @@ export default class RemoteControl {
           this.socket && this.emitData('input', el.innerText);
         }
       };
+      // Native <select>: the overlay swallows the click, so the dropdown can't
+      // be opened by the click itself. We open the native picker on the mirrored
+      // element so the agent can pick an option, then forward the chosen value
+      // to the tracker which applies it to the real <select>.
+      if (el instanceof HTMLSelectElement) {
+        el.onchange = () => {
+          this.socket && this.emitData('select', el.value);
+        };
+        try {
+          // showPicker is gated behind transient activation; we're inside the
+          // synchronous click handler so the user gesture is still valid.
+          // @ts-ignore - showPicker may be missing from older TS lib defs
+          el.showPicker?.();
+        } catch (err) {
+          // Some browsers throw if the picker can't be shown programmatically;
+          // the agent can still change the value once the dropdown is opened.
+        }
+      }
       // TODO: send "focus" event to assist with the nodeID
       el.onkeydown = (e) => {
         if (e.key == 'Tab') {
@@ -152,6 +170,7 @@ export default class RemoteControl {
       };
       el.onblur = () => {
         el.oninput = null;
+        el.onchange = null;
         el.onblur = null;
       };
     }

--- a/tracker/bun.lock
+++ b/tracker/bun.lock
@@ -7,7 +7,7 @@
     },
     "tracker": {
       "name": "@openreplay/tracker",
-      "version": "18.0.4",
+      "version": "18.0.12",
       "dependencies": {
         "@openreplay/network-proxy": "^1.2.4",
         "error-stack-parser": "^2.1.4",
@@ -41,7 +41,7 @@
     },
     "tracker-assist": {
       "name": "@openreplay/tracker-assist",
-      "version": "11.0.13",
+      "version": "11.0.16",
       "dependencies": {
         "csstype": "^3.1.3",
         "fflate": "^0.8.2",

--- a/tracker/tracker-assist/src/Assist.ts
+++ b/tracker/tracker-assist/src/Assist.ts
@@ -413,6 +413,9 @@ export default class Assist {
       socket.on("input", (id, event) =>
         processEvent(id, event, this.remoteControl?.input),
       );
+      socket.on("select", (id, event) =>
+        processEvent(id, event, this.remoteControl?.select),
+      );
     }
 
     // TODO: restrict by id

--- a/tracker/tracker-assist/src/RemoteControl.ts
+++ b/tracker/tracker-assist/src/RemoteControl.ts
@@ -147,4 +147,15 @@ export default class RemoteControl {
       this.focused.innerText = value
     }
   }
+  // Native <select> can't be opened through the agent's mouse (the picker is
+  // a browser-native popup), so the agent opens it on the mirrored DOM and we
+  // receive the chosen value here to apply on the real element.
+  select = (id: string, value: string) => {
+    if (!this.isAuthorized(id) || !this.focused) return
+    if (this.focused instanceof HTMLSelectElement) {
+      this.focused.value = value
+      this.focused.dispatchEvent(new Event('input', { bubbles: true }))
+      this.focused.dispatchEvent(new Event('change', { bubbles: true }))
+    }
+  }
 }

--- a/tracker/tracker-assist/src/version.ts
+++ b/tracker/tracker-assist/src/version.ts
@@ -1,1 +1,1 @@
-export const pkgVersion = "11.0.13";
+export const pkgVersion = "11.0.16";

--- a/tracker/tracker/src/main/app/canvas.ts
+++ b/tracker/tracker/src/main/app/canvas.ts
@@ -52,7 +52,32 @@ class CanvasRecorder {
     setTimeout(() => {
       this.app.nodes.scanTree(this.captureCanvas)
       this.app.nodes.attachNodeCallback(this.captureCanvas)
+      this.app.attachResanitizeCallback(this.resanitizeCanvas)
     }, 125)
+  }
+
+  /**
+   * Reacts to a runtime sanitization change on a canvas: stop capturing if it
+   * just became masked, start if it just became visible. (Already-sent frames
+   * can't be retracted — escalation only stops future capture.)
+   */
+  resanitizeCanvas = (node: Node, id: number) => {
+    if (!hasTag(node, 'canvas')) {
+      return
+    }
+    const isIgnored = this.app.sanitizer.isObscured(id) || this.app.sanitizer.isHidden(id)
+    if (isIgnored) {
+      if (this.snapshots[id] || this.observers.has(id)) {
+        const observer = this.observers.get(id)
+        if (observer) {
+          observer.disconnect()
+          this.observers.delete(id)
+        }
+        this.cleanupCanvas(id)
+      }
+    } else if (!this.snapshots[id] && !this.observers.has(id)) {
+      this.captureCanvas(node)
+    }
   }
 
   restartTracking = () => {

--- a/tracker/tracker/src/main/app/index.ts
+++ b/tracker/tracker/src/main/app/index.ts
@@ -13,6 +13,7 @@ import {
   adjustTimeOrigin,
   createEventListener,
   deleteEventListener,
+  IN_BROWSER,
   now,
   requestIdleCb,
   simpleMerge,
@@ -33,7 +34,7 @@ import Nodes from './nodes/index.js'
 import type { Options as ObserverOptions } from './observer/top_observer.js'
 import Observer, { InlineCssMode } from './observer/top_observer.js'
 import type { Options as SanitizerOptions } from './sanitizer.js'
-import Sanitizer from './sanitizer.js'
+import Sanitizer, { SanitizeLevel } from './sanitizer.js'
 import type { Options as SessOptions } from './session.js'
 import Session from './session.js'
 import Ticker from './ticker.js'
@@ -229,6 +230,8 @@ export default class App {
   readonly ticker: Ticker
   readonly projectKey: string
   readonly sanitizer: Sanitizer
+  // Registered by input/img/canvas to re-emit a node when its level changes.
+  private readonly resanitizeCallbacks: Array<(node: Node, id: number) => void> = []
   readonly debug: Logger
   readonly notify: Logger
   readonly session: Session
@@ -1728,6 +1731,30 @@ export default class App {
 
   restartCanvasTracking = () => {
     this.canvasRecorder?.restartTracking()
+  }
+
+  attachResanitizeCallback = (cb: (node: Node, id: number) => void): void => {
+    this.resanitizeCallbacks.push(cb)
+  }
+
+  callResanitizeCallbacks = (node: Node, id: number): void => {
+    this.resanitizeCallbacks.forEach((cb) => cb(node, id))
+  }
+
+  resanitize = (el?: Element): void => {
+    const root = el ?? (IN_BROWSER ? document.documentElement : undefined)
+    if (!root) {
+      return
+    }
+    this.observer.resanitizeSubtree(root)
+  }
+
+  checkSanitization = (el: Node): SanitizeLevel | undefined => {
+    const id = this.nodes.getID(el)
+    if (id === undefined) {
+      return undefined
+    }
+    return this.sanitizer.getLevel(id)
   }
 
   flushBuffer = async (buffer: Message[]) => {

--- a/tracker/tracker/src/main/app/observer/observer.ts
+++ b/tracker/tracker/src/main/app/observer/observer.ts
@@ -26,6 +26,7 @@ import {
 } from '../guards.js'
 import { inlineRemoteCss } from './cssInliner.js'
 import { nextID } from '../../modules/constructedStyleSheets.js'
+import { SanitizeLevel } from '../sanitizer.js'
 
 const iconCache = {}
 const svgUrlCache = {}
@@ -701,6 +702,112 @@ export default abstract class Observer {
     this.bindTree(nodeToBind)
     beforeCommit(this.app.nodes.getID(node))
     this.commitNodes(true)
+  }
+
+  /**
+   * Re-evaluates sanitization for every tracked node in `root`'s subtree against
+   * the current DOM and re-emits whatever changed. Pass the highest node you
+   * changed (or the document root) so inherited levels propagate correctly.
+   */
+  public resanitizeSubtree(root: Node): void {
+    if (!isObservable(root)) {
+      return
+    }
+    const parent = root.parentNode
+    const parentId = parent !== null ? this.app.nodes.getID(parent) : undefined
+    const parentLevel =
+      parentId !== undefined ? this.app.sanitizer.getLevel(parentId) : SanitizeLevel.Plain
+    this.resanitizeNode(root, parentLevel)
+  }
+
+  private resanitizeNode(node: Node, parentLevel: SanitizeLevel): void {
+    if (isIgnored(node)) {
+      return
+    }
+    const id = this.app.nodes.getID(node)
+    if (id === undefined) {
+      // Untracked (new, or under a hidden ancestor): the live observer handles it.
+      return
+    }
+    const newLevel = this.app.sanitizer.computeLevel(node, parentLevel)
+    const prevLevel = this.app.sanitizer.getLevel(id)
+    const wasHidden = prevLevel === SanitizeLevel.Hidden
+    const willHidden = newLevel === SanitizeLevel.Hidden
+
+    // Crossing the hidden boundary changes the rendered structure (placeholder vs
+    // real subtree), so rebuild rather than re-emit.
+    if (wasHidden !== willHidden) {
+      this.recreateSubtree(node)
+      return
+    }
+    if (willHidden) {
+      return
+    }
+    // Plain <-> Obscured: same structure, only leaf content changes.
+    if (prevLevel !== newLevel) {
+      this.app.sanitizer.setLevel(id, newLevel)
+      this.reemitNode(id, node)
+    }
+    for (let child = node.firstChild; child !== null; child = child.nextSibling) {
+      this.resanitizeNode(child, newLevel)
+    }
+  }
+
+  // Destroys the node player-side and re-emits its subtree from scratch (new ids)
+  // so it materializes at the freshly-computed level.
+  private recreateSubtree(node: Node): void {
+    const id = this.app.nodes.getID(node)
+    if (id === undefined) {
+      return
+    }
+    this.app.send(RemoveNode(id))
+    this.clearSubtreeRegistration(node)
+    this.bindTree(node)
+    this.commitNodes()
+  }
+
+  private clearSubtreeRegistration(node: Node): void {
+    const clearOne = (n: Node) => {
+      const oldId = this.app.nodes.getID(n)
+      if (oldId !== undefined) {
+        this.app.sanitizer.setLevel(oldId, SanitizeLevel.Plain)
+      }
+      this.app.nodes.unregisterNode(n)
+    }
+    const walker = document.createTreeWalker(
+      node,
+      NodeFilter.SHOW_ELEMENT + NodeFilter.SHOW_TEXT,
+      {
+        acceptNode: (n) =>
+          isIgnored(n) || this.app.nodes.getID(n) === undefined
+            ? NodeFilter.FILTER_REJECT
+            : NodeFilter.FILTER_ACCEPT,
+      },
+      // @ts-ignore
+      false,
+    )
+    // Collect first, then clear: unregistering mutates the ids the walker reads.
+    const subtree: Node[] = []
+    while (walker.nextNode()) {
+      subtree.push(walker.currentNode)
+    }
+    clearOne(node)
+    subtree.forEach(clearOne)
+  }
+
+  private reemitNode(id: number, node: Node): void {
+    if (isTextNode(node)) {
+      const parent = node.parentNode
+      if (parent !== null && isElementNode(parent)) {
+        // re-runs sanitize() at the level we just set
+        this.sendNodeData(id, parent, node.data)
+      }
+      return
+    }
+    if (isElementNode(node)) {
+      // inputs/images/canvas re-emit their own payload via registered callbacks
+      this.app.callResanitizeCallbacks(node, id)
+    }
   }
 
   disconnect(): void {

--- a/tracker/tracker/src/main/app/sanitizer.ts
+++ b/tracker/tracker/src/main/app/sanitizer.ts
@@ -44,8 +44,9 @@ export const stringWiper = (input: string) =>
     .replace(/[^\f\n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff\s]/g, '*')
 
 export default class Sanitizer {
-  private readonly obscured: Set<number> = new Set()
-  private readonly hidden: Set<number> = new Set()
+  // Node id -> level. Plain (0) is never stored; a missing entry means Plain.
+  // A map (not the old grow-only Sets) so levels can be raised and lowered.
+  private readonly levels: Map<number, SanitizeLevel> = new Map()
   private readonly options: Options
   public readonly privateMode: boolean
   private readonly app: App
@@ -62,44 +63,74 @@ export default class Sanitizer {
     this.options = Object.assign(defaultOptions, params.options)
   }
 
-  handleNode(id: number, parentID: number, node: Node) {
+  // Pure recomputation of a node's level from the live DOM + parent level.
+  // Reading current state on every call is what lets resanitize() pick up
+  // runtime attribute/domSanitizer changes.
+  computeLevel(node: Node, parentLevel: SanitizeLevel): SanitizeLevel {
     if (this.options.privateMode) {
       if (isElementNode(node) && !hasOpenreplayAttribute(node, 'unmask')) {
-        return this.obscured.add(id)
+        return SanitizeLevel.Obscured
       }
       if (isTextNode(node) && !hasOpenreplayAttribute(node.parentNode as Element, 'unmask')) {
-        return this.obscured.add(id)
+        return SanitizeLevel.Obscured
       }
     }
 
+    let level: SanitizeLevel = SanitizeLevel.Plain
+
     if (
-      this.obscured.has(parentID) ||
+      parentLevel >= SanitizeLevel.Obscured ||
       (isElementNode(node) &&
         (hasOpenreplayAttribute(node, 'masked') || hasOpenreplayAttribute(node, 'obscured')))
     ) {
-      this.obscured.add(id)
+      level = SanitizeLevel.Obscured
     }
     if (
-      this.hidden.has(parentID) ||
+      parentLevel === SanitizeLevel.Hidden ||
       (isElementNode(node) &&
         (hasOpenreplayAttribute(node, 'htmlmasked') || hasOpenreplayAttribute(node, 'hidden')))
     ) {
-      this.hidden.add(id)
+      level = SanitizeLevel.Hidden
     }
 
     if (this.options.domSanitizer !== undefined && isElementNode(node)) {
       const sanitizeLevel = this.options.domSanitizer(node)
-      if (sanitizeLevel === SanitizeLevel.Obscured) {
-        this.obscured.add(id)
+      if (sanitizeLevel === SanitizeLevel.Obscured && level < SanitizeLevel.Obscured) {
+        level = SanitizeLevel.Obscured
       }
       if (sanitizeLevel === SanitizeLevel.Hidden) {
-        this.hidden.add(id)
+        level = SanitizeLevel.Hidden
       }
+    }
+
+    return level
+  }
+
+  getLevel(id: number): SanitizeLevel {
+    return this.levels.get(id) ?? SanitizeLevel.Plain
+  }
+
+  // Sets a node's level (either direction) and returns the previous one.
+  setLevel(id: number, level: SanitizeLevel): SanitizeLevel {
+    const prev = this.getLevel(id)
+    if (level === SanitizeLevel.Plain) {
+      this.levels.delete(id)
+    } else {
+      this.levels.set(id, level)
+    }
+    return prev
+  }
+
+  handleNode(id: number, parentID: number, node: Node) {
+    const level = this.computeLevel(node, this.getLevel(parentID))
+    // Escalate-only: commits never lower a level, only resanitize/setLevel do.
+    if (level > this.getLevel(id)) {
+      this.setLevel(id, level)
     }
   }
 
   sanitize(id: number, data: string): string {
-    if (this.obscured.has(id)) {
+    if (this.getLevel(id) >= SanitizeLevel.Obscured) {
       // TODO: is it the best place to put trim() ? Might trimmed spaces be considered in layout in certain cases?
       return stringWiper(data)
     }
@@ -118,11 +149,11 @@ export default class Sanitizer {
   }
 
   isObscured(id: number): boolean {
-    return this.obscured.has(id)
+    return this.getLevel(id) >= SanitizeLevel.Obscured
   }
 
   isHidden(id: number) {
-    return this.hidden.has(id)
+    return this.getLevel(id) === SanitizeLevel.Hidden
   }
 
   getInnerTextSecure(el: HTMLElement): string {
@@ -134,7 +165,6 @@ export default class Sanitizer {
   }
 
   clear(): void {
-    this.obscured.clear()
-    this.hidden.clear()
+    this.levels.clear()
   }
 }

--- a/tracker/tracker/src/main/index.ts
+++ b/tracker/tracker/src/main/index.ts
@@ -313,6 +313,33 @@ export default class API {
     this.app.restartCanvasTracking()
   }
 
+  /**
+   * Re-evaluates sanitization against the current DOM and re-emits whatever
+   * changed, updating already-recorded nodes mid-session. Call after toggling
+   * `data-openreplay-*` attributes or after changing whatever your `domSanitizer`
+   * keys on (class/id/etc).
+   *
+   * @param el - the highest node you changed; omit to re-scan the whole document;
+   * scanning the entire doc is O(dom size)
+   * */
+  public resanitize = (el?: Element) => {
+    if (this.app === null) {
+      return
+    }
+    this.app.resanitize(el)
+  }
+
+  /**
+   * Returns the sanitization level the tracker currently has for a node
+   * (0 = Plain, 1 = Obscured, 2 = Hidden), or undefined if it isn't tracked.
+   * */
+  public checkSanitization = (el: Node) => {
+    if (this.app === null) {
+      return undefined
+    }
+    return this.app.checkSanitization(el)
+  }
+
   use<T>(fn: (app: App | null, options?: Partial<Options>) => T): T {
     return fn(this.app, this.options)
   }
@@ -480,7 +507,14 @@ export default class API {
   }
 
   identify = this.setUserID
-  track = this.analytics?.track
+  // Delegates at call time: `this.analytics` is assigned in the constructor body,
+  // which runs AFTER field initializers, so binding it here directly would always
+  // capture `undefined`.
+  track = (
+    eventName: string,
+    properties?: Record<string, any>,
+    options?: { send_immediately: boolean },
+  ) => this.analytics?.track(eventName, properties, options)
 
   userID = (id: string): void => {
     deprecationWarn("'userID' method", "'setUserID' method", '/')

--- a/tracker/tracker/src/main/modules/img.ts
+++ b/tracker/tracker/src/main/modules/img.ts
@@ -115,4 +115,11 @@ export default function (app: App): void {
     sendImgAttrs(node)
     observer.observe(node, { attributes: true, attributeFilter: ['src', 'srcset'] })
   })
+
+  // On a runtime level change, re-evaluate placeholder vs real src for this image.
+  app.attachResanitizeCallback((node: Node) => {
+    if (hasTag(node, 'img')) {
+      sendImgAttrs(node)
+    }
+  })
 }

--- a/tracker/tracker/src/main/modules/input.ts
+++ b/tracker/tracker/src/main/modules/input.ts
@@ -234,6 +234,14 @@ export default function (app: App, opts: Partial<Options>): void {
     app.send(InputChange(id, value, mask !== 0, label, hesitationTime, inputTime))
   }
 
+  // Re-emit a field's value when its sanitization level changes at runtime.
+  // getInputValue() reads the current level, so re-sending applies the new mask.
+  app.attachResanitizeCallback((node: Node, id: number) => {
+    if (isTextFieldElement(node) || hasTag(node, 'select')) {
+      sendInputValue(id, node)
+    }
+  })
+
   app.nodes.attachNodeCallback(
     app.safe((node: Node): void => {
       const id = app.nodes.getID(node)

--- a/tracker/tracker/src/main/singleton.ts
+++ b/tracker/tracker/src/main/singleton.ts
@@ -40,14 +40,17 @@ class TrackerSingleton {
       return Promise.resolve({ success: false, reason: 'Not in browser environment' })
     }
 
-    if (!this.ensureConfigured()) {
+    if (!this.ensureConfigured() || !this.instance) {
       return Promise.resolve({ success: false, reason: 'Tracker not configured' })
     }
 
-    return (
-      this.instance?.start(startOpts) ||
-      Promise.resolve({ success: false, reason: 'Tracker not initialized' })
-    )
+    // Tracker.start() rejects (instead of resolving {success:false}) when the
+    // underlying app failed to initialise (non-https, missing api, doNotTrack,
+    // already initialised...). Normalize so callers always get {success, reason}.
+    return this.instance.start(startOpts).catch((reason) => ({
+      success: false,
+      reason: typeof reason === 'string' ? reason : String(reason),
+    }))
   }
 
   /**
@@ -62,7 +65,7 @@ class TrackerSingleton {
     return this.instance.stop()
   }
 
-  setUserID(id: string): void {
+  setUserID = (id: string): void => {
     if (!IN_BROWSER || !this.ensureConfigured() || !this.instance) {
       return
     }
@@ -71,20 +74,22 @@ class TrackerSingleton {
   }
 
   get analytics() {
-    if (this.instance?.analytics) {
-      return this.instance.analytics
-    } else {
-      return null;
-    }
-  };
+    return this.instance?.analytics ?? null
+  }
 
   identify = this.setUserID
-  track = (eventName: string, properties?: Record<string, any>, options?: { send_immediately: boolean }): void => {
+  track = (
+    eventName: string,
+    properties?: Record<string, any>,
+    options?: { send_immediately: boolean },
+  ): void => {
     if (!IN_BROWSER || !this.ensureConfigured() || !this.instance) {
       return
     }
 
-    this.instance.track?.(eventName, properties)
+    // Route through analytics directly: Tracker.track is bound to analytics?.track
+    // at field-init time (before analytics exists), so it is always undefined.
+    this.instance.analytics?.track(eventName, properties, options)
   }
 
   /**
@@ -305,6 +310,61 @@ class TrackerSingleton {
     }
 
     return this.instance.getTabId()
+  }
+
+  /**
+   * Re-evaluates sanitization against the current DOM and re-emits whatever
+   * changed, updating already-recorded nodes mid-session. Call after toggling
+   * `data-openreplay-*` attributes or after changing whatever your `domSanitizer`
+   * keys on (class/id/etc).
+   *
+   * @param el - the highest node you changed; omit to re-scan the whole document.
+   * */
+  resanitize(el?: Element) {
+    if (!IN_BROWSER || !this.ensureConfigured() || !this.instance) {
+      return
+    }
+
+    return this.instance.resanitize(el)
+  }
+
+  /**
+   * Returns the sanitization level the tracker currently has for a node
+   * (0 = Plain, 1 = Obscured, 2 = Hidden), or undefined if it isn't tracked.
+   * */
+  checkSanitization(el: Node) {
+    if (!IN_BROWSER || !this.ensureConfigured() || !this.instance) {
+      return undefined
+    }
+
+    return this.instance.checkSanitization(el)
+  }
+
+  incident(options: { label?: string; startTime: number; endTime?: number }): void {
+    if (!IN_BROWSER || !this.ensureConfigured() || !this.instance) {
+      return
+    }
+
+    this.instance.incident(options)
+  }
+
+  /**
+   * Use custom token for analytics events without session recording
+   * */
+  setAnalyticsToken(token: string): void {
+    if (!IN_BROWSER || !this.ensureConfigured() || !this.instance) {
+      return
+    }
+
+    this.instance.setAnalyticsToken(token)
+  }
+
+  getAnalyticsToken(): string | undefined {
+    if (!IN_BROWSER || !this.ensureConfigured() || !this.instance) {
+      return undefined
+    }
+
+    return this.instance.getAnalyticsToken()
   }
 }
 

--- a/tracker/tracker/src/tests/canvas.test.ts
+++ b/tracker/tracker/src/tests/canvas.test.ts
@@ -21,6 +21,7 @@ describe('CanvasRecorder', () => {
       isObscured: jest.fn().mockReturnValue(false),
       isHidden: jest.fn().mockReturnValue(false),
     }
+    appMock.attachResanitizeCallback = jest.fn()
     appMock.timestamp = jest.fn().mockReturnValue(1000)
     appMock.send = jest.fn()
     appMock.debug = {

--- a/tracker/tracker/src/tests/sanitizer.unit.test.ts
+++ b/tracker/tracker/src/tests/sanitizer.unit.test.ts
@@ -33,7 +33,7 @@ describe('Sanitizer', () => {
   })
 
   test('should handle node and mark it as obscured if parent is obscured', () => {
-    sanitizer['obscured'].add(2)
+    sanitizer.setLevel(2, SanitizeLevel.Obscured)
     sanitizer.handleNode(1, 2, document.createElement('div'))
     expect(sanitizer.isObscured(1)).toBe(true)
   })
@@ -46,7 +46,7 @@ describe('Sanitizer', () => {
   })
 
   test('should handle node and mark it as hidden if parent is hidden', () => {
-    sanitizer['hidden'].add(2)
+    sanitizer.setLevel(2, SanitizeLevel.Hidden)
     sanitizer.handleNode(1, 2, document.createElement('div'))
     expect(sanitizer.isHidden(1)).toBe(true)
   })
@@ -98,7 +98,7 @@ describe('Sanitizer', () => {
   })
 
   test('should sanitize data as obscured if node is marked as obscured', () => {
-    sanitizer['obscured'].add(1)
+    sanitizer.setLevel(1, SanitizeLevel.Obscured)
     const data = 'Sensitive Data'
 
     const sanitizedData = sanitizer.sanitize(1, data)
@@ -121,7 +121,7 @@ describe('Sanitizer', () => {
 
   test('should return inner text of an element securely by sanitizing it', () => {
     const element = document.createElement('div')
-    sanitizer['obscured'].add(1)
+    sanitizer.setLevel(1, SanitizeLevel.Obscured)
     // @ts-expect-error
     element.mockId = 1
     element.innerText = 'Sensitive Data'
@@ -134,5 +134,66 @@ describe('Sanitizer', () => {
     element.innerText = 'Sensitive Data'
     const sanitizedText = sanitizer.getInnerTextSecure(element)
     expect(sanitizedText).toEqual('')
+  })
+
+  describe('two-way level state (dynamic re-sanitization)', () => {
+    test('getLevel defaults to Plain for untracked ids', () => {
+      expect(sanitizer.getLevel(999)).toBe(SanitizeLevel.Plain)
+    })
+
+    test('setLevel returns previous level and can both raise and lower', () => {
+      expect(sanitizer.setLevel(1, SanitizeLevel.Obscured)).toBe(SanitizeLevel.Plain)
+      expect(sanitizer.getLevel(1)).toBe(SanitizeLevel.Obscured)
+      // lower it back
+      expect(sanitizer.setLevel(1, SanitizeLevel.Plain)).toBe(SanitizeLevel.Obscured)
+      expect(sanitizer.getLevel(1)).toBe(SanitizeLevel.Plain)
+      expect(sanitizer.isObscured(1)).toBe(false)
+    })
+
+    test('handleNode is escalate-only: it never lowers an existing level', () => {
+      sanitizer.setLevel(1, SanitizeLevel.Hidden)
+      // a plain div would compute Plain, but handleNode must not downgrade Hidden
+      sanitizer.handleNode(1, 0, document.createElement('div'))
+      expect(sanitizer.isHidden(1)).toBe(true)
+    })
+
+    test('computeLevel reads the live DOM (attributes win over Plain parent)', () => {
+      const obscuredNode = document.createElement('div')
+      obscuredNode.setAttribute('data-openreplay-obscured', '')
+      expect(sanitizer.computeLevel(obscuredNode, SanitizeLevel.Plain)).toBe(SanitizeLevel.Obscured)
+
+      const hiddenNode = document.createElement('div')
+      hiddenNode.setAttribute('data-openreplay-hidden', '')
+      expect(sanitizer.computeLevel(hiddenNode, SanitizeLevel.Plain)).toBe(SanitizeLevel.Hidden)
+
+      const plainNode = document.createElement('div')
+      expect(sanitizer.computeLevel(plainNode, SanitizeLevel.Plain)).toBe(SanitizeLevel.Plain)
+    })
+
+    test('computeLevel inherits the parent level (max semantics)', () => {
+      const node = document.createElement('div')
+      expect(sanitizer.computeLevel(node, SanitizeLevel.Obscured)).toBe(SanitizeLevel.Obscured)
+      expect(sanitizer.computeLevel(node, SanitizeLevel.Hidden)).toBe(SanitizeLevel.Hidden)
+    })
+
+    test('computeLevel reflects a domSanitizer toggled via class at call time', () => {
+      const options: Options = {
+        obscureTextEmails: true,
+        obscureTextNumbers: false,
+        domSanitizer: (node: Element): SanitizeLevel =>
+          node.classList.contains('secret') ? SanitizeLevel.Obscured : SanitizeLevel.Plain,
+      }
+      const app = { nodes: { getID: jest.fn() } }
+      // @ts-expect-error partial app mock
+      const s = new Sanitizer({ app, options })
+      const node = document.createElement('div')
+
+      expect(s.computeLevel(node, SanitizeLevel.Plain)).toBe(SanitizeLevel.Plain)
+      // user toggles the marker the callback keys on, then recomputes
+      node.classList.add('secret')
+      expect(s.computeLevel(node, SanitizeLevel.Plain)).toBe(SanitizeLevel.Obscured)
+      node.classList.remove('secret')
+      expect(s.computeLevel(node, SanitizeLevel.Plain)).toBe(SanitizeLevel.Plain)
+    })
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds dynamic sanitization updates and remote-control support for native select dropdowns to improve masking accuracy and agent interactions. Also fixes analytics tracking binding and stabilizes tracker start behavior.

- New Features
  - Dynamic sanitization: add `resanitize(el?)` and `checkSanitization(el)` to recompute/query levels mid-session; observer/sanitizer now propagate changes and re-emit inputs/images/canvas.
  - Remote Control: enable native `select` dropdowns; emit `select` events from the mirrored DOM and apply the value with `input`/`change` on the real element.

- Refactors
  - Fix `track` to call `analytics?.track` at runtime and accept `options`.
  - Normalize `start()` failures to always return `{ success: false, reason }`.
  - Update tests; bump `@openreplay/tracker` to `18.0.12` and `@openreplay/tracker-assist` to `11.0.16`.

<sup>Written for commit 95b4691e18bf02d1d55e2d23850e1e064d8ff5a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

