### PR TITLE
feat(chalice): support MCP app

### DIFF
--- a/ee/api/app.py
+++ b/ee/api/app.py
@@ -23,11 +23,7 @@ from chalicelib.utils.log import sanitize
 from crons import core_crons, ee_crons, core_dynamic_crons
 from routers import core, core_dynamic
 from routers import ee
-from routers.subs import (
-    health,
-    spot,
-    product_analytics,
-)
+from routers.subs import health, spot, product_analytics, mcp
 
 if config("ENABLE_SSO", cast=bool, default=True):
     from routers import saml
@@ -191,6 +187,9 @@ app.include_router(spot.app_apikey)
 app.include_router(product_analytics.public_app, prefix="/pa")
 app.include_router(product_analytics.app, prefix="/pa")
 app.include_router(product_analytics.app_apikey, prefix="/pa")
+
+app.include_router(mcp.app)
+app.include_router(mcp.public_app)
 
 if config("ENABLE_SSO", cast=bool, default=True):
     app.include_router(saml.public_app)

--- a/ee/api/chalicelib/core/mcp/authorizers.py
+++ b/ee/api/chalicelib/core/mcp/authorizers.py
@@ -1,0 +1,107 @@
+import logging
+
+import jwt
+from decouple import config
+from fastapi import HTTPException
+
+from chalicelib.utils import pg_client
+from chalicelib.utils.TimeUTC import TimeUTC
+from schemas import schemas, MCP
+
+logger = logging.getLogger(__name__)
+
+AUDIENCE = "mcp:OpenReplay"
+MCP_LOGIN_TIMEOUT_S = config("MCP_LOGIN_TIMEOUT_S", cast=int, default=0)
+
+
+def get_supported_audience():
+    return [AUDIENCE]
+
+
+def is_mcp_token(token: str) -> bool:
+    try:
+        decoded_token = jwt.decode(token, options={"verify_signature": False, "verify_exp": False})
+        audience = decoded_token.get("aud")
+        return audience == AUDIENCE
+    except jwt.InvalidTokenError:
+        logger.error(f"Invalid token for is_spot_token: {token}")
+        raise
+
+
+def jwt_authorizer(scheme: str, token: str, leeway=0) -> dict | None:
+    if scheme.lower() != "bearer" or len(token) < 5:
+        return None
+    try:
+        payload = jwt.decode(jwt=token,
+                             key=config("JWT_MCP_SECRET"),
+                             algorithms=config("JWT_MCP_ALGORITHM"),
+                             audience=get_supported_audience(),
+                             leeway=leeway)
+    except jwt.ExpiredSignatureError:
+        logger.debug("! JWT Expired signature")
+        return None
+    except jwt.exceptions.InvalidSignatureError:
+        logger.warning("! JWT Signature verification failed")
+        return None
+    except BaseException as e:
+        logger.warning("! JWT Base Exception", exc_info=e)
+        return None
+    return payload
+
+
+def generate_jwt(user_id, tenant_id, iat, jti, client_id):
+    token = jwt.encode(
+        payload={
+            "userId": user_id,
+            "tenantId": tenant_id,
+            "exp": iat + config("JWT_MCP_EXPIRATION", cast=int),
+            "iss": config("JWT_ISSUER"),
+            "iat": iat,
+            "jti": jti,
+            "aud": AUDIENCE,
+            "clientId": client_id
+        },
+        key=config("JWT_MCP_SECRET"),
+        algorithm=config("JWT_MCP_ALGORITHM")
+    )
+    return token
+
+
+def store_token_request(data: MCP.AuthorizeSchema, cotext: schemas.CurrentContext):
+    with pg_client.PostgresClient() as cur:
+        query = cur.mogrify(
+            """
+            INSERT INTO public.mcp_authentication_tokens(user_id, client_id, state, iat)
+            VALUES (%(user_id)s, %(client_id)s, %(state)s,
+                    timezone('utc'::text, now() - INTERVAL '10s')) ON CONFLICT DO NOTHING;""",
+            {"client_id": data.client_id, "state": data.state,
+             "user_id": cotext.user_id, },
+        )
+        cur.execute(query=query)
+
+
+def get_token_by_state(client_id, state):
+    with pg_client.PostgresClient() as cur:
+        query = cur.mogrify(
+            """
+            UPDATE public.mcp_authentication_tokens
+            SET generated= TRUE
+            WHERE client_id = %(client_id)s
+              AND state = %(state)s
+              AND NOT generated 
+            RETURNING *,EXTRACT(epoch FROM iat)::BIGINT AS iat,
+                (SELECT tenant_id 
+                 FROM public.users 
+                 WHERE users.user_id = mcp_authentication_tokens.user_id 
+                    AND users.deleted_at IS NULL) AS tenant_id;""",
+            {"client_id": client_id, "state": state},
+        )
+        cur.execute(query=query)
+        row = cur.fetchone()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="State not found or token already generated")
+    if MCP_LOGIN_TIMEOUT_S > 0 and (row["iat"] + MCP_LOGIN_TIMEOUT_S) >= TimeUTC.now():
+        raise HTTPException(status_code=408, detail="Login timed out")
+
+    return generate_jwt(user_id=row["user_id"], tenant_id=row["tenant_id"], iat=row["iat"], client_id=client_id, jti=row["jti"])

