### PR TITLE
ui: kai cleanup

### DIFF
--- a/frontend/app/layout/data.ts
+++ b/frontend/app/layout/data.ts
@@ -54,7 +54,6 @@ export const enum MENU {
   SUPPORT = 'support',
   EXIT = 'exit',
   SPOTS = 'spots',
-  KAI = 'kai',
   ACTIVITY = 'activity',
   USER = 'user-page',
   USERS = 'data-users',
@@ -106,18 +105,6 @@ export const categories: (t: TFunction) => Category[] = (t) => [
     key: 'assist',
     items: [
       { label: t('Co-Browse'), key: MENU.LIVE_SESSIONS, icon: 'broadcast' },
-    ],
-  },
-  {
-    title: '',
-    key: 'kai',
-    hidden: menuHidden.kai,
-    items: [
-      {
-        label: t('Kai'),
-        key: MENU.KAI,
-        icon: 'kai-mono',
-      },
     ],
   },
   {

--- a/frontend/app/utils/split-utils.ts
+++ b/frontend/app/utils/split-utils.ts
@@ -11,7 +11,6 @@ export const menuHidden = {
   clips: true,
   vault: true,
   bookmarks: false,
-  kai: true,
   billing: true,
   videoExport: false,
   dataAnalytics: false,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the Kai menu item from the sidebar and deleted the unused menuHidden.kai flag to simplify navigation and remove dead code.

<sup>Written for commit e3d803b9e94f1bce55de364c344e834f51752fd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

