### PR TITLE
Message parser optimization

### DIFF
--- a/backend/cmd/assets/main.go
+++ b/backend/cmd/assets/main.go
@@ -69,7 +69,7 @@ func main() {
 		sessCtx := context.WithValue(ctx, "sessionID", info.SessionID())
 
 		reader := messages.NewMessageReader(batchData)
-		if err := reader.Parse(); err != nil {
+		if err := reader.Parse(nil); err != nil {
 			log.Error(sessCtx, "assets batch parse err: %s, info: %s", err, info.Info())
 			return
 		}

--- a/backend/cmd/ender/main.go
+++ b/backend/cmd/ender/main.go
@@ -56,7 +56,7 @@ func main() {
 	projManager := projects.New(log, pgConn, redisClient, dbMetric)
 	sessManager := sessions.New(log, pgConn, projManager, redisClient, dbMetric, sessions.DoNotIgnoreInactiveProjects)
 
-	sessionEndGenerator, err := ender.New(log, redisClient, enderMetric, ender.EVENTS_SESSION_END_TIMEOUT, cfg.PartitionsNumber)
+	sessionEndGenerator, err := ender.New(log, enderMetric, ender.EVENTS_SESSION_END_TIMEOUT, cfg.PartitionsNumber)
 	if err != nil {
 		log.Fatal(ctx, "can't init ender service: %s", err)
 	}

--- a/backend/internal/config/sink/config.go
+++ b/backend/internal/config/sink/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	ProducerCloseTimeout int           `env:"PRODUCER_CLOSE_TIMEOUT,default=15000"`
 	FileSplitTime        time.Duration `env:"FILE_SPLIT_TIME,default=15s"`
 	MaxFileSize          int64         `env:"MAX_FILE_SIZE,default=524288000"`
-	SyncWorkers          int           `env:"SYNC_WORKERS,default=16"`
+	SyncWorkers          int           `env:"SYNC_WORKERS,default=64"`
 	SyncInterval         time.Duration `env:"SYNC_INTERVAL,default=30s"`
 	SessionTTL           time.Duration `env:"SESSION_TTL,default=10m"`
 }

--- a/backend/internal/ender/ender.go
+++ b/backend/internal/ender/ender.go
@@ -1,11 +1,8 @@
 package ender
 
 import (
-	"context"
-	"fmt"
 	"time"
 
-	"openreplay/backend/pkg/db/redis"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/messages"
 	"openreplay/backend/pkg/metrics/ender"
@@ -13,35 +10,17 @@ import (
 
 type EndedSessionHandler func(map[uint64]uint64) map[uint64]bool
 
-const (
-	pageHasPlayer  uint8 = 1 << 0
-	pageHasAssets  uint8 = 1 << 1
-	pageComplete         = pageHasPlayer | pageHasAssets
-	validKeyTTL          = 4 * time.Hour
-	redisOpTimeout       = 500 * time.Millisecond
-)
-
 // session holds information about user's session live status
 type session struct {
 	lastTimestamp int64 // timestamp from message broker
 	lastUpdate    int64 // local timestamp
 	lastUserTime  uint64
 	isEnded       bool
-	isMobile      bool
-	isValid       bool // true once we saw a legacy batch or a page with both Player+Assets OR for mobile
-	redisChecked  bool
-	seenPages     map[uint64]uint8
-}
-
-func (s *session) Validate() {
-	s.isValid = true
-	s.seenPages = nil
 }
 
 // SessionEnder updates timestamp of last message for each session
 type SessionEnder struct {
 	log      logger.Logger
-	redis    *redis.Client
 	metrics  ender.Ender
 	timeout  int64
 	sessions map[uint64]*session // map[sessionID]session
@@ -50,10 +29,9 @@ type SessionEnder struct {
 	enabled  bool
 }
 
-func New(log logger.Logger, redisClient *redis.Client, metrics ender.Ender, timeout int64, parts int) (*SessionEnder, error) {
+func New(log logger.Logger, metrics ender.Ender, timeout int64, parts int) (*SessionEnder, error) {
 	return &SessionEnder{
 		log:      log,
-		redis:    redisClient,
 		metrics:  metrics,
 		timeout:  timeout,
 		sessions: make(map[uint64]*session),
@@ -114,12 +92,10 @@ func (se *SessionEnder) UpdateSession(msg messages.Message) {
 			lastUpdate:    localTimestamp,
 			lastUserTime:  msgTimestamp, // last timestamp from user's machine
 			isEnded:       false,
-			isMobile:      isMobile,
 		}
 		se.sessions[sessionID] = sess
 		se.metrics.IncreaseActiveSessions()
 		se.metrics.IncreaseTotalSessions()
-		se.updateSessionValidity(sess, sessionID, batch)
 		return
 	}
 	// Keep the highest user's timestamp for correct session duration value
@@ -132,80 +108,6 @@ func (se *SessionEnder) UpdateSession(msg messages.Message) {
 		sess.lastUpdate = localTimestamp
 		sess.isEnded = false
 	}
-	se.updateSessionValidity(sess, sessionID, batch)
-}
-
-func (se *SessionEnder) updateSessionValidity(sess *session, sessID uint64, batch *messages.BatchInfo) {
-	if sess.isValid {
-		return
-	}
-	if sess.isMobile {
-		sess.Validate()
-		return
-	}
-	if batch.Type() == messages.FullBatch {
-		sess.Validate()
-		return
-	}
-	if batch.Type() != messages.PlayerBatch && batch.Type() != messages.AssetsBatch {
-		return
-	}
-
-	if !sess.redisChecked {
-		valid, err := se.hasValidKey(sessID)
-		if err == nil {
-			sess.redisChecked = true
-			if valid {
-				sess.Validate()
-				return
-			}
-		}
-	}
-
-	page := batch.PageNo()
-	if sess.seenPages == nil {
-		sess.seenPages = make(map[uint64]uint8)
-	}
-	if batch.Type() == messages.PlayerBatch {
-		sess.seenPages[page] |= pageHasPlayer
-	} else {
-		sess.seenPages[page] |= pageHasAssets
-	}
-	if sess.seenPages[page] == pageComplete {
-		sess.Validate()
-		se.writeValidKey(sessID)
-	}
-}
-
-func (se *SessionEnder) hasValidKey(sessID uint64) (bool, error) {
-	if se.redis == nil || se.redis.Redis == nil {
-		return false, nil
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), redisOpTimeout)
-	defer cancel()
-	res, err := se.redis.Redis.Exists(ctx, validKey(sessID)).Result()
-	if err != nil {
-		sessCtx := context.WithValue(context.Background(), "sessionID", fmt.Sprintf("%d", sessID))
-		se.log.Warn(sessCtx, "redis EXISTS ender:valid failed: %s", err)
-		return false, err
-	}
-	return res > 0, nil
-}
-
-func (se *SessionEnder) writeValidKey(sessID uint64) {
-	if se.redis == nil || se.redis.Redis == nil {
-		return
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), redisOpTimeout)
-	defer cancel()
-	if err := se.redis.Redis.Set(ctx, validKey(sessID), 1, validKeyTTL).Err(); err != nil {
-		sessCtx := context.WithValue(context.Background(), "sessionID", fmt.Sprintf("%d", sessID))
-		se.log.Warn(sessCtx, "redis SET ender:valid failed: %s", err)
-	}
-}
-
-func validKey(sessID uint64) string {
-	return fmt.Sprintf("ender:valid:%d", sessID)
 }
 
 func (se *SessionEnder) HandleEndedSessions(handler EndedSessionHandler) {
@@ -237,13 +139,6 @@ func (se *SessionEnder) HandleEndedSessions(handler EndedSessionHandler) {
 			continue
 		}
 		sess.isEnded = true
-		if !sess.isValid {
-			sessCtx := context.WithValue(context.Background(), "sessionID", fmt.Sprintf("%d", sessID))
-			se.log.Info(sessCtx, "skip sessionEnd: session has no Player+Assets pair, pages seen: %v", sess.seenPages)
-			delete(se.sessions, sessID)
-			se.metrics.DecreaseActiveSessions()
-			continue
-		}
 		endedCandidates[sessID] = sess.lastUserTime
 	}
 

--- a/backend/pkg/messages/iterator.go
+++ b/backend/pkg/messages/iterator.go
@@ -200,7 +200,6 @@ func (i *messageIteratorImpl) preprocessing(msg Message) error {
 		if i.messageInfo.Index > 1 { // Might be several 0-0 BatchMeta in a row without an error though
 			return fmt.Errorf("batchMeta found at the end of the batch, info: %s", i.batchInfo.Info())
 		}
-		i.messageInfo.Index = m.FirstIndex
 		i.messageInfo.Timestamp = m.Timestamp
 		if m.Timestamp == 0 {
 			i.zeroTsLog("MobileBatchMeta")

--- a/backend/pkg/messages/iterator.go
+++ b/backend/pkg/messages/iterator.go
@@ -15,19 +15,20 @@ type MessageIterator interface {
 }
 
 type messageIteratorImpl struct {
-	log         logger.Logger
-	filter      map[int]struct{}
-	preFilter   map[int]struct{}
-	handler     MessageHandler
-	autoDecode  bool
-	version     uint64
-	size        uint64
-	canSkip     bool
-	broken      bool
-	messageInfo *message
-	batchInfo   *BatchInfo
-	urls        *pageLocations
-	brokenStats *brokenBatches
+	log           logger.Logger
+	filter        map[int]struct{} // union(preFilter, handlerFilter)
+	handlerFilter map[int]struct{}
+	preFilter     map[int]struct{}
+	handler       MessageHandler
+	autoDecode    bool
+	version       uint64
+	size          uint64
+	canSkip       bool
+	broken        bool
+	messageInfo   *message
+	batchInfo     *BatchInfo
+	urls          *pageLocations
+	brokenStats   *brokenBatches
 }
 
 func NewMessageIterator(log logger.Logger, messageHandler MessageHandler, messageFilter []int, autoDecode bool) MessageIterator {
@@ -38,16 +39,25 @@ func NewMessageIterator(log logger.Logger, messageHandler MessageHandler, messag
 		urls:        NewPageLocations(),
 		brokenStats: NewBrokenBatches(),
 	}
+	iter.preFilter = map[int]struct{}{
+		MsgBatchMetadata: {}, MsgTimestamp: {}, MsgSessionStart: {},
+		MsgSessionEnd: {}, MsgSetPageLocation: {}, MsgMobileBatchMeta: {},
+	}
 	if len(messageFilter) != 0 {
-		filter := make(map[int]struct{}, len(messageFilter))
+		handlerFilter := make(map[int]struct{}, len(messageFilter))
+		for _, msgType := range messageFilter {
+			handlerFilter[msgType] = struct{}{}
+		}
+		iter.handlerFilter = handlerFilter
+
+		filter := make(map[int]struct{}, len(messageFilter)+len(iter.preFilter))
+		for msgType := range iter.preFilter {
+			filter[msgType] = struct{}{}
+		}
 		for _, msgType := range messageFilter {
 			filter[msgType] = struct{}{}
 		}
 		iter.filter = filter
-	}
-	iter.preFilter = map[int]struct{}{
-		MsgBatchMetadata: {}, MsgTimestamp: {}, MsgSessionStart: {},
-		MsgSessionEnd: {}, MsgSetPageLocation: {}, MsgMobileBatchMeta: {},
 	}
 	return iter
 }
@@ -65,7 +75,7 @@ func (i *messageIteratorImpl) Iterate(batchData []byte, batchInfo *BatchInfo) {
 	ctx := context.WithValue(context.Background(), "sessionID", batchInfo.sessionID)
 
 	reader := NewMessageReader(batchData)
-	if err := reader.Parse(); err != nil {
+	if err := reader.Parse(i.filter); err != nil {
 		i.brokenStats.Inc(batchInfo.sessionID, err.Error())
 		return
 	}
@@ -74,9 +84,6 @@ func (i *messageIteratorImpl) Iterate(batchData []byte, batchInfo *BatchInfo) {
 	i.prepareVars(batchInfo)
 
 	for reader.Next() {
-		// Increase message index (can be overwritten by batch info message)
-		i.messageInfo.Index++
-
 		msg := reader.Message()
 		msgType := msg.TypeID()
 
@@ -95,9 +102,8 @@ func (i *messageIteratorImpl) Iterate(batchData []byte, batchInfo *BatchInfo) {
 			}
 		}
 
-		// Skip messages we don't have in filter
-		if i.filter != nil {
-			if _, ok := i.filter[msg.TypeID()]; !ok {
+		if i.handlerFilter != nil {
+			if _, ok := i.handlerFilter[msg.TypeID()]; !ok {
 				continue
 			}
 		}
@@ -113,6 +119,7 @@ func (i *messageIteratorImpl) Iterate(batchData []byte, batchInfo *BatchInfo) {
 		}
 
 		// Set meta information for message
+		i.messageInfo.Index = msg.Meta().Index
 		msg.Meta().SetMeta(i.messageInfo)
 
 		// Update timestamp value for iOS message types
@@ -144,7 +151,6 @@ func (i *messageIteratorImpl) preprocessing(msg Message) error {
 		if m.Version > 5 {
 			return fmt.Errorf("incorrect batch version: %d, skip current batch, info: %s", i.version, i.batchInfo.Info())
 		}
-		i.messageInfo.Index = m.PageNo<<32 + m.FirstIndex // 2^32  is the maximum count of messages per page (ha-ha)
 		i.messageInfo.Timestamp = uint64(m.Timestamp)
 		if m.Timestamp == 0 {
 			i.zeroTsLog("BatchMetadata")

--- a/backend/pkg/messages/reader.go
+++ b/backend/pkg/messages/reader.go
@@ -91,7 +91,7 @@ func (m *messageReaderImpl) Parse(filter map[int]struct{}) (err error) {
 				return fmt.Errorf("read message err: %s", err)
 			}
 			if m.msgType == MsgBatchMetadata {
-				if len(m.messages) > 0 {
+				if m.index > 1 {
 					return fmt.Errorf("batch meta not at the start of batch")
 				}
 				switch message := msg.(type) {

--- a/backend/pkg/messages/reader.go
+++ b/backend/pkg/messages/reader.go
@@ -105,6 +105,11 @@ func (m *messageReaderImpl) Parse(filter map[int]struct{}) (err error) {
 					m.reader.SetPointer(0)
 					return nil
 				}
+			} else if m.msgType == MsgMobileBatchMeta {
+				switch message := msg.(type) {
+				case *MobileBatchMeta:
+					m.index = message.FirstIndex
+				}
 			}
 
 			if filter != nil {

--- a/backend/pkg/messages/reader.go
+++ b/backend/pkg/messages/reader.go
@@ -6,7 +6,7 @@ import (
 )
 
 type MessageReader interface {
-	Parse() (err error)
+	Parse(filter map[int]struct{}) (err error)
 	Next() bool
 	Message() Message
 }
@@ -15,33 +15,28 @@ func NewMessageReader(data []byte) MessageReader {
 	return &messageReaderImpl{
 		data:   data,
 		reader: NewBytesReader(data),
-		list:   make([]*MessageMeta, 0, 1024),
 	}
 }
 
-type MessageMeta struct {
-	msgType uint64
-	msgSize uint64
-	msgFrom uint64
-}
-
 type messageReaderImpl struct {
-	data    []byte
-	reader  BytesReader
-	msgType uint64
-	msgSize uint64
-	msgBody []byte
-	version int
-	broken  bool
-	message Message
-	err     error
-	list    []*MessageMeta
-	listPtr int
+	data     []byte
+	reader   BytesReader
+	msgType  uint64
+	msgSize  uint64
+	msgBody  []byte
+	version  int
+	broken   bool
+	message  Message
+	err      error
+	messages []*RawMessage
+	listPtr  int
+	index    uint64
 }
 
-func (m *messageReaderImpl) Parse() (err error) {
+func (m *messageReaderImpl) Parse(filter map[int]struct{}) (err error) {
 	m.listPtr = 0
-	m.list = m.list[:0]
+	m.index = 0
+	m.messages = make([]*RawMessage, 0, 1024)
 	m.broken = false
 	for {
 		// Try to read and decode message type, message size and check range in
@@ -53,6 +48,7 @@ func (m *messageReaderImpl) Parse() (err error) {
 			// Reached the end of batch
 			return nil
 		}
+		m.index++
 
 		// Read message body (and decode if protocol version less than 1)
 		if m.version > 0 && MessageHasSize(m.msgType) {
@@ -67,21 +63,27 @@ func (m *messageReaderImpl) Parse() (err error) {
 			if len(m.data)-int(curr) < int(m.msgSize) {
 				return fmt.Errorf("can't read message body")
 			}
+			m.reader.SetPointer(curr + int64(m.msgSize))
+
+			if filter != nil {
+				if _, ok := filter[int(m.msgType)]; !ok {
+					continue
+				}
+			}
 
 			// Dirty hack to avoid extra memory allocation
 			mTypeByteSize := ByteSizeUint(m.msgType)
 			from := int(curr) - mTypeByteSize
 			WriteUint(m.msgType, m.data, from)
 
-			// Add message meta to list
-			m.list = append(m.list, &MessageMeta{
-				msgType: m.msgType,
-				msgSize: m.msgSize + 1,
-				msgFrom: uint64(from),
+			m.messages = append(m.messages, &RawMessage{
+				tp:     m.msgType,
+				data:   m.data[uint64(from) : uint64(from)+m.msgSize+1],
+				broken: &m.broken,
+				meta: &message{
+					Index: m.index,
+				},
 			})
-
-			// Update data pointer
-			m.reader.SetPointer(curr + int64(m.msgSize))
 		} else {
 			from := m.reader.Pointer() - 1
 			msg, err := ReadMessage(m.msgType, m.reader)
@@ -89,26 +91,35 @@ func (m *messageReaderImpl) Parse() (err error) {
 				return fmt.Errorf("read message err: %s", err)
 			}
 			if m.msgType == MsgBatchMetadata {
-				if len(m.list) > 0 {
+				if len(m.messages) > 0 {
 					return fmt.Errorf("batch meta not at the start of batch")
 				}
 				switch message := msg.(type) {
 				case *BatchMetadata:
 					m.version = int(message.Version)
+					m.index = message.PageNo<<32 + message.FirstIndex
 				}
 				if m.version < 1 || m.version > 5 {
 					// Unsupported tracker version, reset reader
-					m.list = m.list[:0]
+					m.messages = m.messages[:0]
 					m.reader.SetPointer(0)
 					return nil
 				}
 			}
 
-			// Add message meta to list
-			m.list = append(m.list, &MessageMeta{
-				msgType: m.msgType,
-				msgSize: uint64(m.reader.Pointer() - from),
-				msgFrom: uint64(from),
+			if filter != nil {
+				if _, ok := filter[int(m.msgType)]; !ok {
+					continue
+				}
+			}
+
+			m.messages = append(m.messages, &RawMessage{
+				tp:     m.msgType,
+				data:   m.data[uint64(from):uint64(m.reader.Pointer())],
+				broken: &m.broken,
+				meta: &message{
+					Index: m.index,
+				},
 			})
 		}
 	}
@@ -120,19 +131,13 @@ func (m *messageReaderImpl) Next() bool {
 	}
 
 	// For new version of tracker
-	if len(m.list) > 0 {
-		if m.listPtr >= len(m.list) {
+	if len(m.messages) > 0 {
+		if m.listPtr >= len(m.messages) {
 			return false
 		}
 
-		meta := m.list[m.listPtr]
+		m.message = m.messages[m.listPtr]
 		m.listPtr++
-		m.message = &RawMessage{
-			tp:     meta.msgType,
-			data:   m.data[meta.msgFrom : meta.msgFrom+meta.msgSize],
-			broken: &m.broken,
-			meta:   &message{},
-		}
 		return true
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Optimized the `messages` parser to reduce allocations and speed up batch processing, fixed incorrect message indices (web and mobile), and added a strict `BatchMetadata` position check. Simplified session end handling by removing the minimal playable session check and increased sink throughput by raising default sync workers.

- **Performance**
  - Added parse-time filtering via `MessageReader.Parse(filter)` to skip unwanted messages early and reduce allocations.
  - Centralized index calculation in the reader using batch metadata (web and mobile) for correct indices without per-message overhead.
  - Validated that `BatchMetadata` appears only at the start of a batch to avoid corrupt/invalid batches.
  - Removed the minimal playable session check in `ender` (no Redis calls); sessions end based on timeout only.
  - Increased sink `SYNC_WORKERS` default from 16 to 64.

- **Migration**
  - `MessageReader.Parse` now requires a filter argument; pass `nil` to parse all messages.
  - `ender.New` no longer accepts a Redis client; remove that parameter when constructing the service.

<sup>Written for commit 095b18ce886dfc8bc0521bf039c1c35343e844c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

