### PR TITLE
More improvements

### DIFF
--- a/backend/pkg/handlers/custom/pageEventBuilder.go
+++ b/backend/pkg/handlers/custom/pageEventBuilder.go
@@ -31,7 +31,10 @@ func (b *pageEventBuilder) MessageTypes() []int {
 func (b *pageEventBuilder) Handle(message Message, timestamp uint64) Message {
 	switch message.TypeID() {
 	case MsgSetPageLocation:
-		msg := message.Decode().(*SetPageLocation)
+		msg, ok := message.Decode().(*SetPageLocation)
+		if !ok {
+			return nil
+		}
 		if msg.NavigationStart == 0 { // routing without new page loading
 			return &PageEvent{
 				URL:       msg.URL,
@@ -55,7 +58,10 @@ func (b *pageEventBuilder) Handle(message Message, timestamp uint64) Message {
 		if b.pageEvent == nil {
 			break
 		}
-		msg := message.Decode().(*PageLoadTiming)
+		msg, ok := message.Decode().(*PageLoadTiming)
+		if !ok {
+			return nil
+		}
 		if msg.RequestStart <= 30000 {
 			b.pageEvent.RequestStart = msg.RequestStart
 		}
@@ -88,13 +94,19 @@ func (b *pageEventBuilder) Handle(message Message, timestamp uint64) Message {
 		if b.pageEvent == nil {
 			break
 		}
-		msg := message.Decode().(*PageRenderTiming)
+		msg, ok := message.Decode().(*PageRenderTiming)
+		if !ok {
+			return nil
+		}
 		b.pageEvent.SpeedIndex = msg.SpeedIndex
 		b.pageEvent.VisuallyComplete = msg.VisuallyComplete
 		b.pageEvent.TimeToInteractive = msg.TimeToInteractive
 		return nil
 	case MsgWebVitals:
-		msg := message.Decode().(*WebVitals)
+		msg, ok := message.Decode().(*WebVitals)
+		if !ok {
+			return nil
+		}
 		if b.webVitals == nil {
 			b.webVitals = make(map[string]string)
 		}

--- a/backend/pkg/handlers/mobile/tapRage.go
+++ b/backend/pkg/handlers/mobile/tapRage.go
@@ -54,7 +54,10 @@ func (h *TapRageDetector) Handle(message Message, timestamp uint64) Message {
 	var event Message = nil
 	switch message.TypeID() {
 	case MsgMobileClickEvent:
-		m := message.Decode().(*MobileClickEvent)
+		m, ok := message.Decode().(*MobileClickEvent)
+		if !ok {
+			return nil
+		}
 		if h.lastTimestamp+TapTimeDiff < m.Timestamp && h.lastLabel == m.Label {
 			h.lastTimestamp = m.Timestamp
 			h.countsInARow += 1

--- a/backend/pkg/handlers/web/appCrash.go
+++ b/backend/pkg/handlers/web/appCrash.go
@@ -66,17 +66,26 @@ func (h *AppCrashDetector) build() messages.Message {
 func (h *AppCrashDetector) Handle(message messages.Message, timestamp uint64) messages.Message {
 	switch message.TypeID() {
 	case messages.MsgUnbindNodes:
-		msg := message.Decode().(*messages.UnbindNodes)
+		msg, ok := message.Decode().(*messages.UnbindNodes)
+		if !ok {
+			return nil
+		}
 		if msg.TotalRemovedPercent < CrashThreshold {
 			return nil
 		}
 		h.dropTimestamp = timestamp
 		h.dropMessageID = msg.MsgID()
 	case messages.MsgJSException:
-		msg := message.Decode().(*messages.JSException)
+		msg, ok := message.Decode().(*messages.JSException)
+		if !ok {
+			return nil
+		}
 		h.updateLastIssueTimestamp(msg.Timestamp)
 	case messages.MsgNetworkRequest:
-		msg := message.Decode().(*messages.NetworkRequest)
+		msg, ok := message.Decode().(*messages.NetworkRequest)
+		if !ok {
+			return nil
+		}
 		if msg.Status >= 400 {
 			h.updateLastIssueTimestamp(msg.Timestamp)
 		}

--- a/backend/pkg/handlers/web/clickRage.go
+++ b/backend/pkg/handlers/web/clickRage.go
@@ -57,7 +57,10 @@ func (crd *ClickRageDetector) Build() Message {
 }
 
 func (crd *ClickRageDetector) Handle(message Message, timestamp uint64) Message {
-	msg := message.Decode().(*MouseClick)
+	msg, ok := message.Decode().(*MouseClick)
+	if !ok {
+		return nil
+	}
 	if crd.url == "" && msg.Url != "" {
 		crd.url = msg.Url
 	}

--- a/backend/pkg/handlers/web/cpuIssue.go
+++ b/backend/pkg/handlers/web/cpuIssue.go
@@ -67,7 +67,10 @@ func (f *CpuIssueDetector) Build() Message {
 func (f *CpuIssueDetector) Handle(message Message, timestamp uint64) Message {
 	switch message.TypeID() {
 	case MsgPerformanceTrack:
-		msg := message.Decode().(*PerformanceTrack)
+		msg, ok := message.Decode().(*PerformanceTrack)
+		if !ok {
+			return nil
+		}
 		if timestamp < f.lastTimestamp {
 			return nil
 		}
@@ -84,7 +87,10 @@ func (f *CpuIssueDetector) Handle(message Message, timestamp uint64) Message {
 			f.maxRate = cpuRate
 		}
 	case MsgSetPageLocation:
-		msg := message.Decode().(*SetPageLocation)
+		msg, ok := message.Decode().(*SetPageLocation)
+		if !ok {
+			return nil
+		}
 		f.contextString = msg.URL
 	}
 	return nil

--- a/backend/pkg/handlers/web/deadClick.go
+++ b/backend/pkg/handlers/web/deadClick.go
@@ -71,7 +71,10 @@ func (d *DeadClickDetector) Handle(message Message, timestamp uint64) Message {
 	d.lastTimestamp = timestamp
 	switch message.TypeID() {
 	case MsgMouseClick:
-		msg := message.Decode().(*MouseClick)
+		msg, ok := message.Decode().(*MouseClick)
+		if !ok {
+			return nil
+		}
 		if msg.Label == "" {
 			return nil
 		}
@@ -85,7 +88,10 @@ func (d *DeadClickDetector) Handle(message Message, timestamp uint64) Message {
 		d.lastMessageID = message.MsgID()
 		return event
 	case MsgSetInputTarget:
-		msg := message.Decode().(*SetInputTarget)
+		msg, ok := message.Decode().(*SetInputTarget)
+		if !ok {
+			return nil
+		}
 		d.addInputID(msg.ID)
 	case MsgCreateDocument:
 		d.clearInputIDs()

--- a/backend/pkg/handlers/web/memoryIssue.go
+++ b/backend/pkg/handlers/web/memoryIssue.go
@@ -51,7 +51,10 @@ func (f *MemoryIssueDetector) Build() Message {
 func (f *MemoryIssueDetector) Handle(message Message, timestamp uint64) Message {
 	switch message.TypeID() {
 	case MsgPerformanceTrack:
-		msg := message.Decode().(*PerformanceTrack)
+		msg, ok := message.Decode().(*PerformanceTrack)
+		if !ok {
+			return nil
+		}
 		if f.count < MIN_COUNT {
 			f.sum += float64(msg.UsedJSHeapSize)
 			f.count++
@@ -76,7 +79,10 @@ func (f *MemoryIssueDetector) Handle(message Message, timestamp uint64) Message 
 			return f.Build()
 		}
 	case MsgSetPageLocation:
-		msg := message.Decode().(*SetPageLocation)
+		msg, ok := message.Decode().(*SetPageLocation)
+		if !ok {
+			return nil
+		}
 		f.contextString = msg.URL
 	}
 	return nil

--- a/backend/pkg/handlers/web/networkIssue.go
+++ b/backend/pkg/handlers/web/networkIssue.go
@@ -15,7 +15,10 @@ func (f *NetworkIssueDetector) Build() Message {
 }
 
 func (f *NetworkIssueDetector) Handle(message Message, timestamp uint64) Message {
-	msg := message.Decode().(*NetworkRequest)
+	msg, ok := message.Decode().(*NetworkRequest)
+	if !ok {
+		return nil
+	}
 	if msg.Status >= 400 {
 		return &IssueEvent{
 			Type:          "bad_request",

--- a/backend/pkg/handlers/web/performanceAggregator.go
+++ b/backend/pkg/handlers/web/performanceAggregator.go
@@ -41,7 +41,10 @@ func (b *PerformanceAggregator) reset() {
 }
 
 func (b *PerformanceAggregator) Handle(message Message, timestamp uint64) Message {
-	msg := message.Decode().(*PerformanceTrack)
+	msg, ok := message.Decode().(*PerformanceTrack)
+	if !ok {
+		return nil
+	}
 	if b.PerformanceTrackAggr == nil || msg.Frames == -1 || msg.Ticks == -1 {
 		pta := b.Build()
 		b.start(timestamp)

--- a/backend/pkg/logger/logger.go
+++ b/backend/pkg/logger/logger.go
@@ -71,7 +71,7 @@ func (l *loggerImpl) prepare(ctx context.Context, logger *zap.Logger) *zap.Logge
 
 func (l *loggerImpl) Debug(ctx context.Context, message string, args ...interface{}) {
 	logStr := fmt.Sprintf(message, args...)
-	l.prepare(ctx, l.l.With(zap.String("level", "debug"))).Debug(logStr)
+	l.prepare(ctx, l.l).Debug(logStr)
 	if l.useExtra {
 		l.extra.Log(ctx, logStr)
 	}
@@ -79,7 +79,7 @@ func (l *loggerImpl) Debug(ctx context.Context, message string, args ...interfac
 
 func (l *loggerImpl) Info(ctx context.Context, message string, args ...interface{}) {
 	logStr := fmt.Sprintf(message, args...)
-	l.prepare(ctx, l.l.With(zap.String("level", "info"))).Info(logStr)
+	l.prepare(ctx, l.l).Info(logStr)
 	if l.useExtra {
 		l.extra.Log(ctx, logStr)
 	}
@@ -87,7 +87,7 @@ func (l *loggerImpl) Info(ctx context.Context, message string, args ...interface
 
 func (l *loggerImpl) Warn(ctx context.Context, message string, args ...interface{}) {
 	logStr := fmt.Sprintf(message, args...)
-	l.prepare(ctx, l.l.With(zap.String("level", "warn"))).Warn(logStr)
+	l.prepare(ctx, l.l).Warn(logStr)
 	if l.useExtra {
 		l.extra.Log(ctx, logStr)
 	}
@@ -95,7 +95,7 @@ func (l *loggerImpl) Warn(ctx context.Context, message string, args ...interface
 
 func (l *loggerImpl) Error(ctx context.Context, message string, args ...interface{}) {
 	logStr := fmt.Sprintf(message, args...)
-	l.prepare(ctx, l.l.With(zap.String("level", "error"))).Error(logStr)
+	l.prepare(ctx, l.l).Error(logStr)
 	if l.useExtra {
 		l.extra.Log(ctx, logStr)
 	}
@@ -103,7 +103,7 @@ func (l *loggerImpl) Error(ctx context.Context, message string, args ...interfac
 
 func (l *loggerImpl) Fatal(ctx context.Context, message string, args ...interface{}) {
 	logStr := fmt.Sprintf(message, args...)
-	l.prepare(ctx, l.l.With(zap.String("level", "fatal"))).Fatal(logStr)
+	l.prepare(ctx, l.l).Fatal(logStr)
 	if l.useExtra {
 		l.extra.Log(ctx, logStr)
 	}

--- a/backend/pkg/messages/batch-iterator-assets.go
+++ b/backend/pkg/messages/batch-iterator-assets.go
@@ -36,6 +36,6 @@ func (b *assetsBatchIteratorImpl) Iterate(batchData []byte, batch *BatchInfo) {
 	case AssetsBatch:
 		b.batchHandler(batchData, batch)
 	default:
-		b.log.Error(ctx, "unknown batch type: %d, info: %s", batchType, batch)
+		b.log.Error(ctx, "unknown batch type: %d, info: %s", batchType, batch.Info())
 	}
 }

--- a/backend/pkg/messages/batch-reader.go
+++ b/backend/pkg/messages/batch-reader.go
@@ -45,7 +45,7 @@ func (b *batchIteratorImpl) Iterate(batchData []byte, batch *BatchInfo) {
 	case PlayerBatch, AssetsBatch, DevtoolsBatch, AnalyticsBatch:
 		b.batchHandler(batchData, batch)
 	default:
-		b.log.Error(ctx, "unknown batch type: %d, info: %s", batchType, batch)
+		b.log.Error(ctx, "unknown batch type: %d, info: %s", batchType, batch.Info())
 	}
 }
 

--- a/backend/pkg/messages/bytes.go
+++ b/backend/pkg/messages/bytes.go
@@ -8,6 +8,7 @@ import (
 )
 
 type BytesReader interface {
+	Reset(data []byte)
 	ReadSize() (uint64, error)
 	ReadByte() (byte, error)
 	ReadUint() (uint64, error)
@@ -25,10 +26,15 @@ type bytesReaderImpl struct {
 	curr int64
 }
 
-func NewBytesReader(data []byte) BytesReader {
+func NewBytesReader(data []byte) *bytesReaderImpl {
 	return &bytesReaderImpl{
 		data: data,
 	}
+}
+
+func (m *bytesReaderImpl) Reset(data []byte) {
+	m.data = data
+	m.curr = 0
 }
 
 func (m *bytesReaderImpl) ReadSize() (uint64, error) {

--- a/backend/pkg/messages/iterator.go
+++ b/backend/pkg/messages/iterator.go
@@ -127,6 +127,9 @@ func (i *messageIteratorImpl) Iterate(batchData []byte, batchInfo *BatchInfo) {
 }
 
 func (i *messageIteratorImpl) getMobileTimestamp(msg Message) uint64 {
+	if raw, ok := msg.(*RawMessage); ok {
+		return raw.MobileTimestamp()
+	}
 	return GetTimestamp(msg)
 }
 

--- a/backend/pkg/messages/iterator.go
+++ b/backend/pkg/messages/iterator.go
@@ -14,11 +14,17 @@ type MessageIterator interface {
 	Iterate(batchData []byte, batchInfo *BatchInfo)
 }
 
+var preFilterTypes = []int{
+	MsgBatchMetadata, MsgTimestamp, MsgSessionStart,
+	MsgSessionEnd, MsgSetPageLocation, MsgMobileBatchMeta,
+}
+
 type messageIteratorImpl struct {
 	log           logger.Logger
-	filter        map[int]struct{} // union(preFilter, handlerFilter)
-	handlerFilter map[int]struct{}
-	preFilter     map[int]struct{}
+	filter        *TypeFilter // union(preFilter, handlerFilter)
+	handlerFilter *TypeFilter
+	preFilter     *TypeFilter
+	reader        *messageReaderImpl
 	handler       MessageHandler
 	autoDecode    bool
 	version       uint64
@@ -36,27 +42,16 @@ func NewMessageIterator(log logger.Logger, messageHandler MessageHandler, messag
 		log:         log,
 		handler:     messageHandler,
 		autoDecode:  autoDecode,
+		reader:      &messageReaderImpl{reader: NewBytesReader(nil)},
 		urls:        NewPageLocations(),
 		brokenStats: NewBrokenBatches(),
 	}
-	iter.preFilter = map[int]struct{}{
-		MsgBatchMetadata: {}, MsgTimestamp: {}, MsgSessionStart: {},
-		MsgSessionEnd: {}, MsgSetPageLocation: {}, MsgMobileBatchMeta: {},
-	}
+	iter.preFilter = NewTypeFilter(preFilterTypes)
 	if len(messageFilter) != 0 {
-		handlerFilter := make(map[int]struct{}, len(messageFilter))
-		for _, msgType := range messageFilter {
-			handlerFilter[msgType] = struct{}{}
-		}
-		iter.handlerFilter = handlerFilter
+		iter.handlerFilter = NewTypeFilter(messageFilter)
 
-		filter := make(map[int]struct{}, len(messageFilter)+len(iter.preFilter))
-		for msgType := range iter.preFilter {
-			filter[msgType] = struct{}{}
-		}
-		for _, msgType := range messageFilter {
-			filter[msgType] = struct{}{}
-		}
+		filter := NewTypeFilter(preFilterTypes)
+		filter.Add(messageFilter)
 		iter.filter = filter
 	}
 	return iter
@@ -74,8 +69,8 @@ func (i *messageIteratorImpl) prepareVars(batchInfo *BatchInfo) {
 func (i *messageIteratorImpl) Iterate(batchData []byte, batchInfo *BatchInfo) {
 	ctx := context.WithValue(context.Background(), "sessionID", batchInfo.sessionID)
 
-	reader := NewMessageReader(batchData)
-	if err := reader.Parse(i.filter); err != nil {
+	i.reader.Reset(batchData)
+	if err := i.reader.Parse(i.filter); err != nil {
 		i.brokenStats.Inc(batchInfo.sessionID, err.Error())
 		return
 	}
@@ -83,12 +78,12 @@ func (i *messageIteratorImpl) Iterate(batchData []byte, batchInfo *BatchInfo) {
 	// Prepare iterator before processing messages in batch
 	i.prepareVars(batchInfo)
 
-	for reader.Next() {
-		msg := reader.Message()
+	for i.reader.Next() {
+		msg := i.reader.Message()
 		msgType := msg.TypeID()
 
 		// Preprocess "system" messages
-		if _, ok := i.preFilter[msg.TypeID()]; ok {
+		if i.preFilter.Has(msgType) {
 			decoded := msg.Decode()
 			if decoded == nil {
 				i.log.Error(ctx, "decode error, type: %d, reason: %s, info: %s",
@@ -102,10 +97,8 @@ func (i *messageIteratorImpl) Iterate(batchData []byte, batchInfo *BatchInfo) {
 			}
 		}
 
-		if i.handlerFilter != nil {
-			if _, ok := i.handlerFilter[msg.TypeID()]; !ok {
-				continue
-			}
+		if i.handlerFilter != nil && !i.handlerFilter.Has(msg.TypeID()) {
+			continue
 		}
 
 		if i.autoDecode {

--- a/backend/pkg/messages/primitives.go
+++ b/backend/pkg/messages/primitives.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
+	"math/bits"
 )
 
 var (
@@ -52,12 +52,10 @@ func WriteUint(v uint64, buf []byte, p int) int {
 }
 
 func ByteSizeUint(v uint64) int {
-	if v == 0 {
+	if v < 0x80 {
 		return 1
 	}
-	nBits := math.Floor(math.Log2(float64(v))) + 1
-	nBytes := math.Ceil(nBits / 7)
-	return int(nBytes)
+	return (bits.Len64(v) + 6) / 7
 }
 
 func ReadInt(reader io.Reader) (int64, error) {

--- a/backend/pkg/messages/raw.go
+++ b/backend/pkg/messages/raw.go
@@ -26,6 +26,18 @@ func (m *RawMessage) Decode() Message {
 	return msg
 }
 
+func (m *RawMessage) MobileTimestamp() uint64 {
+	if len(m.data) < 2 || !IsMobileType(int(m.tp)) {
+		return m.meta.Timestamp
+	}
+	reader := bytesReaderImpl{data: m.data[1:]}
+	ts, err := reader.ReadUint()
+	if err != nil {
+		return m.meta.Timestamp
+	}
+	return ts
+}
+
 func (m *RawMessage) TypeID() int {
 	return int(m.tp)
 }

--- a/backend/pkg/messages/raw.go
+++ b/backend/pkg/messages/raw.go
@@ -5,7 +5,7 @@ type RawMessage struct {
 	tp        uint64
 	data      []byte
 	broken    *bool
-	meta      *message
+	meta      message
 	decodeErr error
 }
 
@@ -14,14 +14,15 @@ func (m *RawMessage) Encode() []byte {
 }
 
 func (m *RawMessage) Decode() Message {
-	msg, err := ReadMessage(m.tp, NewBytesReader(m.data[1:]))
+	reader := bytesReaderImpl{data: m.data[1:]}
+	msg, err := ReadMessage(m.tp, &reader)
 	if err != nil {
 		m.decodeErr = err
 		*m.broken = true
 		return nil
 	}
 	msg = transformDeprecated(msg)
-	msg.Meta().SetMeta(m.meta)
+	msg.Meta().SetMeta(&m.meta)
 	return msg
 }
 
@@ -30,26 +31,20 @@ func (m *RawMessage) TypeID() int {
 }
 
 func (m *RawMessage) Meta() *message {
-	return m.meta
+	return &m.meta
 }
 
 func (m *RawMessage) SessionID() uint64 {
-	if m.meta != nil {
-		return m.meta.SessionID()
+	if m.meta.batch != nil {
+		return m.meta.batch.sessionID
 	}
 	return 0
 }
 
 func (m *RawMessage) MsgID() uint64 {
-	if m.meta != nil {
-		return m.meta.Index
-	}
-	return 0
+	return m.meta.Index
 }
 
 func (m *RawMessage) Time() uint64 {
-	if m.meta != nil {
-		return m.meta.Timestamp
-	}
-	return 0
+	return m.meta.Timestamp
 }

--- a/backend/pkg/messages/read-message.go
+++ b/backend/pkg/messages/read-message.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func DecodeTimestamp(reader BytesReader) (Message, error) {
+func DecodeTimestamp(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &Timestamp{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -14,7 +14,7 @@ func DecodeTimestamp(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSessionStart(reader BytesReader) (Message, error) {
+func DecodeSessionStart(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SessionStart{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -68,7 +68,7 @@ func DecodeSessionStart(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeCleanSession(reader BytesReader) (Message, error) {
+func DecodeCleanSession(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &CleanSession{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -77,7 +77,7 @@ func DecodeCleanSession(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetPageLocationDeprecated(reader BytesReader) (Message, error) {
+func DecodeSetPageLocationDeprecated(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetPageLocationDeprecated{}
 	if msg.URL, err = reader.ReadString(); err != nil {
@@ -92,7 +92,7 @@ func DecodeSetPageLocationDeprecated(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetViewportSize(reader BytesReader) (Message, error) {
+func DecodeSetViewportSize(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetViewportSize{}
 	if msg.Width, err = reader.ReadUint(); err != nil {
@@ -104,7 +104,7 @@ func DecodeSetViewportSize(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetViewportScroll(reader BytesReader) (Message, error) {
+func DecodeSetViewportScroll(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetViewportScroll{}
 	if msg.X, err = reader.ReadInt(); err != nil {
@@ -116,14 +116,14 @@ func DecodeSetViewportScroll(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeCreateDocument(reader BytesReader) (Message, error) {
+func DecodeCreateDocument(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &CreateDocument{}
 
 	return msg, err
 }
 
-func DecodeCreateElementNode(reader BytesReader) (Message, error) {
+func DecodeCreateElementNode(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &CreateElementNode{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -144,7 +144,7 @@ func DecodeCreateElementNode(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeCreateTextNode(reader BytesReader) (Message, error) {
+func DecodeCreateTextNode(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &CreateTextNode{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -159,7 +159,7 @@ func DecodeCreateTextNode(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMoveNode(reader BytesReader) (Message, error) {
+func DecodeMoveNode(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MoveNode{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -174,7 +174,7 @@ func DecodeMoveNode(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeRemoveNode(reader BytesReader) (Message, error) {
+func DecodeRemoveNode(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &RemoveNode{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -183,7 +183,7 @@ func DecodeRemoveNode(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetNodeAttribute(reader BytesReader) (Message, error) {
+func DecodeSetNodeAttribute(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetNodeAttribute{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -198,7 +198,7 @@ func DecodeSetNodeAttribute(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeRemoveNodeAttribute(reader BytesReader) (Message, error) {
+func DecodeRemoveNodeAttribute(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &RemoveNodeAttribute{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -210,7 +210,7 @@ func DecodeRemoveNodeAttribute(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetNodeData(reader BytesReader) (Message, error) {
+func DecodeSetNodeData(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetNodeData{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -222,7 +222,7 @@ func DecodeSetNodeData(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetCSSData(reader BytesReader) (Message, error) {
+func DecodeSetCSSData(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetCSSData{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -234,7 +234,7 @@ func DecodeSetCSSData(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetNodeScroll(reader BytesReader) (Message, error) {
+func DecodeSetNodeScroll(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetNodeScroll{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -249,7 +249,7 @@ func DecodeSetNodeScroll(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetInputTarget(reader BytesReader) (Message, error) {
+func DecodeSetInputTarget(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetInputTarget{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -261,7 +261,7 @@ func DecodeSetInputTarget(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetInputValue(reader BytesReader) (Message, error) {
+func DecodeSetInputValue(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetInputValue{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -276,7 +276,7 @@ func DecodeSetInputValue(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetInputChecked(reader BytesReader) (Message, error) {
+func DecodeSetInputChecked(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetInputChecked{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -288,7 +288,7 @@ func DecodeSetInputChecked(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMouseMove(reader BytesReader) (Message, error) {
+func DecodeMouseMove(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MouseMove{}
 	if msg.X, err = reader.ReadUint(); err != nil {
@@ -300,7 +300,7 @@ func DecodeMouseMove(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeNetworkRequestDeprecated(reader BytesReader) (Message, error) {
+func DecodeNetworkRequestDeprecated(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &NetworkRequestDeprecated{}
 	if msg.Type, err = reader.ReadString(); err != nil {
@@ -330,7 +330,7 @@ func DecodeNetworkRequestDeprecated(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeConsoleLog(reader BytesReader) (Message, error) {
+func DecodeConsoleLog(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &ConsoleLog{}
 	if msg.Level, err = reader.ReadString(); err != nil {
@@ -342,7 +342,7 @@ func DecodeConsoleLog(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodePageLoadTiming(reader BytesReader) (Message, error) {
+func DecodePageLoadTiming(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &PageLoadTiming{}
 	if msg.RequestStart, err = reader.ReadUint(); err != nil {
@@ -375,7 +375,7 @@ func DecodePageLoadTiming(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodePageRenderTiming(reader BytesReader) (Message, error) {
+func DecodePageRenderTiming(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &PageRenderTiming{}
 	if msg.SpeedIndex, err = reader.ReadUint(); err != nil {
@@ -390,7 +390,7 @@ func DecodePageRenderTiming(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeCustomEvent(reader BytesReader) (Message, error) {
+func DecodeCustomEvent(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &CustomEvent{}
 	if msg.Name, err = reader.ReadString(); err != nil {
@@ -402,7 +402,7 @@ func DecodeCustomEvent(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeUserID(reader BytesReader) (Message, error) {
+func DecodeUserID(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &UserID{}
 	if msg.ID, err = reader.ReadString(); err != nil {
@@ -411,7 +411,7 @@ func DecodeUserID(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeUserAnonymousID(reader BytesReader) (Message, error) {
+func DecodeUserAnonymousID(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &UserAnonymousID{}
 	if msg.ID, err = reader.ReadString(); err != nil {
@@ -420,7 +420,7 @@ func DecodeUserAnonymousID(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMetadata(reader BytesReader) (Message, error) {
+func DecodeMetadata(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &Metadata{}
 	if msg.Key, err = reader.ReadString(); err != nil {
@@ -432,7 +432,7 @@ func DecodeMetadata(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodePageEventDeprecated(reader BytesReader) (Message, error) {
+func DecodePageEventDeprecated(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &PageEventDeprecated{}
 	if msg.MessageID, err = reader.ReadUint(); err != nil {
@@ -489,7 +489,7 @@ func DecodePageEventDeprecated(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeInputEvent(reader BytesReader) (Message, error) {
+func DecodeInputEvent(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &InputEvent{}
 	if msg.MessageID, err = reader.ReadUint(); err != nil {
@@ -510,7 +510,7 @@ func DecodeInputEvent(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodePageEvent(reader BytesReader) (Message, error) {
+func DecodePageEvent(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &PageEvent{}
 	if msg.MessageID, err = reader.ReadUint(); err != nil {
@@ -570,7 +570,7 @@ func DecodePageEvent(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeStringDictGlobal(reader BytesReader) (Message, error) {
+func DecodeStringDictGlobal(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &StringDictGlobal{}
 	if msg.Key, err = reader.ReadUint(); err != nil {
@@ -582,7 +582,7 @@ func DecodeStringDictGlobal(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetNodeAttributeDictGlobal(reader BytesReader) (Message, error) {
+func DecodeSetNodeAttributeDictGlobal(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetNodeAttributeDictGlobal{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -597,7 +597,7 @@ func DecodeSetNodeAttributeDictGlobal(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeNodeAnimationResult(reader BytesReader) (Message, error) {
+func DecodeNodeAnimationResult(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &NodeAnimationResult{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -609,7 +609,7 @@ func DecodeNodeAnimationResult(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeProfiler(reader BytesReader) (Message, error) {
+func DecodeProfiler(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &Profiler{}
 	if msg.Name, err = reader.ReadString(); err != nil {
@@ -627,7 +627,7 @@ func DecodeProfiler(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeOTable(reader BytesReader) (Message, error) {
+func DecodeOTable(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &OTable{}
 	if msg.Key, err = reader.ReadString(); err != nil {
@@ -639,7 +639,7 @@ func DecodeOTable(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeStateAction(reader BytesReader) (Message, error) {
+func DecodeStateAction(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &StateAction{}
 	if msg.Type, err = reader.ReadString(); err != nil {
@@ -648,7 +648,7 @@ func DecodeStateAction(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeReduxDeprecated(reader BytesReader) (Message, error) {
+func DecodeReduxDeprecated(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &ReduxDeprecated{}
 	if msg.Action, err = reader.ReadString(); err != nil {
@@ -663,7 +663,7 @@ func DecodeReduxDeprecated(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeVuex(reader BytesReader) (Message, error) {
+func DecodeVuex(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &Vuex{}
 	if msg.Mutation, err = reader.ReadString(); err != nil {
@@ -675,7 +675,7 @@ func DecodeVuex(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobX(reader BytesReader) (Message, error) {
+func DecodeMobX(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobX{}
 	if msg.Type, err = reader.ReadString(); err != nil {
@@ -687,7 +687,7 @@ func DecodeMobX(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeNgRx(reader BytesReader) (Message, error) {
+func DecodeNgRx(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &NgRx{}
 	if msg.Action, err = reader.ReadString(); err != nil {
@@ -702,7 +702,7 @@ func DecodeNgRx(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeGraphQLDeprecated(reader BytesReader) (Message, error) {
+func DecodeGraphQLDeprecated(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &GraphQLDeprecated{}
 	if msg.OperationKind, err = reader.ReadString(); err != nil {
@@ -723,7 +723,7 @@ func DecodeGraphQLDeprecated(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodePerformanceTrack(reader BytesReader) (Message, error) {
+func DecodePerformanceTrack(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &PerformanceTrack{}
 	if msg.Frames, err = reader.ReadInt(); err != nil {
@@ -741,7 +741,7 @@ func DecodePerformanceTrack(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeStringDictDeprecated(reader BytesReader) (Message, error) {
+func DecodeStringDictDeprecated(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &StringDictDeprecated{}
 	if msg.Key, err = reader.ReadUint(); err != nil {
@@ -753,7 +753,7 @@ func DecodeStringDictDeprecated(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetNodeAttributeDictDeprecated(reader BytesReader) (Message, error) {
+func DecodeSetNodeAttributeDictDeprecated(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetNodeAttributeDictDeprecated{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -768,7 +768,7 @@ func DecodeSetNodeAttributeDictDeprecated(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeStringDict(reader BytesReader) (Message, error) {
+func DecodeStringDict(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &StringDict{}
 	if msg.Key, err = reader.ReadString(); err != nil {
@@ -780,7 +780,7 @@ func DecodeStringDict(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetNodeAttributeDict(reader BytesReader) (Message, error) {
+func DecodeSetNodeAttributeDict(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetNodeAttributeDict{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -795,7 +795,7 @@ func DecodeSetNodeAttributeDict(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeResourceTimingDeprecatedDeprecated(reader BytesReader) (Message, error) {
+func DecodeResourceTimingDeprecatedDeprecated(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &ResourceTimingDeprecatedDeprecated{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -825,7 +825,7 @@ func DecodeResourceTimingDeprecatedDeprecated(reader BytesReader) (Message, erro
 	return msg, err
 }
 
-func DecodeConnectionInformation(reader BytesReader) (Message, error) {
+func DecodeConnectionInformation(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &ConnectionInformation{}
 	if msg.Downlink, err = reader.ReadUint(); err != nil {
@@ -837,7 +837,7 @@ func DecodeConnectionInformation(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetPageVisibility(reader BytesReader) (Message, error) {
+func DecodeSetPageVisibility(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetPageVisibility{}
 	if msg.hidden, err = reader.ReadBoolean(); err != nil {
@@ -846,7 +846,7 @@ func DecodeSetPageVisibility(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodePerformanceTrackAggr(reader BytesReader) (Message, error) {
+func DecodePerformanceTrackAggr(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &PerformanceTrackAggr{}
 	if msg.TimestampStart, err = reader.ReadUint(); err != nil {
@@ -894,7 +894,7 @@ func DecodePerformanceTrackAggr(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeLoadFontFace(reader BytesReader) (Message, error) {
+func DecodeLoadFontFace(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &LoadFontFace{}
 	if msg.ParentID, err = reader.ReadUint(); err != nil {
@@ -912,7 +912,7 @@ func DecodeLoadFontFace(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetNodeFocus(reader BytesReader) (Message, error) {
+func DecodeSetNodeFocus(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetNodeFocus{}
 	if msg.ID, err = reader.ReadInt(); err != nil {
@@ -921,7 +921,7 @@ func DecodeSetNodeFocus(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetNodeAttributeURLBased(reader BytesReader) (Message, error) {
+func DecodeSetNodeAttributeURLBased(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetNodeAttributeURLBased{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -939,7 +939,7 @@ func DecodeSetNodeAttributeURLBased(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetCSSDataURLBased(reader BytesReader) (Message, error) {
+func DecodeSetCSSDataURLBased(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetCSSDataURLBased{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -954,7 +954,7 @@ func DecodeSetCSSDataURLBased(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeTechnicalInfo(reader BytesReader) (Message, error) {
+func DecodeTechnicalInfo(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &TechnicalInfo{}
 	if msg.Type, err = reader.ReadString(); err != nil {
@@ -966,7 +966,7 @@ func DecodeTechnicalInfo(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeCustomIssue(reader BytesReader) (Message, error) {
+func DecodeCustomIssue(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &CustomIssue{}
 	if msg.Name, err = reader.ReadString(); err != nil {
@@ -978,7 +978,7 @@ func DecodeCustomIssue(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetNodeSlot(reader BytesReader) (Message, error) {
+func DecodeSetNodeSlot(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetNodeSlot{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -990,7 +990,7 @@ func DecodeSetNodeSlot(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeAssetCache(reader BytesReader) (Message, error) {
+func DecodeAssetCache(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &AssetCache{}
 	if msg.URL, err = reader.ReadString(); err != nil {
@@ -999,7 +999,7 @@ func DecodeAssetCache(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMouseClick(reader BytesReader) (Message, error) {
+func DecodeMouseClick(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MouseClick{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -1023,7 +1023,7 @@ func DecodeMouseClick(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMouseClickDeprecated(reader BytesReader) (Message, error) {
+func DecodeMouseClickDeprecated(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MouseClickDeprecated{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -1041,7 +1041,7 @@ func DecodeMouseClickDeprecated(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeCreateIFrameDocument(reader BytesReader) (Message, error) {
+func DecodeCreateIFrameDocument(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &CreateIFrameDocument{}
 	if msg.FrameID, err = reader.ReadUint(); err != nil {
@@ -1053,7 +1053,7 @@ func DecodeCreateIFrameDocument(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeAdoptedSSReplaceURLBased(reader BytesReader) (Message, error) {
+func DecodeAdoptedSSReplaceURLBased(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &AdoptedSSReplaceURLBased{}
 	if msg.SheetID, err = reader.ReadUint(); err != nil {
@@ -1068,7 +1068,7 @@ func DecodeAdoptedSSReplaceURLBased(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeAdoptedSSReplace(reader BytesReader) (Message, error) {
+func DecodeAdoptedSSReplace(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &AdoptedSSReplace{}
 	if msg.SheetID, err = reader.ReadUint(); err != nil {
@@ -1080,7 +1080,7 @@ func DecodeAdoptedSSReplace(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeAdoptedSSInsertRuleURLBased(reader BytesReader) (Message, error) {
+func DecodeAdoptedSSInsertRuleURLBased(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &AdoptedSSInsertRuleURLBased{}
 	if msg.SheetID, err = reader.ReadUint(); err != nil {
@@ -1098,7 +1098,7 @@ func DecodeAdoptedSSInsertRuleURLBased(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeAdoptedSSInsertRule(reader BytesReader) (Message, error) {
+func DecodeAdoptedSSInsertRule(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &AdoptedSSInsertRule{}
 	if msg.SheetID, err = reader.ReadUint(); err != nil {
@@ -1113,7 +1113,7 @@ func DecodeAdoptedSSInsertRule(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeAdoptedSSDeleteRule(reader BytesReader) (Message, error) {
+func DecodeAdoptedSSDeleteRule(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &AdoptedSSDeleteRule{}
 	if msg.SheetID, err = reader.ReadUint(); err != nil {
@@ -1125,7 +1125,7 @@ func DecodeAdoptedSSDeleteRule(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeAdoptedSSAddOwner(reader BytesReader) (Message, error) {
+func DecodeAdoptedSSAddOwner(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &AdoptedSSAddOwner{}
 	if msg.SheetID, err = reader.ReadUint(); err != nil {
@@ -1137,7 +1137,7 @@ func DecodeAdoptedSSAddOwner(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeAdoptedSSRemoveOwner(reader BytesReader) (Message, error) {
+func DecodeAdoptedSSRemoveOwner(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &AdoptedSSRemoveOwner{}
 	if msg.SheetID, err = reader.ReadUint(); err != nil {
@@ -1149,7 +1149,7 @@ func DecodeAdoptedSSRemoveOwner(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeJSException(reader BytesReader) (Message, error) {
+func DecodeJSException(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &JSException{}
 	if msg.Name, err = reader.ReadString(); err != nil {
@@ -1167,7 +1167,7 @@ func DecodeJSException(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeZustand(reader BytesReader) (Message, error) {
+func DecodeZustand(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &Zustand{}
 	if msg.Mutation, err = reader.ReadString(); err != nil {
@@ -1179,7 +1179,7 @@ func DecodeZustand(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeBatchMetadata(reader BytesReader) (Message, error) {
+func DecodeBatchMetadata(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &BatchMetadata{}
 	if msg.Version, err = reader.ReadUint(); err != nil {
@@ -1200,7 +1200,7 @@ func DecodeBatchMetadata(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeNetworkRequest(reader BytesReader) (Message, error) {
+func DecodeNetworkRequest(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &NetworkRequest{}
 	if msg.Type, err = reader.ReadString(); err != nil {
@@ -1233,7 +1233,7 @@ func DecodeNetworkRequest(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeWSChannel(reader BytesReader) (Message, error) {
+func DecodeWSChannel(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &WSChannel{}
 	if msg.ChType, err = reader.ReadString(); err != nil {
@@ -1257,7 +1257,7 @@ func DecodeWSChannel(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeResourceTiming(reader BytesReader) (Message, error) {
+func DecodeResourceTiming(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &ResourceTiming{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1314,7 +1314,7 @@ func DecodeResourceTiming(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeIncident(reader BytesReader) (Message, error) {
+func DecodeIncident(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &Incident{}
 	if msg.Label, err = reader.ReadString(); err != nil {
@@ -1329,7 +1329,7 @@ func DecodeIncident(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeLongAnimationTask(reader BytesReader) (Message, error) {
+func DecodeLongAnimationTask(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &LongAnimationTask{}
 	if msg.Name, err = reader.ReadString(); err != nil {
@@ -1353,7 +1353,7 @@ func DecodeLongAnimationTask(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeInputChange(reader BytesReader) (Message, error) {
+func DecodeInputChange(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &InputChange{}
 	if msg.ID, err = reader.ReadUint(); err != nil {
@@ -1377,7 +1377,7 @@ func DecodeInputChange(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSelectionChange(reader BytesReader) (Message, error) {
+func DecodeSelectionChange(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SelectionChange{}
 	if msg.SelectionStart, err = reader.ReadUint(); err != nil {
@@ -1392,7 +1392,7 @@ func DecodeSelectionChange(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMouseThrashing(reader BytesReader) (Message, error) {
+func DecodeMouseThrashing(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MouseThrashing{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1401,7 +1401,7 @@ func DecodeMouseThrashing(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeUnbindNodes(reader BytesReader) (Message, error) {
+func DecodeUnbindNodes(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &UnbindNodes{}
 	if msg.TotalRemovedPercent, err = reader.ReadUint(); err != nil {
@@ -1410,7 +1410,7 @@ func DecodeUnbindNodes(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeResourceTimingDeprecated(reader BytesReader) (Message, error) {
+func DecodeResourceTimingDeprecated(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &ResourceTimingDeprecated{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1446,7 +1446,7 @@ func DecodeResourceTimingDeprecated(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeTabChange(reader BytesReader) (Message, error) {
+func DecodeTabChange(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &TabChange{}
 	if msg.TabId, err = reader.ReadString(); err != nil {
@@ -1455,7 +1455,7 @@ func DecodeTabChange(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeTabData(reader BytesReader) (Message, error) {
+func DecodeTabData(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &TabData{}
 	if msg.TabId, err = reader.ReadString(); err != nil {
@@ -1464,7 +1464,7 @@ func DecodeTabData(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeCanvasNode(reader BytesReader) (Message, error) {
+func DecodeCanvasNode(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &CanvasNode{}
 	if msg.NodeId, err = reader.ReadString(); err != nil {
@@ -1476,7 +1476,7 @@ func DecodeCanvasNode(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeTagTrigger(reader BytesReader) (Message, error) {
+func DecodeTagTrigger(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &TagTrigger{}
 	if msg.TagId, err = reader.ReadInt(); err != nil {
@@ -1485,7 +1485,7 @@ func DecodeTagTrigger(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeRedux(reader BytesReader) (Message, error) {
+func DecodeRedux(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &Redux{}
 	if msg.Action, err = reader.ReadString(); err != nil {
@@ -1503,7 +1503,7 @@ func DecodeRedux(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSetPageLocation(reader BytesReader) (Message, error) {
+func DecodeSetPageLocation(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SetPageLocation{}
 	if msg.URL, err = reader.ReadString(); err != nil {
@@ -1521,7 +1521,7 @@ func DecodeSetPageLocation(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeGraphQL(reader BytesReader) (Message, error) {
+func DecodeGraphQL(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &GraphQL{}
 	if msg.OperationKind, err = reader.ReadString(); err != nil {
@@ -1542,7 +1542,7 @@ func DecodeGraphQL(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeWebVitals(reader BytesReader) (Message, error) {
+func DecodeWebVitals(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &WebVitals{}
 	if msg.Name, err = reader.ReadString(); err != nil {
@@ -1554,7 +1554,7 @@ func DecodeWebVitals(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeIssueEvent(reader BytesReader) (Message, error) {
+func DecodeIssueEvent(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &IssueEvent{}
 	if msg.MessageID, err = reader.ReadUint(); err != nil {
@@ -1581,7 +1581,7 @@ func DecodeIssueEvent(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSessionEnd(reader BytesReader) (Message, error) {
+func DecodeSessionEnd(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SessionEnd{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1593,7 +1593,7 @@ func DecodeSessionEnd(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeSessionSearch(reader BytesReader) (Message, error) {
+func DecodeSessionSearch(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &SessionSearch{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1605,7 +1605,7 @@ func DecodeSessionSearch(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileSessionStart(reader BytesReader) (Message, error) {
+func DecodeMobileSessionStart(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileSessionStart{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1641,7 +1641,7 @@ func DecodeMobileSessionStart(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileSessionEnd(reader BytesReader) (Message, error) {
+func DecodeMobileSessionEnd(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileSessionEnd{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1650,7 +1650,7 @@ func DecodeMobileSessionEnd(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileMetadata(reader BytesReader) (Message, error) {
+func DecodeMobileMetadata(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileMetadata{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1668,7 +1668,7 @@ func DecodeMobileMetadata(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileEvent(reader BytesReader) (Message, error) {
+func DecodeMobileEvent(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileEvent{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1686,7 +1686,7 @@ func DecodeMobileEvent(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileUserID(reader BytesReader) (Message, error) {
+func DecodeMobileUserID(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileUserID{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1701,7 +1701,7 @@ func DecodeMobileUserID(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileUserAnonymousID(reader BytesReader) (Message, error) {
+func DecodeMobileUserAnonymousID(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileUserAnonymousID{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1716,7 +1716,7 @@ func DecodeMobileUserAnonymousID(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileScreenChanges(reader BytesReader) (Message, error) {
+func DecodeMobileScreenChanges(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileScreenChanges{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1740,7 +1740,7 @@ func DecodeMobileScreenChanges(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileCrash(reader BytesReader) (Message, error) {
+func DecodeMobileCrash(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileCrash{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1761,7 +1761,7 @@ func DecodeMobileCrash(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileViewComponentEvent(reader BytesReader) (Message, error) {
+func DecodeMobileViewComponentEvent(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileViewComponentEvent{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1782,7 +1782,7 @@ func DecodeMobileViewComponentEvent(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileClickEvent(reader BytesReader) (Message, error) {
+func DecodeMobileClickEvent(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileClickEvent{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1803,7 +1803,7 @@ func DecodeMobileClickEvent(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileInputEvent(reader BytesReader) (Message, error) {
+func DecodeMobileInputEvent(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileInputEvent{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1824,7 +1824,7 @@ func DecodeMobileInputEvent(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobilePerformanceEvent(reader BytesReader) (Message, error) {
+func DecodeMobilePerformanceEvent(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobilePerformanceEvent{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1842,7 +1842,7 @@ func DecodeMobilePerformanceEvent(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileLog(reader BytesReader) (Message, error) {
+func DecodeMobileLog(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileLog{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1860,7 +1860,7 @@ func DecodeMobileLog(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileInternalError(reader BytesReader) (Message, error) {
+func DecodeMobileInternalError(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileInternalError{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1875,7 +1875,7 @@ func DecodeMobileInternalError(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileNetworkCall(reader BytesReader) (Message, error) {
+func DecodeMobileNetworkCall(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileNetworkCall{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1908,7 +1908,7 @@ func DecodeMobileNetworkCall(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileSwipeEvent(reader BytesReader) (Message, error) {
+func DecodeMobileSwipeEvent(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileSwipeEvent{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1932,7 +1932,7 @@ func DecodeMobileSwipeEvent(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileBatchMeta(reader BytesReader) (Message, error) {
+func DecodeMobileBatchMeta(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileBatchMeta{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1947,7 +1947,7 @@ func DecodeMobileBatchMeta(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileGraphQL(reader BytesReader) (Message, error) {
+func DecodeMobileGraphQL(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileGraphQL{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -1974,7 +1974,7 @@ func DecodeMobileGraphQL(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobilePerformanceAggregated(reader BytesReader) (Message, error) {
+func DecodeMobilePerformanceAggregated(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobilePerformanceAggregated{}
 	if msg.TimestampStart, err = reader.ReadUint(); err != nil {
@@ -2022,7 +2022,7 @@ func DecodeMobilePerformanceAggregated(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func DecodeMobileIssueEvent(reader BytesReader) (Message, error) {
+func DecodeMobileIssueEvent(reader *bytesReaderImpl) (Message, error) {
 	var err error = nil
 	msg := &MobileIssueEvent{}
 	if msg.Timestamp, err = reader.ReadUint(); err != nil {
@@ -2043,7 +2043,7 @@ func DecodeMobileIssueEvent(reader BytesReader) (Message, error) {
 	return msg, err
 }
 
-func ReadMessage(t uint64, reader BytesReader) (Message, error) {
+func ReadMessage(t uint64, reader *bytesReaderImpl) (Message, error) {
 	switch t {
 	case 0:
 		return DecodeTimestamp(reader)

--- a/backend/pkg/messages/reader.go
+++ b/backend/pkg/messages/reader.go
@@ -6,7 +6,7 @@ import (
 )
 
 type MessageReader interface {
-	Parse(filter map[int]struct{}) (err error)
+	Parse(filter *TypeFilter) (err error)
 	Next() bool
 	Message() Message
 }
@@ -20,7 +20,7 @@ func NewMessageReader(data []byte) MessageReader {
 
 type messageReaderImpl struct {
 	data     []byte
-	reader   BytesReader
+	reader   *bytesReaderImpl
 	msgType  uint64
 	msgSize  uint64
 	msgBody  []byte
@@ -28,15 +28,23 @@ type messageReaderImpl struct {
 	broken   bool
 	message  Message
 	err      error
-	messages []*RawMessage
+	messages []RawMessage
 	listPtr  int
 	index    uint64
 }
 
-func (m *messageReaderImpl) Parse(filter map[int]struct{}) (err error) {
+func (m *messageReaderImpl) Reset(data []byte) {
+	m.data = data
+	m.reader.Reset(data)
+	m.version = 0
+	m.message = nil
+	m.err = nil
+}
+
+func (m *messageReaderImpl) Parse(filter *TypeFilter) (err error) {
 	m.listPtr = 0
 	m.index = 0
-	m.messages = make([]*RawMessage, 0, 1024)
+	m.messages = m.messages[:0]
 	m.broken = false
 	for {
 		// Try to read and decode message type, message size and check range in
@@ -65,22 +73,27 @@ func (m *messageReaderImpl) Parse(filter map[int]struct{}) (err error) {
 			}
 			m.reader.SetPointer(curr + int64(m.msgSize))
 
-			if filter != nil {
-				if _, ok := filter[int(m.msgType)]; !ok {
-					continue
-				}
+			if filter != nil && !filter.Has(int(m.msgType)) {
+				continue
 			}
 
-			// Dirty hack to avoid extra memory allocation
-			mTypeByteSize := ByteSizeUint(m.msgType)
-			from := int(curr) - mTypeByteSize
-			WriteUint(m.msgType, m.data, from)
+			// Rewrite the type right before the body (over the last size byte)
+			// so RawMessage.data is a contiguous [type][body] view into the
+			// batch buffer with no extra allocation
+			var from int
+			if m.msgType < 0x80 {
+				from = int(curr) - 1
+				m.data[from] = byte(m.msgType)
+			} else {
+				from = int(curr) - ByteSizeUint(m.msgType)
+				WriteUint(m.msgType, m.data, from)
+			}
 
-			m.messages = append(m.messages, &RawMessage{
+			m.messages = append(m.messages, RawMessage{
 				tp:     m.msgType,
-				data:   m.data[uint64(from) : uint64(from)+m.msgSize+1],
+				data:   m.data[from : curr+int64(m.msgSize)],
 				broken: &m.broken,
-				meta: &message{
+				meta: message{
 					Index: m.index,
 				},
 			})
@@ -112,17 +125,15 @@ func (m *messageReaderImpl) Parse(filter map[int]struct{}) (err error) {
 				}
 			}
 
-			if filter != nil {
-				if _, ok := filter[int(m.msgType)]; !ok {
-					continue
-				}
+			if filter != nil && !filter.Has(int(m.msgType)) {
+				continue
 			}
 
-			m.messages = append(m.messages, &RawMessage{
+			m.messages = append(m.messages, RawMessage{
 				tp:     m.msgType,
-				data:   m.data[uint64(from):uint64(m.reader.Pointer())],
+				data:   m.data[from:m.reader.Pointer()],
 				broken: &m.broken,
-				meta: &message{
+				meta: message{
 					Index: m.index,
 				},
 			})
@@ -141,7 +152,7 @@ func (m *messageReaderImpl) Next() bool {
 			return false
 		}
 
-		m.message = m.messages[m.listPtr]
+		m.message = &m.messages[m.listPtr]
 		m.listPtr++
 		return true
 	}

--- a/backend/pkg/messages/type-filter.go
+++ b/backend/pkg/messages/type-filter.go
@@ -1,0 +1,21 @@
+package messages
+
+type TypeFilter [128]bool
+
+func NewTypeFilter(types []int) *TypeFilter {
+	f := &TypeFilter{}
+	f.Add(types)
+	return f
+}
+
+func (f *TypeFilter) Add(types []int) {
+	for _, t := range types {
+		if t >= 0 && t < len(f) {
+			f[t] = true
+		}
+	}
+}
+
+func (f *TypeFilter) Has(t int) bool {
+	return t >= 0 && t < len(f) && f[t]
+}

--- a/backend/pkg/sdk/service/users.go
+++ b/backend/pkg/sdk/service/users.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 
 	"openreplay/backend/pkg/logger"
@@ -16,6 +17,12 @@ import (
 )
 
 var ErrUserNotFound = errors.New("user not found")
+
+var asyncInsertCtx = clickhouse.Context(context.Background(),
+	clickhouse.WithSettings(clickhouse.Settings{
+		"async_insert":          1,
+		"wait_for_async_insert": 0,
+	}))
 
 type Users interface {
 	Add(session *sessions.Session, user *model.User) error
@@ -79,7 +86,7 @@ func (u *usersImpl) Add(session *sessions.Session, user *model.User) error {
 
 func (u *usersImpl) add(session *sessions.Session, user *model.User) error {
 	u.log.Debug(context.Background(), "sess: %d,user to insert: %+v", session.SessionID, user)
-	if err := u.conn.Exec(context.Background(), insertQuery,
+	if err := u.conn.Exec(asyncInsertCtx, insertQuery,
 		session.ProjectID,
 		user.UserID,
 		user.Email,              // $email
@@ -114,7 +121,7 @@ func (u *usersImpl) add(session *sessions.Session, user *model.User) error {
 		return fmt.Errorf("can't insert user to users table: %s", err)
 	}
 	query := `INSERT INTO product_analytics.users_distinct_id (project_id, distinct_id, "$user_id") VALUES (?, ?, ?)`
-	if err := u.conn.Exec(context.Background(), query, session.ProjectID, session.UserUUID, user.UserID); err != nil {
+	if err := u.conn.Exec(asyncInsertCtx, query, session.ProjectID, session.UserUUID, user.UserID); err != nil {
 		return fmt.Errorf("can't insert user to users_distinct_id table: %s", err)
 	}
 	return nil
@@ -122,7 +129,7 @@ func (u *usersImpl) add(session *sessions.Session, user *model.User) error {
 
 func (u *usersImpl) addUserDistinctID(session *sessions.Session, user *model.User) error {
 	query := `INSERT INTO product_analytics.users_distinct_id (project_id, distinct_id, "$user_id") VALUES (?, ?, ?)`
-	if err := u.conn.Exec(context.Background(), query, session.ProjectID, session.UserUUID, user.UserID); err != nil {
+	if err := u.conn.Exec(asyncInsertCtx, query, session.ProjectID, session.UserUUID, user.UserID); err != nil {
 		return fmt.Errorf("can't insert user to users_distinct_id table: %s", err)
 	}
 	return nil
@@ -159,7 +166,7 @@ func (u *usersImpl) Create(session *sessions.Session, user *model.User) error {
 
 func (u *usersImpl) Update(user *model.User) error {
 	u.log.Debug(context.Background(), "user to update: %+v", user)
-	if err := u.conn.Exec(context.Background(), insertQuery,
+	if err := u.conn.Exec(asyncInsertCtx, insertQuery,
 		user.ProjectID,
 		user.UserID,
 		user.Email,              // $email
@@ -198,5 +205,5 @@ func (u *usersImpl) Update(user *model.User) error {
 
 func (u *usersImpl) Delete(projectID uint32, userID string) error {
 	query := `INSERT INTO product_analytics.users (project_id, "$user_id", _deleted_at) VALUES (?, ?, ?)`
-	return u.conn.Exec(context.Background(), query, projectID, userID, time.Now())
+	return u.conn.Exec(asyncInsertCtx, query, projectID, userID, time.Now())
 }

--- a/ee/backend/pkg/kafka/producer.go
+++ b/ee/backend/pkg/kafka/producer.go
@@ -24,6 +24,7 @@ func NewProducer(messageSizeLimit int, useBatch bool) *Producer {
 		"enable.idempotence":                    true,
 		"bootstrap.servers":                     env.String("KAFKA_SERVERS"),
 		"go.delivery.reports":                   env.Bool("KAFKA_DELIVERY_REPORTS"),
+		"go.delivery.report.fields":             "key",
 		"security.protocol":                     "plaintext",
 		"go.batch.producer":                     useBatch,
 		"message.max.bytes":                     messageSizeLimit, // should be synced with broker config

--- a/mobs/templates/backend~pkg~messages~read-message.go.erb
+++ b/mobs/templates/backend~pkg~messages~read-message.go.erb
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 <% $messages.each do |msg| %>
-func Decode<%= msg.name %>(reader BytesReader) (Message, error) {
+func Decode<%= msg.name %>(reader *bytesReaderImpl) (Message, error) {
     var err error = nil
     msg := &<%= msg.name %>{}
     <%= msg.attributes.map { |attr|
@@ -15,7 +15,7 @@ func Decode<%= msg.name %>(reader BytesReader) (Message, error) {
         return msg, err
 }
 <% end %>
-func ReadMessage(t uint64, reader BytesReader) (Message, error) {
+func ReadMessage(t uint64, reader *bytesReaderImpl) (Message, error) {
 	switch t {<% $messages.each do |msg| %>
 	case <%= msg.id %>:
 		return Decode<%= msg.name %>(reader)<% end %>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved message parsing to cut allocations and speed up batch processing, with safer decoding to prevent panics and correct timestamps when autoDecode=false. Also enabled async ClickHouse inserts and trimmed Kafka delivery reports for lower overhead.

- **Refactors**
  - Reworked `backend/pkg/messages` pipeline: added `TypeFilter` bitmap, resettable `BytesReader`, `MessageReader.Reset`, and zero-copy raw message slicing; decoders now accept `*bytesReaderImpl`.
  - Iterator now reuses a persistent reader and prefilter; uses `RawMessage.MobileTimestamp()` to get correct mobile timestamps without full decode when `autoDecode=false`.
  - Cleaned logger output by removing duplicate level fields.
  - ClickHouse writes are now async via `github.com/ClickHouse/clickhouse-go/v2` context; Kafka producer limits delivery report fields to `key` (`go.delivery.report.fields: key`).

- **Bug Fixes**
  - Added safe Decode() type assertions across web/mobile detectors to avoid panics on malformed messages.
  - Fixed unknown batch type logging to use `batch.Info()`.
  - Ensured correct timestamp handling for mobile messages when not auto-decoding.

<sup>Written for commit b76ddef8b989d0e05db7bafb6ee10fea0de3b59d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

