### PR TITLE
ui: security pass on player layer

### DIFF
--- a/player/src/web/Screen/Screen.ts
+++ b/player/src/web/Screen/Screen.ts
@@ -74,6 +74,9 @@ export default class Screen {
   ) {
     const iframe = document.createElement('iframe');
     iframe.className = styles.iframe;
+    // These flags are fixed when the browsing
+    // context is created, so this MUST be set before the iframe is attached.
+    iframe.setAttribute('sandbox', 'allow-same-origin');
     this.iframe = iframe;
 
     const overlay = document.createElement('div');

--- a/player/src/web/Screen/screen.module.css
+++ b/player/src/web/Screen/screen.module.css
@@ -51,6 +51,7 @@
 }
 
 .mobileIframe {
+  pointer-events: none;
   position: absolute;
   border: none;
   background: none;

--- a/player/src/web/managers/DOM/DOMManager.ts
+++ b/player/src/web/managers/DOM/DOMManager.ts
@@ -23,6 +23,12 @@ import {
   VText,
 } from './VirtualDOM';
 import { deleteRule, insertRule } from './safeCSSRules';
+import {
+  REPLAY_IFRAME_SANDBOX,
+  isForbiddenTag,
+  sanitizeAttribute,
+  sanitizeCssText,
+} from './sanitize';
 
 function isStyleVElement(
   vElem: VElement,
@@ -230,6 +236,15 @@ export default class DOMManager extends ListWalker<Message> {
       return;
     }
 
+    // Untrusted stream: drop event handlers, script-scheme URLs and iframe
+    // navigation sources before they ever reach the real element (see sanitize.ts).
+    const sanitized = sanitizeAttribute(vn.tagName, name, value);
+    if (!sanitized) {
+      logger.log('Rejecting unsafe attribute:', name, msg);
+      return;
+    }
+    value = sanitized.value;
+
     if (vn.tagName === 'INPUT' && name === 'name') {
       // Otherwise binds local autocomplete values (maybe should ignore on the tracker level?)
       return;
@@ -271,7 +286,7 @@ export default class DOMManager extends ListWalker<Message> {
       } else if (pendingMsg.tp === MType.AdoptedSsReplace) {
         olStyleSheet.whenReady((s) => {
           // @ts-ignore
-          s.replaceSync(pendingMsg.text);
+          s.replaceSync(sanitizeCssText(pendingMsg.text));
         });
       }
     }
@@ -316,6 +331,12 @@ export default class DOMManager extends ListWalker<Message> {
         return;
       }
       case MType.CreateElementNode: {
+        // Untrusted stream: never build a node that can execute script or
+        // hijack URL resolution in the player origin (see sanitize.ts).
+        if (isForbiddenTag(msg.tag)) {
+          logger.log('Rejecting forbidden element node:', msg.tag, msg);
+          return;
+        }
         // if (msg.tag.toLowerCase() === 'canvas') msg.tag = 'video'
         const vElem =
           msg.tag === 'SLOT'
@@ -327,6 +348,13 @@ export default class DOMManager extends ListWalker<Message> {
         if (this.vElements.has(msg.id)) {
           logger.error('CreateElementNode: Node already exists', msg);
           return;
+        }
+        if (vElem.tagName === 'IFRAME') {
+          // The iframe's content is rebuilt from messages (CreateIFrameDocument),
+          // so it never needs to load anything itself. Sandbox it without
+          // allow-scripts so a crafted remote/inline src can't run JS, while
+          // keeping allow-same-origin so the player can write its contentDocument.
+          vElem.setAttribute('sandbox', REPLAY_IFRAME_SANDBOX);
         }
         this.vElements.set(msg.id, vElem);
         this.insertNode(msg);
@@ -568,7 +596,7 @@ export default class DOMManager extends ListWalker<Message> {
           return;
         }
         // @ts-ignore (configure ts with recent WebAPI)
-        styleSheet.replaceSync(msg.text);
+        styleSheet.replaceSync(sanitizeCssText(msg.text));
         return;
       }
       case MType.AdoptedSsAddOwner: {

--- a/player/src/web/managers/DOM/safeCSSRules.ts
+++ b/player/src/web/managers/DOM/safeCSSRules.ts
@@ -1,4 +1,5 @@
 import logger from '../../../logger';
+import { sanitizeCssText } from './sanitize';
 
 function isChromium(item) {
   return ['Chromium', 'Google Chrome', 'NewBrowser'].includes(item.brand);
@@ -18,6 +19,8 @@ export function insertRule(
   if (msg.rule.includes('-moz-') && isChromeLike) {
     msg.rule = msg.rule.replace(/-moz-/g, '-webkit-');
   }
+  // Defense-in-depth: neutralize legacy script-bearing CSS constructs.
+  msg.rule = sanitizeCssText(msg.rule);
   try {
     sheet.insertRule(msg.rule, msg.index);
   } catch (e) {
@@ -49,7 +52,7 @@ export function replaceRule(
 ) {
   try {
     sheet.deleteRule(msg.index);
-    sheet.insertRule(msg.rule, msg.index);
+    sheet.insertRule(sanitizeCssText(msg.rule), msg.index);
   } catch (e) {
     logger.warn('Cannot replace rule.', e, '\nmessage: ', msg);
   }

--- a/player/src/web/managers/DOM/sanitize.ts
+++ b/player/src/web/managers/DOM/sanitize.ts
@@ -1,0 +1,150 @@
+/**
+ * Security sanitization for replay DOM construction.
+ *
+ * The player rebuilds a live DOM from a stream of session messages. That stream
+ * is untrusted input: a crafted recording (or a tampered websocket/asset
+ * payload) could try to make the player construct a node or set an attribute
+ * that executes script. Because the player renders into a same-origin iframe
+ * (see Screen.ts), any such execution would run in the OpenReplay app origin —
+ * i.e. a stored XSS against whoever opens the replay.
+ *
+ * The legitimate tracker never captures these (see tracker observer.ts:
+ * `isIgnored` skips SCRIPT/NOSCRIPT/META/TITLE/BASE, and `sendNodeAttribute`
+ * drops `on*` / `src` / `srcset` for HTML elements), so rejecting them here is a
+ * zero-regression trust boundary that also covers crafted streams which bypass
+ * the tracker entirely.
+ */
+
+/**
+ * Tags that can execute script or hijack resource/URL resolution. They are
+ * never useful for replay and must never be created. This mirrors the tracker's
+ * own `isIgnored` blocklist, so legit recordings are unaffected.
+ */
+const FORBIDDEN_TAGS = new Set([
+  'SCRIPT', // executes JS when inserted (createElement + insert runs it)
+  'NOSCRIPT',
+  'BASE', // <base href> rewrites relative URL resolution for the whole replay
+  'META', // <meta http-equiv="refresh"> can navigate/redirect the frame
+  'TITLE',
+]);
+
+export function isForbiddenTag(tag: string): boolean {
+  // SVG elements keep their original case (e.g. <script>, <style>); HTML tags
+  // arrive upper-cased. Normalize so `script` and `SCRIPT` are both caught.
+  return FORBIDDEN_TAGS.has(tag.toUpperCase());
+}
+
+/** Attributes whose value is interpreted as a URL and so can carry a scheme. */
+const URL_ATTRS = new Set([
+  'href',
+  'xlink:href', // tracker strips the `xlink:` prefix, but be safe
+  'src',
+  'srcset',
+  'action',
+  'formaction',
+  'background',
+  'poster',
+  'data',
+  'cite',
+  'longdesc',
+  'ping',
+]);
+
+/**
+ * Schemes that execute script. `data:` is intentionally NOT here: it is heavily
+ * used for legitimate inlined images / masked content / sprites. `data:` only
+ * becomes dangerous in a navigable context (iframe/object/embed), which we
+ * handle separately by stripping iframe src/srcdoc.
+ */
+const SCRIPT_SCHEMES = new Set(['javascript', 'vbscript']);
+
+/** Whitespace and control characters a browser ignores inside a URL scheme. */
+const URL_SCHEME_NOISE = /[\u0000-\u0020]+/g;
+
+/**
+ * Extract a URL's scheme the way a browser would: control characters and
+ * whitespace inside the scheme are ignored by the URL parser, so `java\tscript:`
+ * resolves to `javascript:`. We strip them before comparing. (Values reach us
+ * via setAttribute, never the HTML parser, so HTML entities are NOT decoded and
+ * cannot be used to obfuscate the scheme.)
+ */
+function getScheme(url: string): string {
+  const colon = url.indexOf(':');
+  if (colon === -1) return '';
+  return url.slice(0, colon).replace(URL_SCHEME_NOISE, '').toLowerCase();
+}
+
+export interface SanitizedAttribute {
+  value: string;
+}
+
+/**
+ * Validate a message-driven attribute write. Returns the (possibly unchanged)
+ * value to apply, or `null` if the attribute must be dropped entirely.
+ *
+ * @param tagName - owner element tag (HTML tags are upper-case)
+ * @param name    - attribute name
+ * @param value   - attribute value
+ */
+export function sanitizeAttribute(
+  tagName: string,
+  name: string,
+  value: string,
+): SanitizedAttribute | null {
+  const lname = name.toLowerCase();
+
+  // 1) Event handler content attributes (onload, onerror, onclick, ...) compile
+  //    into listeners as soon as they're set and run in the app origin. They are
+  //    never needed for replay. Mirrors the tracker's `name.substring(0,2)==='on'`.
+  if (lname.startsWith('on')) {
+    return null;
+  }
+
+  // 2) A reconstructed iframe gets its content rebuilt from messages
+  //    (CreateIFrameDocument). It must never load a remote page or an inline
+  //    document, both of which can run script. Strip its navigation sources.
+  if (
+    tagName.toUpperCase() === 'IFRAME' &&
+    (lname === 'src' || lname === 'srcdoc')
+  ) {
+    return null;
+  }
+
+  // 3) Script-executing URL schemes in any URL-bearing attribute.
+  if (URL_ATTRS.has(lname) && SCRIPT_SCHEMES.has(getScheme(value))) {
+    return null;
+  }
+
+  return { value };
+}
+
+/**
+ * Sandbox applied to every reconstructed iframe.
+ *
+ * `allow-same-origin` is required so the player (running in the parent document)
+ * can reach `contentDocument` to rebuild the iframe's content. We deliberately
+ * omit `allow-scripts`, `allow-top-navigation`, `allow-popups`, etc., so even if
+ * a crafted stream slips content into the frame it cannot execute JS or break
+ * out. Note: allow-same-origin WITHOUT allow-scripts is safe — the
+ * "sandbox can remove itself" caveat only applies when both are present.
+ */
+export const REPLAY_IFRAME_SANDBOX = 'allow-same-origin';
+
+/**
+ * Defense-in-depth scrub for CSS text (style tags, adopted stylesheets, inline
+ * style). Modern browsers do not execute JS from CSS, but legacy/vendor
+ * constructs (`expression()`, Firefox `-moz-binding: url(...)`) historically did.
+ * We neutralize them rather than reject the whole rule, so a single bad token
+ * cannot break sheet indexing.
+ */
+const CSS_SCRIPT_CONSTRUCTS =
+  /(expression\s*\(|-moz-binding\s*:|(?:javascript|vbscript)\s*:)/gi;
+
+export function sanitizeCssText(cssText: string): string {
+  CSS_SCRIPT_CONSTRUCTS.lastIndex = 0;
+  if (!CSS_SCRIPT_CONSTRUCTS.test(cssText)) {
+    return cssText;
+  }
+  CSS_SCRIPT_CONSTRUCTS.lastIndex = 0;
+  return cssText.replace(CSS_SCRIPT_CONSTRUCTS, '/* blocked */');
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Blocks script execution from crafted replays by sanitizing DOM attributes/CSS and enforcing sandboxing on iframes. Hardens the player’s DOM rebuild path to prevent stored XSS.

- **Bug Fixes**
  - Reject dangerous tags during node creation: SCRIPT, NOSCRIPT, BASE, META, TITLE.
  - Drop `on*` attributes, strip `javascript:`/`vbscript:` URLs, and remove iframe `src`/`srcdoc` from the untrusted stream.
  - Apply `sandbox="allow-same-origin"` to all replay iframes and set the player iframe sandbox before attaching.
  - Sanitize stylesheet text and CSS rules to neutralize `expression()`, `-moz-binding`, and script-like tokens.
  - Set `.mobileIframe` to `pointer-events: none` to prevent interaction.

<sup>Written for commit acc1914bdd7a4c7a682ef8d1fecd1f343a1863c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

