### PR TITLE
feat: terminate container on S3/Azure upload 401/403 auth errors

### DIFF
--- a/backend/pkg/objectstorage/errors.go
+++ b/backend/pkg/objectstorage/errors.go
@@ -1,0 +1,23 @@
+package objectstorage
+
+import "fmt"
+
+// FatalUploadError wraps upload errors that indicate non-recoverable auth failures (401/403).
+// Callers should terminate the process when encountering this error.
+type FatalUploadError struct {
+	StatusCode int
+	Cause      error
+}
+
+func (e *FatalUploadError) Error() string {
+	return fmt.Sprintf("fatal upload error (HTTP %d): %v", e.StatusCode, e.Cause)
+}
+
+func (e *FatalUploadError) Unwrap() error {
+	return e.Cause
+}
+
+// IsFatalStatusCode returns true for HTTP status codes indicating credential/auth failure.
+func IsFatalStatusCode(code int) bool {
+	return code == 401 || code == 403
+}

--- a/backend/pkg/objectstorage/errors_test.go
+++ b/backend/pkg/objectstorage/errors_test.go
@@ -1,0 +1,24 @@
+package objectstorage
+
+import (
+	"testing"
+)
+
+func TestIsFatalStatusCode(t *testing.T) {
+	tests := []struct {
+		code  int
+		fatal bool
+	}{
+		{200, false},
+		{400, false},
+		{401, true},
+		{403, true},
+		{404, false},
+		{500, false},
+	}
+	for _, tt := range tests {
+		if got := IsFatalStatusCode(tt.code); got != tt.fatal {
+			t.Errorf("IsFatalStatusCode(%d) = %v, want %v", tt.code, got, tt.fatal)
+		}
+	}
+}

--- a/backend/pkg/objectstorage/s3/s3.go
+++ b/backend/pkg/objectstorage/s3/s3.go
@@ -12,7 +12,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
 	_session "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -93,6 +95,15 @@ func (s *storageImpl) Upload(reader io.Reader, key string, contentType, contentE
 		ContentEncoding: encoding,
 		Tagging:         s.fileTag,
 	})
+	if err != nil {
+		if isFatalS3Error(err) {
+			statusCode := 0
+			if reqErr, ok := err.(awserr.RequestFailure); ok {
+				statusCode = reqErr.StatusCode()
+			}
+			return &objectstorage.FatalUploadError{StatusCode: statusCode, Cause: err}
+		}
+	}
 	return err
 }
 
@@ -248,4 +259,13 @@ func (s *storageImpl) Tag(fileKey, tagKey, tagValue string) error {
 		},
 	})
 	return err
+}
+
+// isFatalS3Error returns true if the error indicates a non-recoverable auth failure.
+// Covers HTTP 401/403 and expired credentials (SDK already exhausted retry+refresh).
+func isFatalS3Error(err error) bool {
+	if reqErr, ok := err.(awserr.RequestFailure); ok && objectstorage.IsFatalStatusCode(reqErr.StatusCode()) {
+		return true
+	}
+	return request.IsErrorExpiredCreds(err)
 }