--- a/ee/api/chalicelib/core/mcp/tracer.py
+++ b/ee/api/chalicelib/core/mcp/tracer.py
@@ -1,0 +1,16 @@
+import logging
+
+from chalicelib.utils import pg_client
+
+logger = logging.getLogger(__name__)
+
+
+def store_client_id(client_id: str, user_id: int):
+    with pg_client.PostgresClient() as cur:
+        query = cur.mogrify(
+            """
+            INSERT INTO public.mcp_app_users(user_id, client_id)
+            VALUES (%(user_id)s, %(client_id)s) ON CONFLICT DO NOTHING;""",
+            {"client_id": client_id, "user_id": user_id, },
+        )
+        cur.execute(query=query)

--- a/ee/api/routers/subs/mcp.py
+++ b/ee/api/routers/subs/mcp.py
@@ -1,0 +1,30 @@
+from fastapi import Depends, Body, BackgroundTasks
+from fastapi import HTTPException
+
+import schemas
+from chalicelib.core.mcp import authorizers, tracer
+from or_dependencies import OR_context
+from routers.base import get_routers
+
+public_app, app, app_apikey = get_routers()
+
+
+@app.post('/v1/mcp/authorize', tags=["mcp"])
+def authorize_mcp_app(background_tasks: BackgroundTasks,
+                      data: schemas.MCP.AuthorizeSchema = Body(...),
+                      context: schemas.CurrentContext = Depends(OR_context)):
+    if not (context.email.endswith("asayer.io") or context.email.endswith("openreplay.com")):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    authorizers.store_token_request(data=data, cotext=context)
+    background_tasks.add_task(tracer.store_client_id,
+                              user_id=context.user_id,
+                              client_id=data.client_id)
+    return {"data": {"success": True}}
+
+
+@public_app.get("/v1/mcp/auth-status", tags=["mcp"])
+def get_mcp_jwt(client_id: str, state: str):
+    jwt = authorizers.get_token_by_state(client_id=client_id, state=state)
+    if jwt is None:
+        raise HTTPException(status_code=404, detail="Unauthorized")
+    return {"jwt": jwt}

--- a/ee/api/schemas/__init__.py
+++ b/ee/api/schemas/__init__.py
@@ -4,3 +4,4 @@ from .assist_stats_schema import *
 from .product_analytics import *
 from . import overrides as _overrides
 from .schemas import _PaginatedSchema as PaginatedSchema
+from . import schemas_mcp as MCP

--- a/ee/api/schemas/schemas_mcp.py
+++ b/ee/api/schemas/schemas_mcp.py
@@ -1,0 +1,9 @@
+from pydantic import Field
+
+from .overrides import BaseModel
+
+
+class AuthorizeSchema(BaseModel):
+    state: str = Field(...)
+    # client_id is to identify the running MCP app for a client
+    client_id: str = Field(...)

--- a/ee/scripts/schema/db/init_dbs/postgresql/1.27.0/1.27.0.sql
+++ b/ee/scripts/schema/db/init_dbs/postgresql/1.27.0/1.27.0.sql
@@ -19,7 +19,27 @@ $fn_def$, :'next_version')
 
 --
 
