### PR TITLE
refactor(chalice): SCIM auth tracking

### DIFF
--- a/ee/api/routers/scim/api.py
+++ b/ee/api/routers/scim/api.py
@@ -83,16 +83,19 @@ async def post_token(r: Request):
         code = form.get("code")
         with pg_client.PostgresClient() as cur:
             cur.execute(
+                # @formatter:off
                 cur.mogrify(
                     """ \
                     SELECT *
                     FROM public.scim_auth_codes
                     WHERE auth_code = %(auth_code)s
                       AND tenant_id = %(tenant_id)s
-                      AND NOT used LIMIT 1;
+                      AND NOT used 
+                    LIMIT 1;
                     """,
                     {"auth_code": code, "tenant_id": tenant["tenant_id"]},
                 )
+                # @formatter:on
             )
             row = cur.fetchone()
             if row is None:
@@ -103,7 +106,8 @@ async def post_token(r: Request):
                 cur.mogrify(
                     """
                     UPDATE public.scim_auth_codes
-                    SET used= TRUE
+                    SET used= TRUE,
+                        used_for_jwt= TRUE
                     WHERE auth_code = %(auth_code)s
                       AND tenant_id = %(tenant_id)s
                       AND used IS FALSE
@@ -136,14 +140,17 @@ async def get_authorize(
 ):
     with pg_client.PostgresClient() as cur:
         cur.execute(
+            # @formatter:off
             cur.mogrify(
                 """ \
                 SELECT tenant_id
                 FROM public.tenants
-                WHERE tenant_key = %(tenant_key)s LIMIT 1
+                WHERE tenant_key = %(tenant_key)s 
+                LIMIT 1
                 """,
                 {"tenant_key": client_id},
             )
+            # @formatter:on
         )
         tenant_id = cur.fetchone()
         if tenant_id is None:
@@ -151,18 +158,19 @@ async def get_authorize(
         tenant_id = tenant_id["tenant_id"]
 
         cur.execute(
+            # @formatter:off
             cur.mogrify(
                 """ \
-                WITH u AS (
-                UPDATE public.scim_auth_codes
-                SET used= TRUE
-                WHERE tenant_id = %(tenant_id)s )
-                INSERT
-                INTO public.scim_auth_codes (tenant_id)
-                VALUES (%(tenant_id)s) RETURNING auth_code
+                WITH u AS (UPDATE public.scim_auth_codes
+                           SET used= TRUE
+                           WHERE tenant_id = %(tenant_id)s )
+                INSERT INTO public.scim_auth_codes (tenant_id)
+                VALUES (%(tenant_id)s) 
+                RETURNING auth_code
                 """,
                 {"tenant_id": tenant_id},
             )
+            # @formatter:on
         )
         code = cur.fetchone()
     helpers.set_scim_available()

--- a/ee/scripts/schema/db/init_dbs/postgresql/1.28.0/1.28.0.sql
+++ b/ee/scripts/schema/db/init_dbs/postgresql/1.28.0/1.28.0.sql
@@ -26,6 +26,10 @@ DROP TABLE IF EXISTS public.errors;
 DROP TYPE IF EXISTS error_source;
 DROP TYPE IF EXISTS error_status;
 
+
+ALTER TABLE IF EXISTS public.scim_auth_codes
+    ADD COLUMN IF NOT EXISTS used_for_jwt bool DEFAULT NULL;
+
 COMMIT;
 
 \elif :is_next

--- a/ee/scripts/schema/db/init_dbs/postgresql/init_schema.sql
+++ b/ee/scripts/schema/db/init_dbs/postgresql/init_schema.sql
@@ -115,7 +115,8 @@ CREATE TABLE public.scim_auth_codes
     tenant_id    integer                     NOT NULL REFERENCES public.tenants (tenant_id) ON DELETE CASCADE,
     auth_code    text                        NOT NULL UNIQUE DEFAULT generate_api_key(20),
     created_at   timestamp without time zone NOT NULL        DEFAULT (now() at time zone 'utc'),
-    used         bool                        NOT NULL        DEFAULT FALSE
+    used         bool                        NOT NULL        DEFAULT FALSE,
+    used_for_jwt bool                                        DEFAULT NULL
 );
 
 
@@ -1310,7 +1311,7 @@ CREATE UNIQUE INDEX sessions_videos_session_id_project_id_key ON public.sessions
 
 CREATE TABLE public.actions
 (
-    action_id   uuid                        PRIMARY KEY DEFAULT gen_random_uuid(),
+    action_id   uuid PRIMARY KEY                     DEFAULT gen_random_uuid(),
     project_id  integer                     NOT NULL REFERENCES public.projects (project_id) ON DELETE CASCADE,
     user_id     integer                     NULL REFERENCES public.users (user_id) ON DELETE SET NULL,
     name        varchar(255)                NOT NULL,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add explicit tracking for SCIM auth codes used to mint JWTs and ensure previous codes are invalidated before issuing a new one. This improves auditability of SCIM token flows without changing external behavior.

- **Refactors**
  - Added `used_for_jwt` column on `public.scim_auth_codes` to track JWT redemption.
  - On token exchange, mark codes as `used` and `used_for_jwt = TRUE`.
  - Keep existing behavior of marking prior tenant codes as used before inserting a new auth code.

- **Migration**
  - Run DB migration `1.28.0` to add `used_for_jwt` (defaults to NULL). No manual backfill required.

<sup>Written for commit a0f947eba7feaf3a206aee4b6c39d9dbdfeeb295. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

