### PR TITLE
fix(backend): add session ownership check to first-mob handler

### DIFF
--- a/backend/pkg/replays/api/handlers.go
+++ b/backend/pkg/replays/api/handlers.go
@@ -56,6 +56,16 @@ func (h *handlersImpl) getFirstMob(w http.ResponseWriter, r *http.Request) {
 
 	h.log.Info(r.Context(), "getFirstMob: sessID: %v, projID: %v", sessID, projID)
 
+	isSessionExists, err := h.sessions.IsExists(projID, sessID)
+	if err != nil {
+		h.responser.ResponseWithError(h.log, r.Context(), w, http.StatusInternalServerError, err, startTime, r.URL.Path, bodySize)
+		return
+	}
+	if !isSessionExists {
+		h.responser.ResponseWithError(h.log, r.Context(), w, http.StatusBadRequest, errors.New("wrong session id"), startTime, r.URL.Path, bodySize)
+		return
+	}
+
 	urls, err := h.files.GetMobStartUrl(sessID)
 	if err != nil {
 		h.log.Error(r.Context(), "Error getting start urls: %v", err)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a session ownership check in the first-mob handler to block access to start URLs when the session doesn’t belong to the project. This prevents an IDOR and improves error responses.

- **Bug Fixes**
  - Validate session exists for the project using `IsExists(projID, sessID)` before fetching start URLs.
  - Return `400 Bad Request` for invalid session IDs; return `500 Internal Server Error` on check failures.

<sup>Written for commit 99ef216c59e8dd413e4c9dc22cb9c54360798d18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

