### PR TITLE
OR 3620 s3 upload fatal

### DIFF
--- a/backend/cmd/storage/main.go
+++ b/backend/cmd/storage/main.go
@@ -99,6 +99,11 @@ func main() {
 			srv.Wait()
 			consumer.Close()
 			os.Exit(0)
+		case err := <-srv.FatalCh():
+			log.Error(ctx, "fatal upload error, shutting down: %v", err)
+			srv.Wait()
+			consumer.Close()
+			os.Exit(1)
 		case <-counterTick:
 			log.Info(ctx, "count: %d", counter)
 			counter = 0

--- a/backend/pkg/objectstorage/errors.go
+++ b/backend/pkg/objectstorage/errors.go
@@ -1,0 +1,23 @@
+package objectstorage
+
+import "fmt"
+
+// FatalUploadError wraps upload errors that indicate non-recoverable auth failures (401/403).
+// Callers should terminate the process when encountering this error.
+type FatalUploadError struct {
+	StatusCode int
+	Cause      error
+}
+
+func (e *FatalUploadError) Error() string {
+	return fmt.Sprintf("fatal upload error (HTTP %d): %v", e.StatusCode, e.Cause)
+}
+
+func (e *FatalUploadError) Unwrap() error {
+	return e.Cause
+}
+
+// IsFatalStatusCode returns true for HTTP status codes indicating credential/auth failure.
+func IsFatalStatusCode(code int) bool {
+	return code == 401 || code == 403
+}

--- a/backend/pkg/objectstorage/errors_test.go
+++ b/backend/pkg/objectstorage/errors_test.go
@@ -1,0 +1,57 @@
+package objectstorage
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestFatalUploadError(t *testing.T) {
+	cause := fmt.Errorf("access denied")
+	fatal := &FatalUploadError{StatusCode: 403, Cause: cause}
+
+	// Error message includes status code and cause
+	if fatal.Error() != "fatal upload error (HTTP 403): access denied" {
+		t.Errorf("unexpected error message: %s", fatal.Error())
+	}
+
+	// Unwrap returns cause
+	if !errors.Is(fatal, cause) {
+		t.Error("Unwrap should return cause")
+	}
+
+	// errors.As works
+	var target *FatalUploadError
+	if !errors.As(fatal, &target) {
+		t.Error("errors.As should match FatalUploadError")
+	}
+	if target.StatusCode != 403 {
+		t.Errorf("expected 403, got %d", target.StatusCode)
+	}
+
+	// Wrapped in another error, still detectable
+	wrapped := fmt.Errorf("upload failed: %w", fatal)
+	var target2 *FatalUploadError
+	if !errors.As(wrapped, &target2) {
+		t.Error("errors.As should match through wrapping")
+	}
+}
+
+func TestIsFatalStatusCode(t *testing.T) {
+	tests := []struct {
+		code  int
+		fatal bool
+	}{
+		{200, false},
+		{400, false},
+		{401, true},
+		{403, true},
+		{404, false},
+		{500, false},
+	}
+	for _, tt := range tests {
+		if got := IsFatalStatusCode(tt.code); got != tt.fatal {
+			t.Errorf("IsFatalStatusCode(%d) = %v, want %v", tt.code, got, tt.fatal)
+		}
+	}
+}

--- a/backend/pkg/objectstorage/s3/s3.go
+++ b/backend/pkg/objectstorage/s3/s3.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	_session "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -93,6 +94,13 @@ func (s *storageImpl) Upload(reader io.Reader, key string, contentType, contentE
 		ContentEncoding: encoding,
 		Tagging:         s.fileTag,
 	})
+	if err != nil {
+		if reqErr, ok := err.(awserr.RequestFailure); ok {
+			if objectstorage.IsFatalStatusCode(reqErr.StatusCode()) {
+				return &objectstorage.FatalUploadError{StatusCode: reqErr.StatusCode(), Cause: err}
+			}
+		}
+	}
 	return err
 }
 

--- a/backend/pkg/storage/storage.go
+++ b/backend/pkg/storage/storage.go
@@ -24,6 +24,7 @@ type Uploader interface {
 	Upload(ctx context.Context, sessionID uint64, encryptionKey string) error
 	Clean(ctx context.Context, sessionID uint64) error
 	Wait()
+	FatalCh() <-chan error
 }
 
 type uploadTask struct {
@@ -39,6 +40,7 @@ type uploaderImpl struct {
 	objStorage   objectstorage.ObjectStorage
 	uploaderPool pool.WorkerPool
 	metrics      storageMetrics.Storage
+	fatalCh      chan error
 }
 
 func New(cfg *config.Config, log logger.Logger, objStorage objectstorage.ObjectStorage, metrics storageMetrics.Storage) (Uploader, error) {
@@ -53,6 +55,7 @@ func New(cfg *config.Config, log logger.Logger, objStorage objectstorage.ObjectS
 		log:        log,
 		objStorage: objStorage,
 		metrics:    metrics,
+		fatalCh:    make(chan error, 1),
 	}
 	s.uploaderPool = pool.NewPool(cfg.NumberOfWorkers, cfg.NumberOfWorkers, s.uploadSession)
 	return s, nil
@@ -129,6 +132,15 @@ func (u *uploaderImpl) uploadSession(payload interface{}) {
 		u.metrics.RecordSessionUploadDuration(float64(time.Since(start).Milliseconds()), fileType, mode)
 		if err == nil {
 			u.metrics.IncreaseStorageTotalSessions(fileType)
+		}
+		if err != nil {
+			var fatalErr *objectstorage.FatalUploadError
+			if errors.As(err, &fatalErr) {
+				select {
+				case u.fatalCh <- err:
+				default:
+				}
+			}
 		}
 		return err
 	}
@@ -214,6 +226,10 @@ func (u *uploaderImpl) Clean(ctx context.Context, sessionID uint64) (err error) 
 
 func (u *uploaderImpl) Wait() {
 	u.uploaderPool.Pause()
+}
+
+func (u *uploaderImpl) FatalCh() <-chan error {
+	return u.fatalCh
 }
 
 func (u *uploaderImpl) streamZstdToS3(name, srcPath string) error {

--- a/ee/backend/pkg/objectstorage/azure/azure.go
+++ b/ee/backend/pkg/objectstorage/azure/azure.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -76,6 +77,12 @@ func (s *storageImpl) Upload(reader io.Reader, key string, contentType, contentE
 		},
 		Tags: s.tags,
 	})
+	if err != nil {
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && objectstorage.IsFatalStatusCode(respErr.StatusCode) {
+			return &objectstorage.FatalUploadError{StatusCode: respErr.StatusCode, Cause: err}
+		}
+	}
 	return err
 }
 


### PR DESCRIPTION
    S3 upload auth failures (401/403) are non-recoverable without new
    credentials. Previously these were logged and swallowed, leaving the
    service in a broken state processing messages it can never upload.

    - Add FatalUploadError sentinel type in objectstorage package
    - Detect 401/403 from AWS SDK (awserr.RequestFailure) in s3.Upload()
    - Detect 401/403 from Azure SDK (azcore.ResponseError) in azure.Upload()
    - Signal fatal errors via FatalCh channel for clean shutdown
    - Wire FatalCh in storage cmd main loop: drain pool, close consumer,
      exit with code 1 so k8s restarts the pod with fresh credentials
