### PR TITLE
feat: add nginx rewrite to strip /ingest prefix

### DIFF
--- a/scripts/helmcharts/openreplay/charts/images/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/images/values.yaml
@@ -69,6 +69,9 @@ ingress:
     nginx.org/proxy-connect-timeout: "120s"
     nginx.org/proxy-send-timeout: "300s"
     nginx.org/proxy-read-timeout: "300s"
+    nginx.org/location-snippets: |
+      # Strip /ingest prefix
+      rewrite ^/ingest/(.*)$ /$1 break;
   cors:
     allowOrigin: "*"
     allowMethods: "POST, OPTIONS"


### PR DESCRIPTION
Add location snippet to strip the /ingest prefix from incoming requests, allowing the ingress to route /ingest/* paths to the correct backend endpoints without the prefix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an NGINX location snippet via the `nginx.org/location-snippets` annotation to rewrite /ingest/* paths to the same path without the /ingest prefix. This ensures /ingest requests are routed to the correct backend endpoints.

<sup>Written for commit 163868d6c8dd4f6c5561635fd3a4f9522c6d5c96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

