### PR TITLE
[Storage] fixed the error log's issue

### DIFF
--- a/backend/pkg/storage/storage.go
+++ b/backend/pkg/storage/storage.go
@@ -134,7 +134,7 @@ func (u *uploaderImpl) uploadSession(payload interface{}) {
 	}
 
 	var wg sync.WaitGroup
-	var failedUpload [2]bool
+	var mobsFailed bool
 	var uploadErrors [4]string
 
 	wg.Add(1)
@@ -159,7 +159,7 @@ func (u *uploaderImpl) uploadSession(payload interface{}) {
 		go func() {
 			defer wg.Done()
 			if err := uploadFn(sid+DOM+"s", filePath+"s", "doms"); err != nil {
-				failedUpload[1] = true
+				mobsFailed = true
 				if !IsNotExist(err) {
 					uploadErrors[1] = err.Error()
 				}
@@ -176,7 +176,7 @@ func (u *uploaderImpl) uploadSession(payload interface{}) {
 		go func() {
 			defer wg.Done()
 			if err := uploadFn(sid+DOM+"s", filePath, "doms"); err != nil {
-				failedUpload[0] = true
+				mobsFailed = true
 				if !IsNotExist(err) {
 					uploadErrors[0] = err.Error()
 				}
@@ -185,8 +185,19 @@ func (u *uploaderImpl) uploadSession(payload interface{}) {
 	}
 
 	wg.Wait()
-	if failedUpload[0] && failedUpload[1] {
-		u.log.Error(ctx, "failed to upload session %d, errors: %s", task.sessionID, strings.Join(uploadErrors[:], ","))
+	if mobsFailed {
+		errs := make([]string, 0, len(uploadErrors))
+		for _, e := range uploadErrors {
+			if e != "" {
+				errs = append(errs, e)
+			}
+		}
+		if len(errs) > 0 {
+			u.log.Error(ctx, "failed to upload session %d, errors: %s", task.sessionID, strings.Join(errs, ","))
+		} else {
+			u.log.Debug(ctx, "failed to upload session %d", task.sessionID)
+		}
+
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes session upload error logging in `storage`. Now logs when any DOM upload fails and only includes real error messages, reducing noisy and misleading logs.

- **Bug Fixes**
  - Treats any DOM upload failure as a failed upload (replaces dual-array check with a single flag).
  - Logs only non-empty error messages; falls back to debug when no messages are present.

<sup>Written for commit b9ea813974c55a11ccca19798af523e45ff2912f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

