### PR TITLE
tracker: add bfcache handling, fix other small issues (like win11 par…

### DIFF
--- a/tracker/tracker/CHANGELOG.md
+++ b/tracker/tracker/CHANGELOG.md
@@ -9,7 +9,7 @@
 - fix image mutations being skipped after an untracked node
 - fix in-memory css scan skipping remaining stylesheets after one hits its check limit
 - restore original console methods when the tracker stops
-- correctly detect windows 11 version
+- correctly detect Windows 11 version
 - fix sprite icon cache mixing icons across sprite files and recovering after a failed fetch
 
 ## 18.0.17

--- a/tracker/tracker/CHANGELOG.md
+++ b/tracker/tracker/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 18.1.0
+
+- restart or resume the session when a page is restored from back-forward cache (bfcache)
+- mask every email in a text node, not only nodes that are a single email
+- keep analytics events on failed send and flush them when the tab is hidden
+- fix potential crash when removing an attribute from an svg element
+- prune throttling maps to avoid slow memory growth on long sessions
+- fix leaked interval when multiple duration-based conditions are used
+- fix image mutations being skipped after an untracked node
+- fix in-memory css scan skipping remaining stylesheets after one hits its check limit
+- restore original console methods when the tracker stops
+- correctly detect windows 11 version
+- fix sprite icon cache mixing icons across sprite files and recovering after a failed fetch
+
 ## 18.0.17
 
 - revisiting node maintainer class (should be slightly better performance now)

--- a/tracker/tracker/CHANGELOG.md
+++ b/tracker/tracker/CHANGELOG.md
@@ -11,6 +11,7 @@
 - restore original console methods when the tracker stops
 - correctly detect Windows 11 version
 - fix sprite icon cache mixing icons across sprite files and recovering after a failed fetch
+- preserve protocol version token on first render of the page
 
 ## 18.0.17
 

--- a/tracker/tracker/package.json
+++ b/tracker/tracker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openreplay/tracker",
   "description": "The OpenReplay tracker main package",
-  "version": "18.0.17",
+  "version": "18.1.0",
   "keywords": [
     "logging",
     "replay"

--- a/tracker/tracker/package.json
+++ b/tracker/tracker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openreplay/tracker",
   "description": "The OpenReplay tracker main package",
-  "version": "18.1.0",
+  "version": "18.1.0-beta.0",
   "keywords": [
     "logging",
     "replay"

--- a/tracker/tracker/src/main/app/index.ts
+++ b/tracker/tracker/src/main/app/index.ts
@@ -137,6 +137,14 @@ type AppOptions = {
   localStorage: Storage | null
   sessionStorage: Storage | null
   forceSingleTab?: boolean
+  /**
+   * When a page is restored from the browser's back-forward cache (bfcache),
+   * the tracker resumes the existing session if it was frozen for less than this
+   * many milliseconds, and starts a fresh session otherwise (the previous one has
+   * likely gone stale server-side). Set to 0 to always restart on restore.
+   * @default 1800000 (30 min)
+   */
+  bfcacheRestartThreshold?: number
   /** Sometimes helps to prevent session breaking due to dict reset */
   disableStringDict?: boolean
   assistSocketHost?: string
@@ -284,6 +292,7 @@ export default class App {
   private frameOderNumber = 0
   private frameLevel = 0
   private emptyBatchCounter = 0
+  private lastHiddenAt: number | null = null
 
   constructor(
     projectKey: string,
@@ -314,6 +323,7 @@ export default class App {
       localStorage: null,
       sessionStorage: null,
       forceSingleTab: false,
+      bfcacheRestartThreshold: 30 * 60 * 1000,
       assistSocketHost: '',
       captureIFrames: true,
       obscureTextEmails: false,
@@ -1106,7 +1116,22 @@ export default class App {
         }
       }
       this.attachEventListener(document.body, 'mouseleave', alertWorker, false, false)
-      this.attachEventListener(window, 'pagehide', alertWorker, false, false)
+      this.attachEventListener(
+        window,
+        'pagehide',
+        () => {
+          // pagehide is the entry point into the back-forward cache; remember when
+          // it fired so pageshow can measure how long the page stayed frozen.
+          this.lastHiddenAt = Date.now()
+          alertWorker()
+        },
+        false,
+        false,
+      )
+      // Detect restores from the back-forward cache. Attached directly rather than via
+      // attachEventListener so it persists through stop()/restart() and can still catch a
+      // restore that happens while the tracker is briefly stopped.
+      window.addEventListener('pageshow', this.handlePageShow, false)
       // TODO: stop session after inactivity timeout (make configurable)
       this.attachEventListener(
         document,
@@ -1131,6 +1156,29 @@ export default class App {
           this.debug.error('Session restart failed', e)
         })
     })
+  }
+
+  private handlePageShow = (e: PageTransitionEvent): void => {
+    // Only back-forward cache restores set persisted === true; a normal navigation is false.
+    if (!e || !e.persisted) {
+      return
+    }
+    try {
+      const frozenMs = this.lastHiddenAt != null ? Date.now() - this.lastHiddenAt : null
+      this.lastHiddenAt = null
+      const threshold = this.options.bfcacheRestartThreshold ?? 30 * 60 * 1000
+      // If we couldn't measure the freeze, or it outlasted the threshold, the session has
+      // likely expired server-side - start a clean one. Otherwise let the resumed page
+      // continue on the existing session (preserving continuity).
+      if (frozenMs === null || frozenMs >= threshold) {
+        this.debug.info('OpenReplay: restarting session after bfcache restore', { frozenMs })
+        this.restart()
+      } else {
+        this.debug.info('OpenReplay: resuming session after bfcache restore', { frozenMs })
+      }
+    } catch (err) {
+      this._debug('bfcache_restore', err)
+    }
   }
 
   private handleWorkerMsg(data: FromWorkerData) {

--- a/tracker/tracker/src/main/app/index.ts
+++ b/tracker/tracker/src/main/app/index.ts
@@ -1128,10 +1128,16 @@ export default class App {
         false,
         false,
       )
-      // Detect restores from the back-forward cache. Attached directly rather than via
-      // attachEventListener so it persists through stop()/restart() and can still catch a
-      // restore that happens while the tracker is briefly stopped.
-      window.addEventListener('pageshow', this.handlePageShow, false)
+      // Detect restores from the back-forward cache. Registered through
+      // attachEventListener so it's removed on stop (no leak) and a tracker that was
+      // intentionally stopped does not resurrect itself on a back/forward restore.
+      this.attachEventListener(
+        window,
+        'pageshow',
+        this.handlePageShow as EventListener,
+        false,
+        false,
+      )
       // TODO: stop session after inactivity timeout (make configurable)
       this.attachEventListener(
         document,
@@ -1144,12 +1150,18 @@ export default class App {
     }
   }
 
-  private restart = () => {
+  private restart = (forceNew = false) => {
     this.stop(false)
     this.waitStatus(ActivityState.NotActive).then(() => {
       this.allowAppStart()
-      this.start(this.prevOpts, true)
+      // Force a brand-new session when asked (e.g. a stale bfcache restore) without
+      // letting forceNew leak into later restarts through prevOpts.
+      const startOpts = forceNew ? { ...this.prevOpts, forceNew: true } : this.prevOpts
+      this.start(startOpts, true)
         .then((r) => {
+          if (forceNew) {
+            this.prevOpts = { ...this.prevOpts, forceNew: false }
+          }
           this.debug.info('Session restart', r)
         })
         .catch((e) => {
@@ -1163,16 +1175,20 @@ export default class App {
     if (!e || !e.persisted) {
       return
     }
+    // Don't resurrect a tracker that was intentionally stopped.
+    if (this.activityState === ActivityState.NotActive) {
+      return
+    }
     try {
       const frozenMs = this.lastHiddenAt != null ? Date.now() - this.lastHiddenAt : null
       this.lastHiddenAt = null
       const threshold = this.options.bfcacheRestartThreshold ?? 30 * 60 * 1000
       // If we couldn't measure the freeze, or it outlasted the threshold, the session has
-      // likely expired server-side - start a clean one. Otherwise let the resumed page
-      // continue on the existing session (preserving continuity).
+      // likely expired server-side - start a fresh one (forceNew). Otherwise let the
+      // resumed page continue on the existing session (preserving continuity).
       if (frozenMs === null || frozenMs >= threshold) {
         this.debug.info('OpenReplay: restarting session after bfcache restore', { frozenMs })
-        this.restart()
+        this.restart(true)
       } else {
         this.debug.info('OpenReplay: resuming session after bfcache restore', { frozenMs })
       }

--- a/tracker/tracker/src/main/app/observer/observer.ts
+++ b/tracker/tracker/src/main/app/observer/observer.ts
@@ -51,8 +51,13 @@ export async function parseUseEl(
       return
     }
 
-    if (iconCache[symbolId]) {
-      return iconCache[symbolId]
+    // Key the cache by url + symbol + mode: the same symbol id lives in different
+    // sprite files, and different modes store different value shapes (object vs
+    // string vs data-url), so keying by symbolId alone returns the wrong asset.
+    const cacheKey = `${url || 'local'}#${symbolId}#${mode}`
+
+    if (iconCache[cacheKey]) {
+      return iconCache[cacheKey]
     }
 
     // happens if svg spritemap is local, fastest case for us
@@ -73,7 +78,7 @@ export async function parseUseEl(
         </svg>
       `
 
-        iconCache[symbolId] = inlineSvg
+        iconCache[cacheKey] = inlineSvg
 
         return inlineSvg
       } else {
@@ -81,7 +86,7 @@ export async function parseUseEl(
         return
       }
     }
-    let svgDoc: Document
+    let svgDoc: Document | undefined
     if (svgUrlCache[url]) {
       if (svgUrlCache[url] === 1) {
         await new Promise((resolve) => {
@@ -105,10 +110,21 @@ export async function parseUseEl(
       }
     } else {
       svgUrlCache[url] = 1
-      const response = await fetch(url)
-      const svgText = await response.text()
-      svgDoc = domParser.parseFromString(svgText, 'image/svg+xml')
-      svgUrlCache[url] = svgDoc
+      try {
+        const response = await fetch(url)
+        const svgText = await response.text()
+        svgDoc = domParser.parseFromString(svgText, 'image/svg+xml')
+        svgUrlCache[url] = svgDoc
+      } catch (e) {
+        // Clear the in-flight sentinel so a failed fetch doesn't wedge every
+        // future <use> for this url into a 10s poll-then-give-up loop.
+        delete svgUrlCache[url]
+        throw e
+      }
+    }
+
+    if (!svgDoc) {
+      return
     }
 
     // @ts-ignore
@@ -121,7 +137,7 @@ export async function parseUseEl(
 
     if (mode === 'inline') {
       const res = { paths: symbol.innerHTML, vbox: symbol.getAttribute('viewBox') || '0 0 24 24' }
-      iconCache[symbolId] = res
+      iconCache[cacheKey] = res
       return res
     }
     if (mode === 'svgtext') {
@@ -131,7 +147,7 @@ export async function parseUseEl(
         </svg>
       `
 
-      iconCache[symbolId] = inlineSvg
+      iconCache[cacheKey] = inlineSvg
 
       return inlineSvg
     }
@@ -144,7 +160,7 @@ export async function parseUseEl(
       const encodedSvg = btoa(inlineSvg)
       const dataUrl = `data:image/svg+xml;base64,${encodedSvg}`
 
-      iconCache[symbolId] = dataUrl
+      iconCache[cacheKey] = dataUrl
 
       return dataUrl
     }
@@ -361,6 +377,7 @@ export default abstract class Observer {
       }
       if (value === null) {
         this.app.send(RemoveNodeAttribute(id, name))
+        return
       }
 
       if (isUseElement(node) && name === 'href' && !this.disableSprites) {

--- a/tracker/tracker/src/main/app/observer/observer.ts
+++ b/tracker/tracker/src/main/app/observer/observer.ts
@@ -54,7 +54,9 @@ export async function parseUseEl(
     // Key the cache by url + symbol + mode: the same symbol id lives in different
     // sprite files, and different modes store different value shapes (object vs
     // string vs data-url), so keying by symbolId alone returns the wrong asset.
-    const cacheKey = `${url || 'local'}#${symbolId}#${mode}`
+    // Namespace remote vs in-document sprites so a relative sprite file literally
+    // named "local" can't collide with the in-document bucket.
+    const cacheKey = url ? `url:${url}#${symbolId}#${mode}` : `doc:${symbolId}#${mode}`
 
     if (iconCache[cacheKey]) {
       return iconCache[cacheKey]

--- a/tracker/tracker/src/main/app/sanitizer.ts
+++ b/tracker/tracker/src/main/app/sanitizer.ts
@@ -139,10 +139,18 @@ export default class Sanitizer {
       data = data.replace(/\d/g, '0')
     }
     if (this.options.obscureTextEmails) {
-      data = data.replace(/^\w+([+.-]\w+)*@\w+([.-]\w+)*\.\w{2,3}$/g, (email) => {
-        const [name, domain] = email.split('@')
-        const [domainName, host] = domain.split('.')
-        return `${stars(name)}@${stars(domainName)}.${stars(host)}`
+      // Match every email-like substring anywhere in the text (not just when the
+      // whole node is a single email), and preserve every domain label including
+      // multi-part TLDs (e.g. .co.uk) so nothing leaks through unmasked.
+      data = data.replace(/[^\s@]+@[^\s@]+\.[^\s@]+/g, (email) => {
+        const atIdx = email.lastIndexOf('@')
+        const name = email.slice(0, atIdx)
+        const domain = email.slice(atIdx + 1)
+        const maskedDomain = domain
+          .split('.')
+          .map((part) => stars(part))
+          .join('.')
+        return `${stars(name)}@${maskedDomain}`
       })
     }
     return data

--- a/tracker/tracker/src/main/modules/analytics/batcher.ts
+++ b/tracker/tracker/src/main/modules/analytics/batcher.ts
@@ -122,8 +122,13 @@ class Batcher {
     return Array.from(uniqueEventsByType.values())
   }
 
-  private sendBatch(batch: Record<string, any>) {
+  private sendBatch(
+    batch: Record<string, any>,
+    keepalive = false,
+    onTerminalFailure?: () => void,
+  ) {
     if (this.stopped) {
+      onTerminalFailure?.()
       return
     }
     const sentBatch = batch
@@ -131,11 +136,14 @@ class Batcher {
     const send = () => {
       const token = this.getToken()
       if (!token) {
+        // No token yet: keep the events so they go out once one is available.
+        onTerminalFailure?.()
         return
       }
       attempts++
       return fetch(`${this.backendUrl}${this.apiEdp}`, {
         method: 'POST',
+        keepalive,
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
@@ -154,6 +162,7 @@ class Batcher {
                 send()
               })
             }
+            onTerminalFailure?.()
             return
           }
           if (response.status === 403) {
@@ -162,6 +171,7 @@ class Batcher {
                 send()
               })
             }
+            onTerminalFailure?.()
             return
           }
           if (!response.ok) {
@@ -171,6 +181,8 @@ class Batcher {
         .catch(() => {
           if (attempts < this.retryLimit) {
             setTimeout(() => void send(), this.retryTimeout)
+          } else {
+            onTerminalFailure?.()
           }
         })
     }
@@ -180,7 +192,14 @@ class Batcher {
   private paused = false
 
   private onVisibilityChange = () => {
-    this.paused = document.hidden
+    if (document.hidden) {
+      // The tab may be closing; flush now with keepalive so buffered events
+      // survive the transition instead of waiting for the (paused) interval.
+      this.flush(true)
+      this.paused = true
+    } else {
+      this.paused = false
+    }
   }
 
   startAutosend() {
@@ -196,17 +215,40 @@ class Batcher {
     }, this.autosendInterval)
   }
 
-  flush() {
-    const categories = Object.keys(this.batch)
-    const isEmpty = categories.every((category) => this.batch[category].length === 0)
+  flush(keepalive = false) {
+    const cats = Object.keys(this.batch)
+    const isEmpty = cats.every((category) => this.batch[category].length === 0)
     if (isEmpty) {
       return
     }
 
-    this.sendBatch(this.getBatches())
-    categories.forEach((key) => {
+    const batches = this.getBatches()
+    // Snapshot what we're about to send so we can restore it if the request
+    // ultimately fails, instead of dropping events the moment we clear the buffer.
+    const snapshot = {
+      [categories.people]: [...batches.data[categories.people]],
+      [categories.events]: [...batches.data[categories.events]],
+    }
+    cats.forEach((key) => {
       this.batch[key] = []
     })
+    this.sendBatch(batches, keepalive, () => this.requeue(snapshot))
+  }
+
+  private requeue(snapshot: Record<string, any[]>) {
+    if (this.stopped) {
+      return
+    }
+    // Put the failed events back at the front, ahead of anything queued since,
+    // so they're retried on the next flush rather than lost.
+    this.batch[categories.people] = [
+      ...snapshot[categories.people],
+      ...this.batch[categories.people],
+    ]
+    this.batch[categories.events] = [
+      ...snapshot[categories.events],
+      ...this.batch[categories.events],
+    ]
   }
 
   stop() {

--- a/tracker/tracker/src/main/modules/analytics/constantProperties.ts
+++ b/tracker/tracker/src/main/modules/analytics/constantProperties.ts
@@ -69,7 +69,12 @@ export default class ConstantProperties {
     private readonly sessionStorage: StorageLike,
   ) {
     const { width, height, browser, browserVersion, browserMajorVersion, os, osVersion, mobile } =
-      uaParse(win)
+      uaParse(win, (refinedOsVersion) => {
+        // Windows 10/11 are indistinguishable from the UA string; the async
+        // high-entropy result lands after construction, so update it live here.
+        // `all` is a getter, so later events pick up the corrected value.
+        this.osVersion = refinedOsVersion
+      })
     const storedUserId = this.sessionStorage.getItem(userIdKey)
     if (storedUserId) {
       this.user_id = storedUserId

--- a/tracker/tracker/src/main/modules/analytics/tests/sharedProperties.test.ts
+++ b/tracker/tracker/src/main/modules/analytics/tests/sharedProperties.test.ts
@@ -79,7 +79,7 @@ describe('ConstantProperties', () => {
   test('constructs with correct base properties', () => {
     const properties = new ConstantProperties(localStorageMock, sessionStorageMock)
 
-    expect(utils.uaParse).toHaveBeenCalledWith(window)
+    expect(utils.uaParse).toHaveBeenCalledWith(window, expect.any(Function))
     expect(properties.os).toBe('Windows')
     expect(properties.osVersion).toBe('10')
     expect(properties.browser).toBe('Chrome')

--- a/tracker/tracker/src/main/modules/analytics/utils.ts
+++ b/tracker/tracker/src/main/modules/analytics/utils.ts
@@ -19,7 +19,10 @@ interface ClientOS {
 /**
  * Detects client browser, OS, and device information
  */
-export function uaParse(sWindow: Window & typeof globalThis): ClientData {
+export function uaParse(
+  sWindow: Window & typeof globalThis,
+  onOsVersionUpdate?: (osVersion: string) => void,
+): ClientData {
   const unknown = '-'
 
   // Screen detection
@@ -184,7 +187,11 @@ export function uaParse(sWindow: Window & typeof globalThis): ClientData {
             .getHighEntropyValues(['platformVersion'])
             .then((ua) => {
               const version = parseInt(ua.platformVersion.split('.')[0], 10)
-              osVersion = version < 13 ? '10' : '11'
+              // uaParse has already returned by the time this resolves, so a local
+              // assignment would be lost - notify the caller to update its state.
+              const refined = version < 13 ? '10' : '11'
+              osVersion = refined
+              onOsVersionUpdate?.(refined)
             })
             .catch(() => {
               // ignore errors and keep osVersion as is

--- a/tracker/tracker/src/main/modules/conditionsManager.ts
+++ b/tracker/tracker/src/main/modules/conditionsManager.ts
@@ -147,20 +147,25 @@ export default class ConditionsManager {
     }
   }
 
-  durationInt: ReturnType<typeof setInterval> | null = null
+  durationInts: Array<ReturnType<typeof setInterval>> = []
+
+  private clearDurationInt(int: ReturnType<typeof setInterval>) {
+    clearInterval(int)
+    this.durationInts = this.durationInts.filter((i) => i !== int)
+  }
 
   processDuration(durationMs: number, condName: string) {
-    this.durationInt = setInterval(() => {
-      const sessionLength = performance.now()
-      if (sessionLength > durationMs) {
+    // Track each interval independently: with more than one duration condition a
+    // single shared field would leak every interval but the last, and the timer
+    // would keep firing after it triggered.
+    const int = setInterval(() => {
+      if (performance.now() > durationMs) {
+        this.clearDurationInt(int)
         this.trigger(condName)
       }
     }, 1000)
-    this.app.attachStopCallback(() => {
-      if (this.durationInt) {
-        clearInterval(this.durationInt)
-      }
-    })
+    this.durationInts.push(int)
+    this.app.attachStopCallback(() => this.clearDurationInt(int))
   }
 
   networkRequest(message: NetworkRequest) {

--- a/tracker/tracker/src/main/modules/console.ts
+++ b/tracker/tracker/src/main/modules/console.ts
@@ -123,6 +123,10 @@ export default function (app: App, opts: Partial<Options>): void {
   app.attachStartCallback(reset)
   app.ticker.attach(reset, 33, false)
 
+  // Restorers for every method we patch, so we can put the host's console back
+  // when the session stops instead of leaving it proxied for the page's lifetime.
+  const restores: Array<() => void> = []
+
   const patchConsole = (console: Console, ctx: typeof globalThis) => {
     const handler = {
       apply: function (target: Console['log'], thisArg: typeof this, argumentsList: unknown[]) {
@@ -144,6 +148,9 @@ export default function (app: App, opts: Partial<Options>): void {
       const fn = (ctx.console as any)[method]
       // is there any way to preserve the original console trace?
       ;(console as any)[method] = new Proxy(fn, handler)
+      restores.push(() => {
+        ;(console as any)[method] = fn
+      })
     })
   }
 
@@ -151,6 +158,23 @@ export default function (app: App, opts: Partial<Options>): void {
     patchConsole(context.console, context),
   )
 
-  patchContext(window)
+  let patched = false
+  const startPatching = () => {
+    if (patched) {
+      return
+    }
+    patched = true
+    patchContext(window)
+  }
+  // Patch immediately, and re-patch on any later start; restore on stop so the
+  // host console isn't left wrapped for the page's lifetime and capture is
+  // re-established symmetrically across a stop/restart.
+  startPatching()
+  app.attachStartCallback(startPatching)
+  app.attachStopCallback(() => {
+    patched = false
+    restores.forEach((restore) => restore())
+    restores.length = 0
+  })
   app.observer.attachContextCallback(patchContext)
 }

--- a/tracker/tracker/src/main/modules/cssrules.ts
+++ b/tracker/tracker/src/main/modules/cssrules.ts
@@ -54,14 +54,12 @@ export default function (app: App, opts: CssRulesOptions) {
         const sheetID = styleSheetIDMap.get(sheet)
         if (!sheetID) continue
         if (options.checkLimit) {
-          if (!checkIterations[sheetID]) {
-            checkIterations[sheetID] = 0
-          } else {
-            checkIterations[sheetID]++
-          }
+          checkIterations[sheetID] = (checkIterations[sheetID] ?? 0) + 1
           if (checkIterations[sheetID] > options.checkLimit) {
             trackedSheets.delete(sheet)
-            return
+            // continue, not return: skipping one exhausted sheet must not
+            // abandon the remaining tracked sheets in this scan.
+            continue
           }
         }
         for (let j = 0; j < sheet.cssRules.length; j++) {

--- a/tracker/tracker/src/main/modules/img.ts
+++ b/tracker/tracker/src/main/modules/img.ts
@@ -88,7 +88,7 @@ export default function (app: App): void {
           const target = mutation.target as HTMLImageElement
           const id = app.nodes.getID(target)
           if (id === undefined) {
-            return
+            continue
           }
           if (mutation.attributeName === 'src') {
             sendSrc(id, target)

--- a/tracker/tracker/src/main/utils.ts
+++ b/tracker/tracker/src/main/utils.ts
@@ -359,12 +359,17 @@ export function throttleWithTrailing<K, Args extends any[]>(
         timeouts.delete(key);
       }
       lastCalls.set(key, now);
+      // args are consumed now; don't retain them keyed by every id we ever saw
+      lastArgs.delete(key);
       fn(key, ...args);
     } else if (!timeouts.has(key)) {
       const timeoutId = setTimeout(() => {
-        lastCalls.set(key, Date.now());
         timeouts.delete(key);
         const finalArgs = lastArgs.get(key)!;
+        // Trailing call closes the throttle window for this key: drop its
+        // bookkeeping so the maps don't grow one permanent entry per key.
+        lastArgs.delete(key);
+        lastCalls.delete(key);
         fn(key, ...finalArgs);
       }, remaining);
       timeouts.set(key, timeoutId);

--- a/tracker/tracker/src/tests/console.test.ts
+++ b/tracker/tracker/src/tests/console.test.ts
@@ -23,6 +23,7 @@ describe('Console logging module', () => {
       safe: jest.fn((callback) => callback),
       send: jest.fn(),
       attachStartCallback: jest.fn(),
+      attachStopCallback: jest.fn(),
       sanitizer: {
         privateMode: false,
       },


### PR DESCRIPTION
…sing) ->> changelog.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds robust bfcache handling to `@openreplay/tracker` so sessions resume or restart after a back/forward restore. Improves analytics reliability by keeping unsent events and flushing with keepalive when the tab hides.

- **New Features**
  - bfcache: resume or restart based on `bfcacheRestartThreshold` (30m default).
  - Analytics: flush on tab hide with keepalive; keep and requeue events when no token or after send failures.

- **Bug Fixes**
  - Email masking: find emails inside text and mask every domain label.
  - OS detection: correct Windows 11 via UA high‑entropy update.
  - SVG/assets: fix sprite icon cache keying across files/modes; recover after failed fetch; avoid crash on attribute removal.
  - Recording: don’t skip remaining stylesheets after a check limit; don’t skip image mutations after untracked nodes.
  - Perf/leaks: prune throttle bookkeeping; clear per‑condition duration timers; restore original console methods on stop.
  - Preserve protocol version token on first render.

<sup>Written for commit 39911b22b039103e359635ccc2e51681bf5438e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

