### PR TITLE
fix(canvases): restore /ingest rewrite + CORS on the canvases ingress (regressed in 82d306fd3)

### DIFF
--- a/scripts/helmcharts/openreplay/charts/canvases/templates/ingress.yaml
+++ b/scripts/helmcharts/openreplay/charts/canvases/templates/ingress.yaml
@@ -8,10 +8,34 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "canvases.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    nginx.org/location-snippets: |
+      {{- if .Values.ingress.cors }}
+      # CORS configuration
+      add_header 'Access-Control-Allow-Origin' '{{ tpl .Values.ingress.cors.allowOrigin . }}' always;
+      add_header 'Access-Control-Allow-Methods' '{{ tpl .Values.ingress.cors.allowMethods . }}' always;
+      add_header 'Access-Control-Allow-Headers' '{{ tpl .Values.ingress.cors.allowHeaders . }}' always;
+      add_header 'Access-Control-Expose-Headers' '{{ tpl .Values.ingress.cors.exposeHeaders . }}' always;
+
+      # Handle preflight
+      if ($request_method = 'OPTIONS') {
+        add_header 'Access-Control-Allow-Origin' '{{ tpl .Values.ingress.cors.allowOrigin . }}' always;
+        add_header 'Access-Control-Allow-Methods' '{{ tpl .Values.ingress.cors.allowMethods . }}' always;
+        add_header 'Access-Control-Allow-Headers' '{{ tpl .Values.ingress.cors.allowHeaders . }}' always;
+        add_header 'Access-Control-Max-Age' '{{ tpl .Values.ingress.cors.maxAge . }}';
+        add_header 'Content-Type' 'text/plain charset=UTF-8';
+        add_header 'Content-Length' 0;
+        return 204;
+      }
+      {{- end }}
+
+      # Strip /ingest prefix so the canvases service receives /v1/web/images
+      rewrite ^/ingest/(.*)$ /$1 break;
+    {{- with .Values.ingress.annotations }}
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ tpl $value $ | quote }}
+    {{- end }}
+    {{- end }}
 spec:
   ingressClassName: {{ tpl .Values.ingress.className . }}
   rules:

--- a/scripts/helmcharts/openreplay/charts/canvases/values.yaml
+++ b/scripts/helmcharts/openreplay/charts/canvases/values.yaml
@@ -72,7 +72,7 @@ ingress:
   cors:
     allowOrigin: "*"
     allowMethods: "POST, OPTIONS"
-    allowHeaders: "Content-Type, Authorization, Content-Encoding, X-Openreplay-Batch"
+    allowHeaders: "Content-Type, Authorization, Content-Encoding, X-Openreplay-Batch, datatype"
     exposeHeaders: "Content-Length"
     maxAge: "1728000"
     allowCredentials: "false"


### PR DESCRIPTION
### What
Restores the URL rewrite + CORS location-snippet on the `canvases` ingress that makes
`POST /ingest/v1/web/images` (web canvas upload) routable. Mirrors the `http` chart's
ingress template and adds `datatype` to `cors.allowHeaders` (the tracker sends it).

### Why
The fix for this was merged in 958aaa815 (2026-03-05, following #4427 which moved the
web images endpoint to the canvases service), but the chart refactor 82d306fd3
(2026-04-14, "use tpl for ingressClassName across all charts") replaced the template
and dropped the `nginx.org/location-snippets` block. Since then, on a fresh install:

- the ingress forwards the **unstripped** `/ingest/v1/web/images` to the canvases
  service, which only serves `/v1/web/images` → **404**
- no CORS headers are rendered, so browsers surface it as a CORS error
- `charts/canvases/values.yaml` still ships the `ingress.cors` block, but the
  template never references it (orphaned config)

Net effect: canvas recording is broken for web sessions on current `main` / v1.27.x
self-hosted installs. Related issue: #4706.

### How
`charts/canvases/templates/ingress.yaml` now renders the same annotation pattern as
`charts/http/templates/ingress.yaml`: the CORS headers from `.Values.ingress.cors`
(incl. the OPTIONS → 204 preflight branch) plus `rewrite ^/ingest/(.*)$ /$1 break;`,
while keeping the tpl-based `ingressClassName` and values-driven annotations from
82d306fd3.

### Testing
- `helm template` renders the rewrite + CORS snippet with default values
- On a v1.27 install: `OPTIONS /ingest/v1/web/images` → 204 with CORS headers;
  `POST` without token → 401 (handler reached); canvas frames accepted end-to-end
  with a live tracker (`canvasEnabled: true`)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the rewrite and CORS config on the `canvases` ingress so web uploads to `/ingest/v1/web/images` work again without 404/CORS errors. Mirrors the `http` chart behavior and adds `datatype` to allowed CORS headers.

- **Bug Fixes**
  - Add `nginx.org/location-snippets` with CORS headers from `.Values.ingress.cors`, including an OPTIONS → 204 preflight.
  - Strip the `/ingest` prefix before forwarding (`rewrite ^/ingest/(.*)$ /$1 break;`) so the service receives `/v1/web/images`.
  - Render user-provided ingress annotations via `tpl` and keep the templated `ingressClassName`.

<sup>Written for commit 6c0e6c00a761b945db08c22d45c4bbf1c565c283. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

