### PR TITLE
ui: fix segment/feature auto refresh on creation, handle metadata key…

### DIFF
--- a/frontend/app/components/Dashboard/components/BreakdownFilter/BreakdownFilter.tsx
+++ b/frontend/app/components/Dashboard/components/BreakdownFilter/BreakdownFilter.tsx
@@ -100,10 +100,12 @@ function BreakdownFilter({ metric, observeChanges = () => {} }: Props) {
     .map((label: string) => allFilterOptions.find((f) => f.name === label))
     .filter((f): f is Filter => f !== undefined);
   const activeFilterNames = breakdownFilters.map((f: any) => f.name);
+  const isMetadata = (i: Filter) =>
+    String(i.category).toLowerCase() === 'metadata';
   const propertyOptions: Filter[] = allFilterOptions.filter(
     (i) =>
       !i.isEvent &&
-      supportedOptions.includes(i.name) &&
+      (supportedOptions.includes(i.name) || isMetadata(i)) &&
       !activeFilterNames.includes(i.name),
   );
   const canAddMore = activeFilterNames.length < 3;

--- a/frontend/app/components/DataManagement/Segments/SegmentPage.tsx
+++ b/frontend/app/components/DataManagement/Segments/SegmentPage.tsx
@@ -92,6 +92,7 @@ function SegmentPage() {
         t('Segment {{name}} created successfully', { name: created.name }),
       );
       queryClient.invalidateQueries({ queryKey: ['segments-list'] });
+      void filterStore.fetchFilters(String(siteId), true);
       history.push(withSiteId(dataManagement.segmentPage(created.id), siteId!));
     },
     onError: () => {
@@ -108,6 +109,7 @@ function SegmentPage() {
       queryClient.invalidateQueries({
         queryKey: ['segment', siteId, segmentId],
       });
+      void filterStore.fetchFilters(String(siteId), true);
     },
     onError: () => {
       toast.error(t('Failed to update segment. Please try again.'));
@@ -118,6 +120,7 @@ function SegmentPage() {
     mutationFn: () => deleteSegment(segmentId!),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['segments-list'] });
+      void filterStore.fetchFilters(String(siteId), true);
       history.push(backLink);
     },
     onError: () => {

--- a/frontend/app/components/shared/ORLoader.tsx
+++ b/frontend/app/components/shared/ORLoader.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-const OpenReplayPreloader =
-  require('../../svg/openreplay-preloader.svg').default;
+import OpenReplayPreloader from '../../svg/openreplay-preloader.svg';
 
 interface ORLoaderProps {
   width?: string;

--- a/frontend/app/mstore/filterStore.ts
+++ b/frontend/app/mstore/filterStore.ts
@@ -443,9 +443,12 @@ export default class FilterStore {
     return filters.map((filter) => ({ ...filter }));
   };
 
-  fetchFilters = async (projectId: string): Promise<Filter[]> => {
-    // Return cached filters if available
-    if (this.filters[projectId]?.length) {
+  fetchFilters = async (
+    projectId: string,
+    force = false,
+  ): Promise<Filter[]> => {
+    // Return cached filters if available (unless a refresh is forced)
+    if (!force && this.filters[projectId]?.length) {
       return this.getFilters(projectId);
     }
 

--- a/frontend/app/mstore/searchStore.ts
+++ b/frontend/app/mstore/searchStore.ts
@@ -9,7 +9,12 @@ import {
 } from 'Types/filter/newFilter';
 import { makeAutoObservable, runInAction } from 'mobx';
 
-import { filterStore, sessionStore, settingsStore } from 'App/mstore';
+import {
+  filterStore,
+  projectStore,
+  sessionStore,
+  settingsStore,
+} from 'App/mstore';
 import { checkFilterValue } from 'App/mstore/types/filter';
 import FilterItem from 'App/mstore/types/filterItem';
 import SavedSearch, { ISavedSearch } from 'App/mstore/types/savedSearch';
@@ -414,6 +419,8 @@ class SearchStore {
 
     // Refresh the list to show the latest saved searches
     await this.fetchSavedSearchList();
+    // Refresh filters so the new/updated segment appears in OmniSearch
+    void filterStore.fetchFilters(String(projectStore.activeSiteId), true);
   }
 
   clearList() {

--- a/frontend/app/mstore/tagWatchStore.ts
+++ b/frontend/app/mstore/tagWatchStore.ts
@@ -1,4 +1,4 @@
-import { projectStore } from '@/mstore';
+import { filterStore, projectStore } from '@/mstore';
 import { makeAutoObservable } from 'mobx';
 
 import { tagWatchService } from 'App/services';
@@ -49,6 +49,7 @@ export default class TagWatchStore {
     try {
       const pid = projectId || projectStore.active?.projectId;
       const tagId: number = await tagWatchService.createTag(pid!, data);
+      void filterStore.fetchFilters(String(projectStore.activeSiteId), true);
       return tagId;
     } catch (e) {
       console.error(e);
@@ -60,6 +61,7 @@ export default class TagWatchStore {
       const pid = projectId || projectStore.active?.projectId;
       await tagWatchService.deleteTag(pid!, id);
       this.setTags(this.tags.filter((t) => t.tagId !== id));
+      void filterStore.fetchFilters(String(projectStore.activeSiteId), true);
     } catch (e) {
       console.error(e);
     }
@@ -73,6 +75,7 @@ export default class TagWatchStore {
     try {
       const pid = projectId || projectStore.active?.projectId;
       await tagWatchService.updateTag(pid!, id, data);
+      void filterStore.fetchFilters(String(projectStore.activeSiteId), true);
       const updatedTag = this.tags.find((t) => t.tagId === id);
       if (updatedTag) {
         this.setTags(


### PR DESCRIPTION
…s in charts breakdowns

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing auto-refresh for segments and feature tags so new items show up immediately in filters and OmniSearch. Also enables using metadata keys in chart breakdowns.

- **Bug Fixes**
  - Added a `force` flag to `filterStore.fetchFilters(projectId, force)` and call it after create/update/delete of segments, saved searches, and tag watches to refresh filters without a page reload.
  - Included metadata-category filters in BreakdownFilter property options so charts can break down by metadata keys.

- **Refactors**
  - Switched `ORLoader` SVG import to an ES import to simplify bundling.

<sup>Written for commit 8d9b914ee1b739412092b7f7700324ab17dfb6cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

