### PR TITLE
Updated patch build from main be43a085b51fb6eb3221a9fb5fc45bc9f0db4f43

### DIFF
--- a/scripts/helmcharts/openreplay/charts/db/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/db/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.1"
+AppVersion: "v1.27.2"

--- a/scripts/helmcharts/openreplay/charts/ender/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/ender/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.2"
+AppVersion: "v1.27.3"

--- a/scripts/helmcharts/openreplay/charts/sink/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/sink/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 name: sink
 description: A Helm chart for Kubernetes
-
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -11,14 +10,12 @@ description: A Helm chart for Kubernetes
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.1
-
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.0"
+AppVersion: "v1.27.1"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Helm chart AppVersion fields to the latest patch: `db` v1.27.2, `ender` v1.27.3, `sink` v1.27.1. Aligns charts with the patch build so deployments pull the new images; also removes extra whitespace in `sink/Chart.yaml`.

<sup>Written for commit d4d95360d45f266c1cbc26a3c8c1128fc0db9f65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

