### PR TITLE
Fix kubectl version skew and removed --short flag in openreplay-cli

### DIFF
--- a/scripts/helmcharts/openreplay-cli
+++ b/scripts/helmcharts/openreplay-cli
@@ -174,7 +174,7 @@ function install_packages() {
     log info Installing helm
     sudo /var/lib/openreplay/eget -q --upgrade-only --to "$OR_DIR" https://get.helm.sh/helm-v3.10.2-linux-${pkg_type}.tar.gz -f helm
     log info Installing kubectl
-    sudo /var/lib/openreplay/eget -q --upgrade-only --to "$OR_DIR" https://dl.k8s.io/release/v1.25.0/bin/linux/${pkg_type}/kubectl
+    sudo /var/lib/openreplay/eget -q --upgrade-only --to "$OR_DIR" https://dl.k8s.io/release/v1.31.5/bin/linux/${pkg_type}/kubectl
     command -v busybox || {
         [[ $pkg_type != "arm64" ]] && {
             log info Installing Busybox
@@ -240,7 +240,7 @@ function status() {
     awk '(NR<2)' </etc/os-release
     echo "CPU Count: $(nproc)"
     log info Kubernetes
-    kubecolor version --short
+    kubecolor version --short 2>/dev/null || kubecolor version
     log info Openreplay Component
     kubecolor get po -n "${APP_NS}"
     kubecolor get po -n "${DB_NS}"


### PR DESCRIPTION
- Bump pinned kubectl download from v1.25.0 to v1.31.5 to match the k3s version recommended in the upgrade docs
- Make the kubecolor version check in status() fall back to the non---short form, since --short was removed from upstream kubectl

Fixes: https://github.com/openreplay/openreplay/issues/4758

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `kubectl` to v1.31.5 to match `k3s` and make `openreplay-cli status` handle the removed `--short` flag. We now try `kubecolor version --short` and fall back to `kubecolor version` to avoid failures.

<sup>Written for commit c99c087240a8b9fc73ba1e061f8ae2ca1007f25a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

