### PR TITLE
ui: add fake select ui on native focus events

### DIFF
--- a/player/src/web/MessageManager.ts
+++ b/player/src/web/MessageManager.ts
@@ -120,6 +120,7 @@ export default class MessageManager {
   };
 
   private clickManager: ListWalker<MouseClick> = new ListWalker();
+  private lastSelectClickTime = -1;
   private mouseThrashingManager: ListWalker<MouseThrashing> = new ListWalker();
   private activityManager: ActivityManager | null = null;
   private mouseMoveManager: MouseMoveManager;
@@ -289,6 +290,8 @@ export default class MessageManager {
 
   resetMessageManagers() {
     this.clickManager = new ListWalker();
+    this.lastSelectClickTime = -1;
+    this.screen.selectMenu.hide();
     this.mouseMoveManager = new MouseMoveManager(this.screen);
     this.activityManager = new ActivityManager(this.session.durationMs);
     this.activeTabManager = new ActiveTabManager();
@@ -328,6 +331,12 @@ export default class MessageManager {
       // getting clicks happened during last 600ms
       if (!!lastClick && t - lastClick.time < 600) {
         this.screen.cursor.click();
+        // Fire once per click: a native <select> picker can't be reopened during
+        // replay (needs a user gesture), so approximate it with a synthetic list.
+        if (lastClick.time !== this.lastSelectClickTime) {
+          this.lastSelectClickTime = lastClick.time;
+          this.screen.showSelectMenu(this.getNode(lastClick.id)?.node);
+        }
       }
       const lastThrashing = this.mouseThrashingManager.moveGetLast(t);
       if (!!lastThrashing && t - lastThrashing.time < 300) {

--- a/player/src/web/Screen/Screen.ts
+++ b/player/src/web/Screen/Screen.ts
@@ -1,5 +1,6 @@
 import styles from './screen.module.css';
 import Cursor from './Cursor';
+import SelectDropdown from './SelectDropdown';
 
 import type { Point, Dimensions } from './types';
 
@@ -62,6 +63,7 @@ function isIframe(el: Element): el is HTMLIFrameElement {
 export default class Screen {
   readonly overlay: HTMLDivElement;
   readonly cursor: Cursor;
+  readonly selectMenu: SelectDropdown;
   private selectionTargets: Element[];
   private readonly iframe: HTMLIFrameElement;
   private readonly screen: HTMLDivElement;
@@ -92,6 +94,37 @@ export default class Screen {
     this.screen = screen;
 
     this.cursor = new Cursor(this.overlay, isMobile); // TODO: move outside
+    this.selectMenu = new SelectDropdown(this.overlay);
+  }
+
+  private remoteControlActive = false;
+
+  /**
+   * During remote control the agent drives the real <select> (native picker via
+   * showPicker on their own gesture), so the synthetic replay picker must stay
+   * out of the way. Toggled by the assist RemoteControl.
+   */
+  setRemoteControlActive(active: boolean): void {
+    this.remoteControlActive = active;
+    if (active) {
+      this.selectMenu.hide();
+    }
+  }
+
+  /**
+   * Reflect a recorded click on a native <select>: show a synthetic option list
+   * approximating the open picker (the real one can't be reopened during replay
+   * — it needs a user gesture). Any other click target dismisses it.
+   */
+  showSelectMenu(node: Node | null | undefined): void {
+    if (this.remoteControlActive) {
+      return;
+    }
+    if (node instanceof HTMLSelectElement) {
+      this.selectMenu.open(node);
+    } else {
+      this.selectMenu.hide();
+    }
   }
 
   addMobileStyles(stableTop?: boolean) {
@@ -113,6 +146,7 @@ export default class Screen {
   }
 
   clean() {
+    this.selectMenu.remove(); // clears its pending timer + scroll listener
     this.iframe?.remove?.();
     this.overlay?.remove?.();
     this.screen?.remove?.();

--- a/player/src/web/Screen/SelectDropdown.ts
+++ b/player/src/web/Screen/SelectDropdown.ts
@@ -1,0 +1,164 @@
+/**
+ * Native <select> pickers are browser chrome: opening them requires transient
+ * activation (a real user gesture), which replay playback never has. So we can't
+ * reopen the real dropdown a user saw. Instead, when a recorded click lands on a
+ * <select>, we draw a synthetic option list in the overlay layer that approximates
+ * the open picker, highlight the recorded value, and dismiss it on the next
+ * interaction event (click / focus / input) that isn't the select itself.
+ */
+export default class SelectDropdown {
+  private readonly container: HTMLDivElement;
+  private currentSelect: HTMLSelectElement | null = null;
+  private confirmTimeout?: ReturnType<typeof setTimeout>;
+  // Document we attached the scroll listener to, so we can detach it on hide.
+  private scrollDoc: Document | null = null;
+  private readonly onScroll = () => this.hide();
+  // Brief hold after the recorded value lands, so the picked option is visible
+  // before the picker closes. This is a pick confirmation, not an idle timeout.
+  private static readonly CONFIRM_MS = 450;
+
+  constructor(private readonly overlay: HTMLDivElement) {
+    this.container = document.createElement('div');
+    Object.assign(this.container.style, {
+      position: 'absolute',
+      display: 'none',
+      zIndex: '9',
+      boxSizing: 'border-box',
+      maxHeight: '240px',
+      overflowY: 'auto',
+      background: '#fff',
+      border: '1px solid rgba(0,0,0,0.2)',
+      borderRadius: '4px',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.18)',
+      padding: '4px 0',
+      font: '13px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+      color: '#111',
+      pointerEvents: 'none',
+    });
+    overlay.appendChild(this.container);
+  }
+
+  /**
+   * Show the synthetic dropdown positioned under `select`, listing its options
+   * with the currently-selected one highlighted.
+   */
+  open(select: HTMLSelectElement): void {
+    if (select.options.length === 0) {
+      this.hide();
+      return;
+    }
+    let rect: DOMRect;
+    try {
+      rect = select.getBoundingClientRect();
+    } catch {
+      return;
+    }
+    // Element not rendered / not visible — nothing to anchor to.
+    if (rect.width === 0 && rect.height === 0) {
+      return;
+    }
+    this.clearConfirmTimeout();
+    this.detachScroll();
+    this.currentSelect = select;
+    this.render(select);
+    // The overlay shares the iframe's coordinate origin and scales with it, so
+    // iframe-viewport coords from getBoundingClientRect map straight to overlay
+    // coords. Anchor under the select.
+    Object.assign(this.container.style, {
+      display: 'block',
+      left: `${rect.left}px`,
+      top: `${rect.bottom}px`,
+      minWidth: `${rect.width}px`,
+    });
+    // The dropdown is anchored at a fixed point; once the page scrolls the select
+    // moves out from under it, so dismiss (like a real native picker). Capture
+    // phase catches non-bubbling scrolls on inner containers too.
+    this.scrollDoc = select.ownerDocument;
+    this.scrollDoc?.addEventListener('scroll', this.onScroll, {
+      capture: true,
+      passive: true,
+    });
+  }
+
+  /**
+   * A recorded input/value change was applied. If it's the open select, move the
+   * highlight to the chosen option then close (pick confirmation). Any other
+   * element changing means the user moved on — close immediately.
+   */
+  onValueApplied(node: Node): void {
+    if (!this.currentSelect) {
+      return;
+    }
+    if (node === this.currentSelect) {
+      this.render(this.currentSelect);
+      this.clearConfirmTimeout();
+      this.confirmTimeout = setTimeout(() => this.hide(), SelectDropdown.CONFIRM_MS);
+    } else {
+      this.hide();
+    }
+  }
+
+  /**
+   * A recorded focus change was applied. Focus landing on the open select itself
+   * (e.g. the very click that opened it) is ignored; focus moving anywhere else
+   * — or a blur (node null) — closes the picker.
+   */
+  onFocus(node: Node | null): void {
+    if (!this.currentSelect || node === this.currentSelect) {
+      return;
+    }
+    this.hide();
+  }
+
+  hide(): void {
+    this.clearConfirmTimeout();
+    this.detachScroll();
+    this.container.style.display = 'none';
+    this.container.replaceChildren();
+    this.currentSelect = null;
+  }
+
+  remove(): void {
+    this.hide();
+    this.container.remove();
+  }
+
+  private detachScroll(): void {
+    if (this.scrollDoc) {
+      this.scrollDoc.removeEventListener('scroll', this.onScroll, {
+        capture: true,
+      });
+      this.scrollDoc = null;
+    }
+  }
+
+  private render(select: HTMLSelectElement): void {
+    const frag = document.createDocumentFragment();
+    const options = Array.from(select.options);
+    for (const opt of options) {
+      const item = document.createElement('div');
+      Object.assign(item.style, {
+        padding: '4px 12px',
+        whiteSpace: 'nowrap',
+      });
+      item.textContent = opt.label || opt.text || opt.value || ' ';
+      if (opt.disabled) {
+        item.style.color = '#9aa0a6';
+      }
+      if (opt.selected) {
+        item.style.background = '#e8f0fe';
+        item.style.fontWeight = '600';
+      }
+      frag.appendChild(item);
+    }
+    this.container.replaceChildren(frag);
+    this.container.scrollTop = 0;
+  }
+
+  private clearConfirmTimeout(): void {
+    if (this.confirmTimeout) {
+      clearTimeout(this.confirmTimeout);
+      this.confirmTimeout = undefined;
+    }
+  }
+}

--- a/player/src/web/assist/RemoteControl.ts
+++ b/player/src/web/assist/RemoteControl.ts
@@ -221,6 +221,9 @@ export default class RemoteControl {
   };
 
   private toggleRemoteControl(enable: boolean) {
+    // Suppress the synthetic <select> replay picker while the agent controls the
+    // real element (they get the native picker via their own gesture).
+    this.screen.setRemoteControlActive(enable);
     if (enable) {
       this.screen.overlay.addEventListener('mousemove', this.onMouseMove);
       this.screen.overlay.addEventListener('click', this.onMouseClick);

--- a/player/src/web/managers/DOM/DOMManager.ts
+++ b/player/src/web/managers/DOM/DOMManager.ts
@@ -481,6 +481,8 @@ export default class DOMManager extends ListWalker<Message> {
           this.pendingSelectValues.set(msg.id, val);
         } else {
           nodeWithValue.value = val; // Maybe make special VInputValueElement type for lazy value update
+          // Input on another element dismisses the synthetic <select> picker.
+          this.screen.selectMenu.onValueApplied(nodeWithValue);
         }
         return;
       }
@@ -491,6 +493,8 @@ export default class DOMManager extends ListWalker<Message> {
           return;
         }
         (vElem.node as HTMLInputElement).checked = msg.checked; // Maybe make special VCheckableElement type for lazy checking
+        // Input on another element dismisses the synthetic <select> picker.
+        this.screen.selectMenu.onValueApplied(vElem.node);
         return;
       }
       case MType.SetNodeData:
@@ -747,6 +751,9 @@ export default class DOMManager extends ListWalker<Message> {
       node.value = val;
       if (node.value === val || node.options.length > 0) {
         this.pendingSelectValues.delete(id);
+        // If the synthetic picker for this select is open, move its highlight to
+        // the applied value and dismiss it shortly after.
+        this.screen.selectMenu.onValueApplied(node);
       }
     });
   };
@@ -772,7 +779,12 @@ export default class DOMManager extends ListWalker<Message> {
     return this.stylesManager.moveReady().then(() => {
       /* Waiting for styles to be applied first */
       /* Applying focus */
-      this.focusManager.move(t);
+      const focusChange = this.focusManager.move(t);
+      // A focus landing anywhere but the open <select> (or a blur) dismisses the
+      // synthetic picker; focus on the select itself (its opening click) is kept.
+      if (focusChange !== undefined) {
+        this.screen.selectMenu.onFocus(focusChange);
+      }
       /* Applying text selections */
       this.selectionManager.move(t);
       /* Applying all scrolls */

--- a/player/src/web/managers/DOM/FocusManager.ts
+++ b/player/src/web/managers/DOM/FocusManager.ts
@@ -11,10 +11,14 @@ export default class FocusManager extends ListWalker<SetNodeFocus> {
 
   private focused: Element | null = null;
 
-  move(t: number) {
+  /**
+   * @returns `undefined` when no new focus message was crossed, otherwise the
+   * newly focused node (or `null` on blur). Lets callers react to focus changes.
+   */
+  move(t: number): Element | null | undefined {
     const msg = this.moveGetLast(t);
     if (!msg) {
-      return;
+      return undefined;
     }
     this.focused?.classList.remove(FOCUS_CLASSNAME);
     const oldParent = this.focused?.parentElement;
@@ -26,12 +30,12 @@ export default class FocusManager extends ListWalker<SetNodeFocus> {
     }
     if (msg.id === -1) {
       this.focused = null;
-      return;
+      return null;
     }
     const vn = this.vElements.get(msg.id);
     if (!vn) {
       logger.error('Node not found', msg);
-      return;
+      return undefined;
     }
     this.focused = vn.node;
     this.focused.classList.add(FOCUS_CLASSNAME);
@@ -39,5 +43,6 @@ export default class FocusManager extends ListWalker<SetNodeFocus> {
     if (currParent) {
       currParent.classList.add(`${FOCUS_CLASSNAME}-within`);
     }
+    return this.focused;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show a synthetic dropdown for native <select> elements during replay so viewers can see options and the chosen value. It opens on the recorded click and closes on focus change, input elsewhere, or scroll.

- New Features
  - Added an overlay-based `SelectDropdown` that anchors under the clicked `<select>` and highlights the selected option.
  - Opens once per recorded click; dismisses on focus away, value/input on another element, or page scroll, with a brief post-select confirmation delay.
  - Disabled during remote control so the agent uses the real native picker.
  - Resets and cleans up timers/listeners on player reset and screen cleanup.

<sup>Written for commit 19a245b7ebd5a9ad16e64ebd5a23daa7c2c4f57c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

