### PR TITLE
SCIM fix

### DIFF
--- a/ee/api/chalicelib/utils/scim_auth.py
+++ b/ee/api/chalicelib/utils/scim_auth.py
@@ -20,7 +20,7 @@ if len(ACCESS_SECRET_KEY) == 0:
 
 
 def create_tokens(tenant_id):
-    if len(ACCESS_SECRET_KEY) == 0:
+    if len(ACCESS_SECRET_KEY) == 0 or len(REFRESH_SECRET_KEY) == 0:
         logger.warning("!!! SCIM not configured")
         raise HTTPException(status_code=401, detail="SCIM not configured")
 

--- a/ee/api/chalicelib/utils/scim_auth.py
+++ b/ee/api/chalicelib/utils/scim_auth.py
@@ -42,6 +42,8 @@ def create_tokens(tenant_id):
 
 
 def verify_access_token(token: str):
+    if len(ACCESS_SECRET_KEY) == 0:
+        raise HTTPException(status_code=401, detail="SCIM not configured")
     try:
         payload = jwt.decode(
             token, ACCESS_SECRET_KEY, algorithms=[ALGORITHM], audience=users.AUDIENCE
@@ -54,6 +56,8 @@ def verify_access_token(token: str):
 
 
 def verify_refresh_token(token: str):
+    if len(REFRESH_SECRET_KEY) == 0:
+        raise HTTPException(status_code=401, detail="SCIM not configured")
     try:
         payload = jwt.decode(
             token, REFRESH_SECRET_KEY, algorithms=[ALGORITHM], audience=users.AUDIENCE

--- a/ee/api/routers/scim/groups.py
+++ b/ee/api/routers/scim/groups.py
@@ -299,14 +299,17 @@ def restore_resource(tenant_id: int, resource: Resource) -> dict | None:
                         COALESCE(
                         (SELECT json_agg(users)
                          FROM public.users
-                         WHERE users.role_id = roles.role_id),
+                         WHERE users.tenant_id = %(tenant_id)s
+                            AND (users.role_id = roles.role_id
+                                    OR users.admin_privilege_role_id = roles.role_id)),
                         '[]'
                     ) AS users,
                     COALESCE(
                         (SELECT json_agg(projects.project_key)
                          FROM public.projects
                          LEFT JOIN public.roles_projects USING (project_id)
-                         WHERE roles_projects.role_id = roles.role_id),
+                         WHERE tenant_id = %(tenant_id)s
+                            AND roles_projects.role_id = roles.role_id),
                         '[]'
                     ) AS project_keys
                 """,

--- a/ee/api/routers/scim/groups.py
+++ b/ee/api/routers/scim/groups.py
@@ -202,6 +202,7 @@ def _set_users_role(tenant_id: int, user_ids: list[int], new_role_id: int | None
             constraints.append("users.user_id IN %(user_ids)s")
         if len(constraints) == 1:
             return
+        constraints.append("users.tenant_id = %(tenant_id)s")
         cur.execute(
             cur.mogrify(
                 f"""\
