### PR TITLE
Updated patch build from main ea5aa2bc77d6c5e41ecfdca750c858cb45b348a5

### DIFF
--- a/scripts/helmcharts/openreplay/charts/api/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/api/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.5"
+AppVersion: "v1.27.6"

--- a/scripts/helmcharts/openreplay/charts/assets/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/assets/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.1"
+AppVersion: "v1.27.2"

--- a/scripts/helmcharts/openreplay/charts/db/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/db/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.0"
+AppVersion: "v1.27.1"

--- a/scripts/helmcharts/openreplay/charts/ender/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/ender/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.1"
+AppVersion: "v1.27.2"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped Helm chart AppVersion to the latest patch builds so deployments use the new images. Charts updated: api v1.27.6, assets v1.27.2, db v1.27.1, ender v1.27.2.

<sup>Written for commit 1825b557b35647c3e3a72838db94c1787775ac3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

