### PR TITLE
ui: update ui look

### DIFF
--- a/frontend/app/components/McpAuthorize/McpAuthorize.tsx
+++ b/frontend/app/components/McpAuthorize/McpAuthorize.tsx
@@ -4,12 +4,9 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
 
-import APIClient from 'App/api_client';
-import { useStore } from 'App/mstore';
+import { client, useStore } from 'App/mstore';
 import { sessions, withSiteId } from 'App/routes';
 import { useLocation, useNavigate } from 'App/routing';
-
-const logo = new URL('../../assets/logo.svg', import.meta.url);
 
 function McpAuthorize() {
   const { t } = useTranslation();
@@ -17,6 +14,7 @@ function McpAuthorize() {
   const accountName = userStore.account.name;
   const location = useLocation();
   const navigate = useNavigate();
+  const [authorized, setAuthorized] = React.useState(false);
 
   const searchParams = new URLSearchParams(location.search);
   const state = searchParams.get('state');
@@ -27,24 +25,19 @@ function McpAuthorize() {
   };
   const handleAuthorize = async () => {
     try {
-      const client = new APIClient();
       const response = await client.post('/v1/mcp/authorize', {
         state,
         clientId,
       });
       const data = await response.json();
       if (data?.data?.success) {
-        window.close();
+        setAuthorized(true);
       } else if (data?.errors?.length) {
         toast.error(data.errors[0]);
       }
     } catch (e: any) {
       toast.error(e.message || 'Something went wrong');
     }
-  };
-
-  const handleDecline = () => {
-    window.close();
   };
 
   const handleLogout = () => {
@@ -80,30 +73,38 @@ function McpAuthorize() {
       <Card style={{ width: 400 }}>
         <div className="flex flex-col items-center gap-4">
           <Logo siteId={projectsStore.activeSiteId} />
-          <div className="text-center">
-            <div>
-              {t(
-                'Openreplay MCP Application would like to connect to your account',
-              )}
+          {authorized ? (
+            <div className="flex flex-col items-center gap-4">
+              <div className="text-center">
+                {t('Authorization successful. You can close this page now.')}
+              </div>
+              <div className="link" onClick={openRoot}>
+                {t('Back to Openreplay')}
+              </div>
             </div>
-            <div className="font-semibold mt-1">{accountName}</div>
-          </div>
-          <div className="flex flex-col items-center gap-2 w-full mt-2">
-            <Button type="primary" block onClick={handleAuthorize}>
-              {t('Authorize and close this page')}
-            </Button>
-            <div className="flex gap-2 w-full items-center">
-              <Button block onClick={handleDecline}>
-                {t('Decline')}
-              </Button>
-              <Button block onClick={handleLogout}>
-                {t('Logout')}
-              </Button>
-            </div>
-            <div className="link mt-2" onClick={openRoot}>
-              {t('Back to Openreplay')}
-            </div>
-          </div>
+          ) : (
+            <>
+              <div className="text-center">
+                <div>
+                  {t(
+                    'Openreplay MCP Application would like to connect to your account',
+                  )}
+                </div>
+                <div className="font-semibold mt-1">{accountName}</div>
+              </div>
+              <div className="flex flex-col items-center gap-2 w-full mt-2">
+                <Button type="primary" block onClick={handleAuthorize}>
+                  {t('Authorize')}
+                </Button>
+                <Button block onClick={handleLogout}>
+                  {t('Logout')}
+                </Button>
+                <div className="link mt-2" onClick={openRoot}>
+                  {t('Back to Openreplay')}
+                </div>
+              </div>
+            </>
+          )}
         </div>
       </Card>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Revamped the MCP authorization screen for a clearer flow: shows a success state instead of auto-closing, and cleans up the actions. Also switched the API call to the shared `client`.

- New Features
  - Added post-authorization success view with message and “Back to Openreplay” link.
  - Simplified actions: primary “Authorize,” removed “Decline,” kept “Logout.”

- Refactors
  - Replaced `APIClient` with `client` from `App/mstore` for `/v1/mcp/authorize`.
  - Removed unused logo import and the `handleDecline` handler.

<sup>Written for commit 0a538e2fd9128817232c59f4e28f1dbd7c1cebce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