@@ -224,6 +225,7 @@ def _set_users_admin_privilege(tenant_id: int, user_ids: list[int],
         constraints.append("users.user_id IN %(user_ids)s")
     if len(constraints) == 1:
         return
+    constraints.append("users.tenant_id = %(tenant_id)s")
     with pg_client.PostgresClient() as cur:
         params = {
             "tenant_id": tenant_id,
@@ -292,7 +294,8 @@ def restore_resource(tenant_id: int, resource: Resource) -> dict | None:
                 UPDATE public.roles
                 SET deleted_at = NULL
                 WHERE role_id = %(role_id)s
-                  AND NOT protected RETURNING roles.*, 
+                  AND tenant_id = %(tenant_id)s
+                  AND NOT protected RETURNING roles.*,
                         COALESCE(
                         (SELECT json_agg(users)
                          FROM public.users
@@ -307,7 +310,7 @@ def restore_resource(tenant_id: int, resource: Resource) -> dict | None:
                         '[]'
                     ) AS project_keys
                 """,
-                {"role_id": resource.id},
+                {"role_id": resource.id, "tenant_id": tenant_id},
             )
         )
         item = cur.fetchone()

--- a/ee/api/routers/scim/providers.py
+++ b/ee/api/routers/scim/providers.py
@@ -22,6 +22,7 @@ from scim2_models import (
 from scim2_server import provider
 from scim2_models import SCIMException
 from scim2_server.utils import merge_resources
+from fastapi import HTTPException as FastAPIHTTPException
 from werkzeug import Request, Response
 from werkzeug.exceptions import HTTPException, NotFound, PreconditionFailed
 from werkzeug.routing.exceptions import RequestRedirect
@@ -36,18 +37,22 @@ class MultiTenantProvider(provider.SCIMProvider):
     def check_auth(self, request: Request):
         logger.debug(f"call processed by check_auth: {request.method} {request.path}")
         auth = request.headers.get("Authorization")
-        if not auth or not auth.startswith("Bearer "):
-            return None
-        token = auth[len("Bearer "):]
+        token = auth[len("Bearer "):] if auth and auth.startswith("Bearer ") else None
         if not token:
             return Response(
                 "Missing or invalid Authorization header",
                 status=401,
                 headers={"WWW-Authenticate": 'Bearer realm="login required"'},
             )
-        payload = verify_access_token(token)
-        tenant_id = payload["tenant_id"]
-        return tenant_id
+        try:
+            payload = verify_access_token(token)
+        except FastAPIHTTPException as e:
+            return Response(
+                e.detail,
+                status=e.status_code,
+                headers={"WWW-Authenticate": 'Bearer realm="login required"'},
+            )
+        return payload["tenant_id"]
 
     def get_service_provider_config(self):
         auth_schemes = [
@@ -259,6 +264,8 @@ class MultiTenantProvider(provider.SCIMProvider):
             if endpoint != "service_provider_config":
                 # RFC7643, Section 5: skip authentication for ServiceProviderConfig
                 tenant_id = self.check_auth(request)
+                if isinstance(tenant_id, Response):
+                    return tenant_id
 
             # Wrap the entire call in a transaction. Should probably be optimized (use transaction only when necessary).
             with self.backend:

--- a/ee/api/routers/scim/users.py
+++ b/ee/api/routers/scim/users.py
@@ -117,8 +117,9 @@ def search_existing(tenant_id: int, resource: Resource) -> dict | None:
                 SELECT *
                 FROM public.users
                 WHERE email = %(email)s
+                  AND tenant_id = %(tenant_id)s
                 """,
-                {"email": resource.user_name},
+                {"email": resource.user_name, "tenant_id": tenant_id},
             )
         )
         item = cur.fetchone()
@@ -144,7 +145,8 @@ def restore_resource(tenant_id: int, resource: Resource) -> dict | None:
                     jwt_iat       = NULL,
                     weekly_report = default
                 WHERE email = %(email)s
-                  AND role!='owner' 
+                  AND tenant_id = %(tenant_id)s
+                  AND role!='owner'
                 RETURNING *
                 """,
                 {
@@ -218,7 +220,7 @@ def update_resource(tenant_id: int, resource: Resource) -> dict | None:
                    "email       = %(email)s",
                    "internal_id = %(internal_id)s",
                    "updated_at  = now()"]
-        constraints = ["user_id = %(user_id)s"]
+        constraints = ["user_id = %(user_id)s", "tenant_id = %(tenant_id)s"]
         if resource.active is False:
             updates.append("deleted_at = now()")
             constraints.append("role!='owner'")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened SCIM auth and enforced tenant scoping for users, groups, and roles to prevent cross-tenant access and return clearer auth errors. Fixes missing/invalid Bearer handling and blocks SCIM when not configured.

- **Bug Fixes**
  - Auth: Return 401 with `WWW-Authenticate` for missing/invalid Bearer; treat unset access/refresh secrets as “SCIM not configured”; map token verify errors to 401; stop processing unauthenticated requests.
  - Tenancy: Add `tenant_id` filters to user search/restore/update and group role/admin updates; scope role restore and its user/project subqueries to the tenant.

<sup>Written for commit 8d5cd85e255a2d29cc7bb96ad56428f5fc0c0353. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

