### PR TITLE
ui: normalize selected inputs

### DIFF
--- a/frontend/app/components/Session_/UnitStepsModal/index.tsx
+++ b/frontend/app/components/Session_/UnitStepsModal/index.tsx
@@ -50,6 +50,21 @@ interface MultiInputEntry {
   elements: { parentSelector: string; index: number; value: string }[];
 }
 
+function normalizeSelector(selector: string): string {
+  return selector.replace(
+    /\[\s*([-\w:]+)\s*([~|^$*]?=)\s*([^\]]*?)\s*\]/g,
+    (_full, attr, op, rawValue) => {
+      const value = rawValue.trim();
+      const alreadyQuoted =
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"));
+      if (alreadyQuoted) return `[${attr}${op}${value}]`;
+      const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      return `[${attr}${op}"${escaped}"]`;
+    },
+  );
+}
+
 function getParentSelector(el: Element): string {
   const parent = el.parentElement;
   if (!parent || parent === el.ownerDocument.body) return '';
@@ -209,7 +224,7 @@ function UnitStepsModal({ onClose }: Props) {
 
         try {
           const allEls = Array.from(
-            doc.querySelectorAll(ev.label),
+            doc.querySelectorAll(normalizeSelector(ev.label)),
           ) as HTMLInputElement[];
 
           if (allEls.length > 1) {
@@ -301,7 +316,7 @@ function UnitStepsModal({ onClose }: Props) {
       const doc = screenObj?.document;
       if (!doc) return;
       try {
-        const els = doc.querySelectorAll(selector);
+        const els = doc.querySelectorAll(normalizeSelector(selector));
         const el = els[index] as HTMLElement | undefined;
         if (el) {
           screenObj?.highlightElement(el);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Normalize CSS attribute selectors in UnitStepsModal to prevent invalid selector errors and make input selection and highlighting reliable.

- **Bug Fixes**
  - Added a normalizeSelector helper that trims, quotes, and escapes attribute values in selectors.
  - Applied normalization to all querySelectorAll calls for event labels and element highlighting.

<sup>Written for commit f5053dfd2df25f07ba5dd2f0bf0f53f73492e6ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

