### PR TITLE
ui: check timestamp parser for heatmap

### DIFF
--- a/frontend/app/mstore/dashboardStore.ts
+++ b/frontend/app/mstore/dashboardStore.ts
@@ -577,6 +577,7 @@ export default class DashboardStore {
             abortSignal,
           );
           data.domURL = sessionResp?.domURL || [];
+          data.startedAt = sessionResp?.startTs ?? data.startTs ?? 0;
           data.events = [];
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes heatmap timestamp parsing by ensuring a valid session start time is always set. We now populate the start time from the session response and fall back when missing to avoid empty or misaligned heatmaps.

- **Bug Fixes**
  - Set startedAt using sessionResp.startTs, then existing startTs, else 0 to prevent parser errors and align heatmap buckets.

<sup>Written for commit 612c79265339a0075aa7fc6ec7dd4b9114a52666. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

