### PR TITLE
refactor(chalice): refactored SCIM

### DIFF
--- a/api/or_dependencies.py
+++ b/api/or_dependencies.py
@@ -34,7 +34,8 @@ class ORRoute(APIRoute):
                 response: Response = await original_route_handler(request)
             except RequestValidationError as exc:
                 # 422 validation exception
-                logger.warning(f"!!! 422 exception when calling: {sanitize(request.method, max_length=16)} {sanitize(str(request.url))}")
+                logger.warning(
+                    f"!!! 422 exception when calling: {sanitize(request.method, max_length=16)} {sanitize(str(request.url))}")
                 logger.warning(exc.errors())
                 for e in exc.errors():
                     if e.get("msg", "").endswith("must be alphanumeric"):
@@ -45,8 +46,17 @@ class ORRoute(APIRoute):
                 if e.status_code // 100 == 4:
                     return JSONResponse(content={"errors": e.detail if isinstance(e.detail, list) else [e.detail]},
                                         status_code=e.status_code)
+                elif e.status_code // 100 == 5:
+                    logger.error(f"!!! status code:{e.status_code}")
+                    logger.exception(e)
+                    return JSONResponse(content={"errors": ["Internal server error."]},
+                                        status_code=e.status_code)
                 else:
                     raise e
+            except Exception as e:
+                logger.exception(e)
+                return JSONResponse(content={"errors": ["Internal server error."]},
+                                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
             if isinstance(response, JSONResponse):
                 response: JSONResponse = response

--- a/ee/api/app.py
+++ b/ee/api/app.py
@@ -29,6 +29,7 @@ if config("ENABLE_SSO", cast=bool, default=True):
     from routers import saml
     from routers.scim import api as scim
     from routers.scim.middlewares import PrefixMiddleware
+    from chalicelib.utils import SAML2_helper
 
 loglevel = config("LOGLEVEL", default=logging.WARNING)
 print(f">Loglevel set to: {loglevel}")
@@ -199,5 +200,7 @@ if config("ENABLE_SSO", cast=bool, default=True):
     app.include_router(scim.app)
     app.include_router(scim.app_apikey)
 
-    SCIM_MOUNT_PATH = "/sso/scim/v2"
-    app.mount(SCIM_MOUNT_PATH, WSGIMiddleware(PrefixMiddleware(scim.scim_app, SCIM_MOUNT_PATH)))
+    if SAML2_helper.is_scim_configured():
+        logger.info("SCIM configured, mounting endpoints...")
+        SCIM_MOUNT_PATH = "/sso/scim/v2"
+        app.mount(SCIM_MOUNT_PATH, WSGIMiddleware(PrefixMiddleware(scim.scim_app, SCIM_MOUNT_PATH)))

--- a/ee/api/chalicelib/utils/SAML2_helper.py
+++ b/ee/api/chalicelib/utils/SAML2_helper.py
@@ -171,8 +171,14 @@ def get_landing_URL(query_params: dict = None, redirect_to_link2=False):
 environ["hastSAML2"] = str(is_saml2_available())
 
 
+def is_scim_configured():
+    return len(config("SCIM_ACCESS_SECRET_KEY", default="")) > 4 \
+        and len(config("SCIM_REFRESH_SECRET_KEY", default="")) > 4
+
+
 def is_scim_available():
-    return __scim_helpers.is_scim_available()
+    return is_scim_configured() \
+        and __scim_helpers.is_scim_available()
 
 
 def group_name_to_role_name(group_name: str) -> str:

--- a/ee/api/chalicelib/utils/scim_auth.py
+++ b/ee/api/chalicelib/utils/scim_auth.py
@@ -6,6 +6,7 @@ from decouple import config
 from fastapi import HTTPException, Depends
 from fastapi.security import OAuth2PasswordBearer
 from chalicelib.core import users
+from chalicelib.utils import SAML2_helper
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +21,7 @@ if len(ACCESS_SECRET_KEY) == 0:
 
 
 def create_tokens(tenant_id):
-    if len(ACCESS_SECRET_KEY) == 0 or len(REFRESH_SECRET_KEY) == 0:
+    if not SAML2_helper.is_scim_configured():
         logger.warning("!!! SCIM not configured")
         raise HTTPException(status_code=401, detail="SCIM not configured")
 
@@ -42,7 +43,7 @@ def create_tokens(tenant_id):
 
 
 def verify_access_token(token: str):
-    if len(ACCESS_SECRET_KEY) == 0:
+    if not SAML2_helper.is_scim_configured():
         raise HTTPException(status_code=401, detail="SCIM not configured")
     try:
         payload = jwt.decode(
@@ -56,7 +57,7 @@ def verify_access_token(token: str):
 
 
 def verify_refresh_token(token: str):
-    if len(REFRESH_SECRET_KEY) == 0:
+    if not SAML2_helper.is_scim_configured():
         raise HTTPException(status_code=401, detail="SCIM not configured")
     try:
         payload = jwt.decode(

--- a/ee/api/or_dependencies.py
+++ b/ee/api/or_dependencies.py
@@ -43,8 +43,17 @@ class ORRoute(APIRoute):
                 if e.status_code // 100 == 4:
                     return JSONResponse(content={"errors": e.detail if isinstance(e.detail, list) else [e.detail]},
                                         status_code=e.status_code)
+                elif e.status_code // 100 == 5:
+                    logger.error(f"!!! status code:{e.status_code}")
+                    logger.exception(e)
+                    return JSONResponse(content={"errors": ["Internal server error."]},
+                                        status_code=e.status_code)
                 else:
                     raise e
+            except Exception as e:
+                logger.exception(e)
+                return JSONResponse(content={"errors": ["Internal server error."]},
+                                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
             if isinstance(response, JSONResponse):
                 response: JSONResponse = response

--- a/ee/api/routers/scim/providers.py
+++ b/ee/api/routers/scim/providers.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 from typing import Union
 
 from pydantic import ValidationError
@@ -291,5 +290,4 @@ class MultiTenantProvider(provider.SCIMProvider):
             return self.make_error(Error(status=400, detail=str(e)))
         except Exception as e:
             self.log.exception(e)
-            tb = traceback.format_exc()
-            return self.make_error(Error(status=500, detail=str(e) + "\n" + tb))
+            return self.make_error(Error(status=500, detail="Internal server error."))


### PR DESCRIPTION
refactor(chalice): prevent stacktrace leak

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened SCIM and API error handling to prevent stacktrace leaks and only enable SCIM when properly configured. This improves security and avoids exposing internals.

- **Bug Fixes**
  - Return generic 500 errors in SCIM provider and global route handler; log details server-side.
  - Handle 5xx `HTTPException` and catch-all exceptions in `custom_route_handler` with a safe error response.
  - Add `SAML2_helper.is_scim_configured()` and gate SCIM token ops and endpoint mounting behind it; mount SCIM only when secrets are set.

<sup>Written for commit a2b05b213eac7a798b351e5e3eada8826dfcd175. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

