### PR TITLE
Updated patch build from main ae8de6893250dd41175c6b2d312545c515fa5a16

### DIFF
--- a/scripts/helmcharts/openreplay/charts/api/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/api/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.4"
+AppVersion: "v1.27.5"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped the API Helm chart AppVersion from v1.27.4 to v1.27.5 to ship the latest patch build and ensure deployments pick up the new image. After merge, the automated tag update job will run.

<sup>Written for commit ded37e7067f35b9347bf8b4a367e2cf4804bbdda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

