### PR TITLE
mcp: add workflow file

### DIFF
--- a/.github/workflows/build-mcpb.yaml
+++ b/.github/workflows/build-mcpb.yaml
@@ -1,0 +1,75 @@
+name: Build MCPB Bundle
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'mcp_app/**'
+      - 'player/**'
+      - '.github/workflows/build-mcpb.yaml'
+  pull_request:
+    paths:
+      - 'mcp_app/**'
+      - 'player/**'
+      - '.github/workflows/build-mcpb.yaml'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: build-mcpb-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-mcpb:
+    name: Build MCPB
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: mcp_app
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Update version from release tag
+        if: github.event_name == 'release'
+        run: |
+          version_number=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
+          echo "Updating manifest version to ${version_number}"
+          sed -i.bak "s/\"version\": \".*\"/\"version\": \"${version_number}\"/" manifest.json
+          rm -f manifest.json.bak
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: yarn
+          cache-dependency-path: mcp_app/yarn.lock
+
+      - name: Install player dependencies
+        working-directory: player
+        run: yarn install --frozen-lockfile
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build UI, server and pack MCPB
+        run: sh pack.sh
+
+      - name: Upload MCPB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openreplay-mcp
+          path: mcp_app/openreplay.mcpb
+          retention-days: 90
+
+      - name: Upload to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" openreplay.mcpb --clobber

--- a/mcp_app/pack.sh
+++ b/mcp_app/pack.sh
@@ -1,2 +1,3 @@
+yarn build
 npx @anthropic-ai/mcpb pack
 mv mcp_app.mcpb openreplay.mcpb


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a GitHub Actions workflow to build and publish the MCP bundle and updates the pack script to run the UI build before packaging. Artifacts are uploaded on push/PR and attached to Releases.

- **New Features**
  - Builds MCPB on push/PR, Releases, and manual runs; cancels in-progress runs per ref.
  - Updates manifest.json version from the release tag.
  - Uses Node 22 with Yarn cache; installs `player` and `mcp_app` deps.
  - Updates `pack.sh` to run `yarn build` before `@anthropic-ai/mcpb` pack.
  - Uploads `openreplay.mcpb` as an artifact and attaches it to Releases.

<sup>Written for commit f6c1a2530c60e5d69c95dd452baa1360599056a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

