### PR TITLE
Sink optimization for mobile sessions

### DIFF
--- a/backend/pkg/messages/batch-iterator-assets.go
+++ b/backend/pkg/messages/batch-iterator-assets.go
@@ -22,13 +22,13 @@ func NewAssetsBatchIterator(log logger.Logger, batchHandler BatchHandler, messag
 func (b *assetsBatchIteratorImpl) Iterate(batchData []byte, batch *BatchInfo) {
 	ctx := context.WithValue(context.Background(), "sessionID", batch.sessionID)
 
-	batchType, batchTimestamp, err := getBatchType(batchData)
+	meta, err := getBatchType(batchData)
 	if err != nil {
 		b.log.Error(ctx, "failed to read batch meta: %s", err)
 		return
 	}
-	batch.version = batchType
-	batch.dataTs = batchTimestamp
+	batch.version = meta.batchType
+	batch.dataTs = meta.timestamp
 
 	switch batch.Type() {
 	case RawData, FullBatch:
@@ -36,6 +36,6 @@ func (b *assetsBatchIteratorImpl) Iterate(batchData []byte, batch *BatchInfo) {
 	case AssetsBatch:
 		b.batchHandler(batchData, batch)
 	default:
-		b.log.Error(ctx, "unknown batch type: %d, info: %s", batchType, batch.Info())
+		b.log.Error(ctx, "unknown batch type: %d, info: %s", meta.batchType, batch.Info())
 	}
 }

--- a/backend/pkg/messages/batch-reader.go
+++ b/backend/pkg/messages/batch-reader.go
@@ -31,13 +31,24 @@ func NewBatchIterator(log logger.Logger, batchHandler BatchHandler, messageItera
 func (b *batchIteratorImpl) Iterate(batchData []byte, batch *BatchInfo) {
 	ctx := context.WithValue(context.Background(), "sessionID", batch.sessionID)
 
-	batchType, batchTimestamp, err := getBatchType(batchData)
+	meta, err := getBatchType(batchData)
 	if err != nil {
 		b.log.Error(ctx, "failed to read batch meta: %s", err)
 		return
 	}
-	batch.version = batchType
-	batch.dataTs = batchTimestamp
+	batch.version = meta.batchType
+	batch.dataTs = meta.timestamp
+
+	if meta.mobileWriteEnd >= 0 {
+		if meta.mobileWriteEnd == 0 {
+			// Replay slice is empty (Length == len(MobileBatchMeta)): nothing for the mob file.
+			return
+		}
+		// Raw format (like web player batches): headerV2 + domS/domE routing in MobWriter.
+		batch.SetType(PlayerBatch)
+		b.batchHandler(batchData[:meta.mobileWriteEnd], batch)
+		return
+	}
 
 	switch batch.Type() {
 	case RawData, FullBatch:
@@ -45,35 +56,62 @@ func (b *batchIteratorImpl) Iterate(batchData []byte, batch *BatchInfo) {
 	case PlayerBatch, AssetsBatch, DevtoolsBatch, AnalyticsBatch:
 		b.batchHandler(batchData, batch)
 	default:
-		b.log.Error(ctx, "unknown batch type: %d, info: %s", batchType, batch.Info())
+		b.log.Error(ctx, "unknown batch type: %d, info: %s", meta.batchType, batch.Info())
 	}
 }
 
-func getBatchType(data []byte) (uint64, int64, error) {
+type batchMeta struct {
+	batchType      uint64
+	timestamp      int64
+	mobileWriteEnd int
+}
+
+func getBatchType(data []byte) (batchMeta, error) {
+	meta := batchMeta{mobileWriteEnd: -1}
 	if len(data) == 0 {
-		return 0, 0, errors.New("empty batch meta")
+		return meta, errors.New("empty batch meta")
 	}
 	reader := NewBytesReader(data)
 	msgType, err := reader.ReadUint()
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to read message type: %w", err)
+		return meta, fmt.Errorf("failed to read message type: %w", err)
 	}
 	switch msgType {
 	case MsgBatchMetadata:
 		msg, err := DecodeBatchMetadata(reader)
 		if err != nil {
-			return 0, 0, fmt.Errorf("failed to decode web batch metadata: %w", err)
+			return meta, fmt.Errorf("failed to decode web batch metadata: %w", err)
 		}
 		metadata := msg.(*BatchMetadata)
-		return metadata.Version, metadata.Timestamp, nil
+		meta.batchType = metadata.Version
+		meta.timestamp = metadata.Timestamp
+		return meta, nil
 	case MsgMobileBatchMeta:
 		msg, err := DecodeMobileBatchMeta(reader)
 		if err != nil {
-			return 0, 0, fmt.Errorf("failed to decode mobile batch metadata: %w", err)
+			return meta, fmt.Errorf("failed to decode mobile batch metadata: %w", err)
 		}
 		metadata := msg.(*MobileBatchMeta)
-		return uint64(FullBatch), int64(metadata.Timestamp), nil
+		meta.batchType = uint64(FullBatch)
+		meta.timestamp = int64(metadata.Timestamp)
+
+		metaLen := int(reader.Pointer())
+		length := int(metadata.Length)
+		switch {
+		case length < metaLen:
+			// old tracker: keep mobileWriteEnd == -1, parse every message as before.
+		case length == metaLen:
+			// new tracker, empty replay slice: nothing to write to the mob file.
+			meta.mobileWriteEnd = 0
+		case length <= len(data):
+			// new tracker: write data[0:length] raw to the mob file.
+			meta.mobileWriteEnd = length
+		default:
+			// fall back to full parse to avoid losing data.
+		}
+		return meta, nil
 	default:
-		return uint64(RawData), 0, nil
+		meta.batchType = uint64(RawData)
+		return meta, nil
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Optimize mobile sink by writing new mobile tracker batches directly to the mob file without parsing to cut CPU and latency. Keeps backward compatibility by falling back to full parsing for old trackers and malformed payloads.

- **New Features**
  - Updated `getBatchType` to return `batchMeta` (`batchType`, `timestamp`, `mobileWriteEnd`) and switched readers, including `assetsBatchIterator`, to use it.
  - For `MsgMobileBatchMeta`, compute `mobileWriteEnd`; if > 0, set `PlayerBatch` and pass `batchData[:mobileWriteEnd]` to `batchHandler`; if 0, no-op (empty replay slice).
  - Fallback: if `Length` is smaller than header or exceeds buffer, parse all messages as before; unknown types default to `RawData`.

<sup>Written for commit 00de4984b39115fc6616614163a4ad4c38e04002. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

