### PR TITLE
ui: parse broken files with player

### DIFF
--- a/frontend/app/player/web/MessageLoader.ts
+++ b/frontend/app/player/web/MessageLoader.ts
@@ -56,6 +56,11 @@ export default class MessageLoader {
       'Checking protocol format from header',
       binary.slice(0, 24).join(' '),
     );
+    const hasHeader = binary.slice(0, 3).every((b) => b === 0xff);
+    if (!hasHeader) {
+      // probably second file in the recording cuz messages arrived late
+      return 3;
+    }
     const isV2 =
       binary.slice(0, 7).every((b) => b === 0xff) && binary[7] === 0xfe;
     if (isV2) return 2;
@@ -70,7 +75,7 @@ export default class MessageLoader {
     const hasHeader =
       data.slice(0, 7).every((b) => b === 0xff) &&
       (data[7] === 0xff || data[7] === 0xfe || data[7] === 0xfd);
-    return hasHeader ? data.slice(8) : data;
+    return hasHeader && data[0] !== 81 ? data.slice(8) : data;
   }
 
   rawMessages: any[] = [];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the player parse split or “broken” recording files by inferring the protocol header and only stripping it when safe. Fixes playback when messages arrive late or the file starts mid-stream.

- **Bug Fixes**
  - If the first 3 bytes aren’t 0xff, assume we’re in a second file and use protocol v3.
  - Strip the 8-byte header only when present and the first byte isn’t 81, avoiding truncating valid frames.

<sup>Written for commit 12366e61babea41aa44821e1ad5010093815537b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

