### PR TITLE
ui: mcp auth page

### DIFF
--- a/frontend/app/PrivateRoutes.tsx
+++ b/frontend/app/PrivateRoutes.tsx
@@ -51,6 +51,7 @@ const components: any = {
     () => import('Components/DataManagement/Segments/SegmentPage'),
   ),
   TagsPage: lazy(() => import('Components/DataManagement/Tags/index')),
+  McpAuthorize: lazy(() => import('Components/McpAuthorize/McpAuthorize')),
 };
 
 const enhancedComponents: any = {
@@ -276,6 +277,10 @@ function PrivateRoutes() {
         <Route path={SPOT_PATH} element={<enhancedComponents.Spot />} />
 
         <Route path="/integrations/*" element={<IntegrationsRedirect />} />
+        <Route
+          path={routes.mcpAuthorize()}
+          element={<components.McpAuthorize />}
+        />
 
         {/* DASHBOARD and Metrics */}
         <Route

--- a/frontend/app/Router.tsx
+++ b/frontend/app/Router.tsx
@@ -209,7 +209,8 @@ const Router: React.FC = () => {
     location.pathname.includes('/assist/') ||
     location.pathname.includes('multiview') ||
     location.pathname.includes('/view-spot/') ||
-    location.pathname.includes('/spots/');
+    location.pathname.includes('/spots/') ||
+    location.pathname.includes('/mcp/authorize');
   if (isIframe) {
     return (
       <IFrameRoutes isJwt={isJwt} isLoggedIn={isLoggedIn} loading={loading} />

--- a/frontend/app/components/McpAuthorize/McpAuthorize.tsx
+++ b/frontend/app/components/McpAuthorize/McpAuthorize.tsx
@@ -1,0 +1,113 @@
+import Logo from '@/layout/Logo';
+import { Button, Card } from 'antd';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
+
+import APIClient from 'App/api_client';
+import { useStore } from 'App/mstore';
+import { sessions, withSiteId } from 'App/routes';
+import { useLocation, useNavigate } from 'App/routing';
+
+const logo = new URL('../../assets/logo.svg', import.meta.url);
+
+function McpAuthorize() {
+  const { t } = useTranslation();
+  const { userStore, loginStore, projectsStore } = useStore();
+  const accountName = userStore.account.name;
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const searchParams = new URLSearchParams(location.search);
+  const state = searchParams.get('state');
+  const clientId = searchParams.get('client_id');
+
+  const openRoot = () => {
+    navigate(withSiteId(sessions(), projectsStore.activeSiteId));
+  };
+  const handleAuthorize = async () => {
+    try {
+      const client = new APIClient();
+      const response = await client.post('/v1/mcp/authorize', {
+        state,
+        clientId,
+      });
+      const data = await response.json();
+      if (data?.data?.success) {
+        window.close();
+      } else if (data?.errors?.length) {
+        toast.error(data.errors[0]);
+      }
+    } catch (e: any) {
+      toast.error(e.message || 'Something went wrong');
+    }
+  };
+
+  const handleDecline = () => {
+    window.close();
+  };
+
+  const handleLogout = () => {
+    loginStore.invalidateSpotJWT();
+    window.postMessage({ type: 'orspot:invalidate' }, '*');
+    void userStore.logout();
+  };
+
+  if (!userStore.isEnterprise) {
+    return (
+      <div className="flex items-center justify-center bg-gray-lightest fixed top-0 bottom-0 left-0 right-0">
+        <Card style={{ width: 400 }}>
+          <div className="flex flex-col items-center gap-4">
+            <Logo siteId={projectsStore.activeSiteId} />
+            <div className="text-center">
+              <div>
+                {t(
+                  'This page is only available for Enterprise Edition of Open Replay',
+                )}
+              </div>
+            </div>
+            <div className="link mt-2" onClick={openRoot}>
+              {t('Back to Openreplay')}
+            </div>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center bg-gray-lightest fixed top-0 bottom-0 left-0 right-0">
+      <Card style={{ width: 400 }}>
+        <div className="flex flex-col items-center gap-4">
+          <Logo siteId={projectsStore.activeSiteId} />
+          <div className="text-center">
+            <div>
+              {t(
+                'Openreplay MCP Application would like to connect to your account',
+              )}
+            </div>
+            <div className="font-semibold mt-1">{accountName}</div>
+          </div>
+          <div className="flex flex-col items-center gap-2 w-full mt-2">
+            <Button type="primary" block onClick={handleAuthorize}>
+              {t('Authorize and close this page')}
+            </Button>
+            <div className="flex gap-2 w-full items-center">
+              <Button block onClick={handleDecline}>
+                {t('Decline')}
+              </Button>
+              <Button block onClick={handleLogout}>
+                {t('Logout')}
+              </Button>
+            </div>
+            <div className="link mt-2" onClick={openRoot}>
+              {t('Back to Openreplay')}
+            </div>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export default McpAuthorize;

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -159,6 +159,7 @@ export const spot = (id = ':spotId', hash?: string | number): string =>
 export const highlights = (): string => '/highlights';
 
 export const kai = (): string => '/kai';
+export const mcpAuthorize = (): string => '/mcp/authorize';
 export const dataManagement = {
   activity: () => '/data-management/activity',
   userPage: (id = ':userId', hash?: string | number) =>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an MCP authorization flow with a new page at /mcp/authorize so users can approve the MCP app. The page works in a popup/iframe, is Enterprise-only, and closes on success.

- New Features
  - New `McpAuthorize` page (lazy-loaded) at /mcp/authorize with Authorize, Decline, and Logout actions; shows the account name; blocks non-Enterprise users with a back link.
  - Sends POST /v1/mcp/authorize with state and client_id from the URL; closes the window on success and shows errors via toasts.
  - Route wired into `PrivateRoutes`; added `routes.mcpAuthorize()`; included in `Router` iframe paths.

<sup>Written for commit 9f1a8944db12d8c9b7a2f11312936adee1c3914f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