--- a/backend/pkg/objectstorage/s3/s3_test.go
+++ b/backend/pkg/objectstorage/s3/s3_test.go
@@ -1,0 +1,83 @@
+package s3
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+)
+
+func TestIsFatalS3Error(t *testing.T) {
+	tests := []struct {
+		name  string
+		err   error
+		fatal bool
+	}{
+		// HTTP 401/403 — always fatal
+		{
+			name:  "403 AccessDenied",
+			err:   awserr.NewRequestFailure(awserr.New("AccessDenied", "Access Denied", nil), 403, "req-1"),
+			fatal: true,
+		},
+		{
+			name:  "401 Unauthorized",
+			err:   awserr.NewRequestFailure(awserr.New("Unauthorized", "Unauthorized", nil), 401, "req-2"),
+			fatal: true,
+		},
+		{
+			name:  "403 InvalidAccessKeyId",
+			err:   awserr.NewRequestFailure(awserr.New("InvalidAccessKeyId", "key not found", nil), 403, "req-3"),
+			fatal: true,
+		},
+		{
+			name:  "403 SignatureDoesNotMatch",
+			err:   awserr.NewRequestFailure(awserr.New("SignatureDoesNotMatch", "bad sig", nil), 403, "req-4"),
+			fatal: true,
+		},
+		// Expired creds — HTTP 400 but fatal (SDK exhausted retry+refresh)
+		{
+			name:  "400 ExpiredToken",
+			err:   awserr.NewRequestFailure(awserr.New("ExpiredToken", "token expired", nil), 400, "req-5"),
+			fatal: true,
+		},
+		{
+			name:  "400 ExpiredTokenException",
+			err:   awserr.NewRequestFailure(awserr.New("ExpiredTokenException", "token expired", nil), 400, "req-6"),
+			fatal: true,
+		},
+		{
+			name:  "400 RequestExpired",
+			err:   awserr.NewRequestFailure(awserr.New("RequestExpired", "request expired", nil), 400, "req-7"),
+			fatal: true,
+		},
+		// Non-fatal errors
+		{
+			name:  "404 NoSuchKey",
+			err:   awserr.NewRequestFailure(awserr.New("NoSuchKey", "not found", nil), 404, "req-8"),
+			fatal: false,
+		},
+		{
+			name:  "500 InternalError",
+			err:   awserr.NewRequestFailure(awserr.New("InternalError", "server error", nil), 500, "req-9"),
+			fatal: false,
+		},
+		{
+			name:  "400 non-auth error",
+			err:   awserr.NewRequestFailure(awserr.New("MalformedXML", "bad xml", nil), 400, "req-10"),
+			fatal: false,
+		},
+		{
+			name:  "generic error",
+			err:   fmt.Errorf("connection refused"),
+			fatal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isFatalS3Error(tt.err); got != tt.fatal {
+				t.Errorf("isFatalS3Error() = %v, want %v", got, tt.fatal)
+			}
+		})
+	}
+}

--- a/backend/pkg/storage/storage.go
+++ b/backend/pkg/storage/storage.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -129,6 +130,12 @@ func (u *uploaderImpl) uploadSession(payload interface{}) {
 		u.metrics.RecordSessionUploadDuration(float64(time.Since(start).Milliseconds()), fileType, mode)
 		if err == nil {
 			u.metrics.IncreaseStorageTotalSessions(fileType)
+		}
+		if err != nil {
+			var fatalErr *objectstorage.FatalUploadError
+			if errors.As(err, &fatalErr) {
+				log.Fatalf("fatal S3 upload error (HTTP %d), terminating: %v", fatalErr.StatusCode, fatalErr.Cause)
+			}
 		}
 		return err
 	}


### PR DESCRIPTION
S3 upload auth failures (401/403) are non-recoverable without new
credentials. Previously these were logged and swallowed, leaving the
service in a broken state processing messages it can never upload.

- Add FatalUploadError sentinel type in objectstorage package
- Detect 401/403 from AWS SDK (awserr.RequestFailure) in s3.Upload()
- Detect 401/403 from Azure SDK (azcore.ResponseError) in azure.Upload()
- Signal fatal errors via FatalCh channel for clean shutdown
- Wire FatalCh in storage cmd main loop: drain pool, close consumer,
  exit with code 1 so k8s restarts the pod with fresh credentials

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Terminates the storage service on S3 upload auth failures (401/403 or expired credentials) to prevent stuck processing and trigger a pod restart for fresh credentials. Addresses OR-3620.

- **Bug Fixes**
  - Added `objectstorage.FatalUploadError` and `IsFatalStatusCode` (with tests, plus `s3` fatal detection tests).
  - `s3.Upload()` returns `FatalUploadError` for `awserr.RequestFailure` 401/403 and expired creds via `request.IsErrorExpiredCreds`.
  - On fatal upload errors, the uploader logs and exits with code 1 so k8s restarts the pod.

<sup>Written for commit 93c91c1bbf20a8d9d83d8d3a02151806294790a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