-ALTER TABLE public.tags ADD COLUMN IF NOT EXISTS location text NULL DEFAULT NULL;
+ALTER TABLE IF EXISTS public.tags
+    ADD COLUMN IF NOT EXISTS location text NULL DEFAULT NULL;
+
+CREATE TABLE IF NOT EXISTS public.mcp_authentication_tokens
+(
+    user_id   integer                     NOT NULL REFERENCES public.users (user_id) ON DELETE CASCADE,
+    client_id text                        NOT NULL,
+    state     text                        NOT NULL,
+    jti       text                        NOT NULL DEFAULT generate_api_key(10),
+    iat       timestamp without time zone NULL     DEFAULT NULL,
+    generated bool                                 DEFAULT FALSE,
+    PRIMARY KEY (user_id, client_id, state)
+);
+
+CREATE TABLE IF NOT EXISTS public.mcp_app_users
+(
+    user_id    integer                     NOT NULL REFERENCES public.users (user_id) ON DELETE CASCADE,
+    client_id  text                        NOT NULL,
+    created_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc'),
+    PRIMARY KEY (user_id, client_id)
+);
 
 COMMIT;
 

--- a/ee/scripts/schema/db/init_dbs/postgresql/init_schema.sql
+++ b/ee/scripts/schema/db/init_dbs/postgresql/init_schema.sql
@@ -1369,7 +1369,7 @@ CREATE UNIQUE INDEX sessions_videos_session_id_project_id_key ON public.sessions
 
 CREATE TABLE public.actions
 (
-    action_id   uuid                        PRIMARY KEY DEFAULT gen_random_uuid(),
+    action_id   uuid PRIMARY KEY                     DEFAULT gen_random_uuid(),
     project_id  integer                     NOT NULL REFERENCES public.projects (project_id) ON DELETE CASCADE,
     user_id     integer                     NULL REFERENCES public.users (user_id) ON DELETE SET NULL,
     name        varchar(255)                NOT NULL,
@@ -1386,5 +1386,24 @@ CREATE INDEX actions_project_id_is_public_idx ON public.actions (project_id, is_
 CREATE INDEX actions_name_gin_idx ON public.actions USING GIN (name gin_trgm_ops);
 CREATE UNIQUE INDEX actions_project_id_name_idx ON public.actions (project_id, name);
 CREATE INDEX actions_project_id_created_at_idx ON public.actions (project_id, created_at DESC);
+
+CREATE TABLE public.mcp_authentication_tokens
+(
+    user_id   integer                     NOT NULL REFERENCES public.users (user_id) ON DELETE CASCADE,
+    client_id text                        NOT NULL,
+    state     text                        NOT NULL,
+    jti       text                        NOT NULL DEFAULT generate_api_key(10),
+    iat       timestamp without time zone NULL     DEFAULT NULL,
+    generated bool                                 DEFAULT FALSE,
+    PRIMARY KEY (user_id, client_id, state)
+);
+
+CREATE TABLE public.mcp_app_users
+(
+    user_id    integer                     NOT NULL REFERENCES public.users (user_id) ON DELETE CASCADE,
+    client_id  text                        NOT NULL,
+    created_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc'),
+    PRIMARY KEY (user_id, client_id)
+);
 
 COMMIT;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add MCP app auth flow with JWT, new endpoints to authorize and fetch tokens, and DB tables to track requests and app users. Authorization is restricted to internal users only.

- New Features
  - POST /v1/mcp/authorize (internal-only) and GET /v1/mcp/auth-status.
  - JWTs with audience "mcp:OpenReplay", signed via configured secret/algorithm; optional login timeout.
  - Store pending auth requests and mark as generated on retrieval; background task records client_id per user.
  - Routers registered on the main app.

- Migration
  - Run DB migrations to create public.mcp_authentication_tokens and public.mcp_app_users.
  - Configure env vars: JWT_MCP_SECRET, JWT_MCP_ALGORITHM, JWT_ISSUER, JWT_MCP_EXPIRATION (required); MCP_LOGIN_TIMEOUT_S (optional).

<sup>Written for commit b61cdd74a0c0598ff90fb3709a71f8fcb9315451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

