### PR TITLE
New assist api

### DIFF
--- a/tracker/bun.lock
+++ b/tracker/bun.lock
@@ -7,7 +7,7 @@
     },
     "tracker": {
       "name": "@openreplay/tracker",
-      "version": "18.0.15",
+      "version": "18.1.0",
       "dependencies": {
         "@openreplay/network-proxy": "^1.2.5",
         "error-stack-parser": "^2.1.4",

--- a/tracker/tracker-assist/CHANGELOG.md
+++ b/tracker/tracker-assist/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 11.0.18
+
+- autostart options
+- start/stop methods
+- options to ignore anonymous sessions
+
 ## 11.0.17
 
 - improvements for rc interaction with select els

--- a/tracker/tracker-assist/README.md
+++ b/tracker/tracker-assist/README.md
@@ -81,7 +81,40 @@ trackerAssist({
   config: RTCConfiguration;
   serverURL: string
   callUITemplate?: string;
+  agentShortNames?: boolean;
+  ignoreAnonymous?: boolean;
+  autostart?: Autostart; // 'disabled' | 'continuation' | 'auto'
 })
+```
+
+- `agentShortNames`: When `true`, only the first part of an agent's name is shown in the call popup (e.g. `"John Doe"` → `"John"`). Defaults to `false`.
+- `ignoreAnonymous`: When `true`, assist postpones connecting until a `userID` is set on the session (via `tracker.setUserID(...)`). Anonymous sessions won't appear as live until identified. Defaults to `false`.
+- `autostart`: Controls when assist connects. Import the `Autostart` enum from the package. Defaults to `Autostart.Auto`.
+  - `Autostart.Auto`: always connect on `tracker.start()` (legacy behavior).
+  - `Autostart.Disabled`: never connect automatically; call `assist.start()` yourself.
+  - `Autostart.Continuation`: connect only after `assist.start()` is called, but remember that choice in `sessionStorage` so assist auto-continues across page reloads until `assist.stop()` is called.
+
+#### Public methods
+
+`tracker.use(trackerAssist(options))` returns the assist instance (or `undefined` when assist can't load — e.g. inside an iframe, unsupported browser, or tracker version mismatch), which exposes:
+
+- `start()`: connect assist. In `Autostart.Continuation` mode this also persists the flag used to auto-continue after reloads. No-op until the tracker itself is active.
+- `stop()`: disconnect assist and tear down all live connections. It won't reconnect automatically until `start()` is called again; in `Autostart.Continuation` mode it clears the persisted flag.
+
+```js
+import Tracker from '@openreplay/tracker';
+import trackerAssist, { Autostart } from '@openreplay/tracker-assist';
+
+const tracker = new Tracker({ projectKey: PROJECT_KEY });
+const assist = tracker.use(trackerAssist({ autostart: Autostart.Continuation }));
+
+tracker.start().then(() => {
+  // enable assist on demand; it will resume automatically on reload
+  assist?.start();
+});
+
+// later, to fully turn it off:
+assist?.stop();
 ```
 
 ```js

--- a/tracker/tracker-assist/package.json
+++ b/tracker/tracker-assist/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openreplay/tracker-assist",
   "description": "Tracker plugin for screen assistance through the WebRTC",
-  "version": "11.0.17",
+  "version": "11.0.18",
   "keywords": [
     "WebRTC",
     "assistance",

--- a/tracker/tracker-assist/src/Assist.ts
+++ b/tracker/tracker-assist/src/Assist.ts
@@ -19,6 +19,24 @@ import { gzip } from "fflate";
 
 const textEncoder = new TextEncoder();
 
+// sessionStorage flag used by Autostart.Continuation to survive page reloads
+const SS_CONTINUE_KEY = "__openreplay_assist_continue";
+
+/**
+ * Controls when assist connects to the server.
+ */
+export enum Autostart {
+  /** Never auto-connect; assist starts only via an explicit start() call. */
+  Disabled = "disabled",
+  /**
+   * Auto-connect on reload only if start() was called earlier in this
+   * browser session (persisted in sessionStorage). stop() cancels it.
+   */
+  Continuation = "continuation",
+  /** Always auto-connect on tracker start (default, legacy behavior). */
+  Auto = "auto",
+}
+
 type StartEndCallback = (agentInfo?: Record<string, any>) => (() => any) | void;
 
 interface AgentInfo {
@@ -71,6 +89,15 @@ export interface Options {
    * @default false
    */
   ignoreAnonymous: boolean;
+  /**
+   * When assist connects to the server:
+   * - Autostart.Auto (default): always on tracker start.
+   * - Autostart.Disabled: only via an explicit start() call.
+   * - Autostart.Continuation: only via start(), but the choice is remembered
+   *   in sessionStorage so it auto-continues across page reloads until stop().
+   * @default Autostart.Auto
+   */
+  autostart: Autostart;
 }
 
 enum CallingState {
@@ -97,6 +124,8 @@ export default class Assist {
   private assistDemandedRestart = false;
   private userStopped = false;
   private pendingStart: (() => void) | null = null;
+  private titleNode: HTMLTitleElement | null = null;
+  private titleObserver: MutationObserver | null = null;
   private callingState: CallingState = CallingState.False;
   private remoteControl: RemoteControl | null = null;
   private peerReconnectTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -137,6 +166,7 @@ export default class Assist {
         compressionMinBatchSize: 5000,
         agentShortNames: false,
         ignoreAnonymous: false,
+        autostart: Autostart.Auto,
       },
       options,
     );
@@ -160,30 +190,27 @@ export default class Assist {
       "BroadcastChannel" in window ? new BroadcastChannel("or-assist") : null;
     this.tabBus?.addEventListener("message", this.handleTabStateMessage);
 
-    const titleNode = document.querySelector("title");
-    const observer =
-      titleNode &&
-      new MutationObserver(() => {
-        this.emit("UPDATE_SESSION", { pageTitle: document.title });
-      });
-    const beginAssist = () => {
-      this.onStart();
-      this.publishState({ type: "assist_state_check" });
-      observer &&
-        observer.observe(titleNode, {
-          childList: true,
-        });
-    };
+    this.titleNode = document.querySelector("title");
+    this.titleObserver = this.titleNode
+      ? new MutationObserver(() => {
+          this.emit("UPDATE_SESSION", { pageTitle: document.title });
+        })
+      : null;
     app.attachStartCallback(() => {
       if (this.assistDemandedRestart || this.userStopped) {
         return;
       }
-      // postpone start until a userID is attached to the session
-      if (this.options.ignoreAnonymous && !this.app.getSessionInfo().userID) {
-        this.pendingStart = beginAssist;
+      // autostart gate: disabled never auto-connects, continuation only when
+      // start() was called earlier this browser session
+      if (!this.shouldAutoStart()) {
         return;
       }
-      beginAssist();
+      // postpone start until a userID is attached to the session
+      if (this.options.ignoreAnonymous && !this.app.getSessionInfo().userID) {
+        this.pendingStart = this.beginAssist;
+        return;
+      }
+      this.beginAssist();
     });
     app.attachStopCallback(() => {
       if (this.assistDemandedRestart) {
@@ -194,7 +221,7 @@ export default class Assist {
       // restart must reconnect with a fresh socket (new session/tab identity)
       // via onStart, not reuse this one.
       this.socket = null;
-      observer && observer.disconnect();
+      this.titleObserver?.disconnect();
     });
     app.attachCommitCallback((messages) => {
       if (this.agentsConnected) {
@@ -251,27 +278,61 @@ export default class Assist {
     });
   }
 
+  /** Connects assist and wires up the title/cross-tab state watchers. */
+  private beginAssist = () => {
+    this.onStart();
+    this.publishState({ type: "assist_state_check" });
+    if (this.titleObserver && this.titleNode) {
+      this.titleObserver.observe(this.titleNode, { childList: true });
+    }
+  };
+
+  private get continuationEnabled(): boolean {
+    return this.options.autostart === Autostart.Continuation;
+  }
+
+  /** Whether assist should connect automatically on tracker start. */
+  private shouldAutoStart(): boolean {
+    switch (this.options.autostart) {
+      case Autostart.Disabled:
+        return false;
+      case Autostart.Continuation:
+        return sessionStorage.getItem(SS_CONTINUE_KEY) === "1";
+      case Autostart.Auto:
+      default:
+        return true;
+    }
+  }
+
   /**
    * Stops assist: disconnects the socket and cleans up all connections.
    * Assist won't restart automatically on the next tracker start until
-   * start() is called.
+   * start() is called. In Autostart.Continuation mode this also clears the
+   * persisted flag, so a reload won't auto-continue.
    */
   public stop = () => {
     this.userStopped = true;
     this.pendingStart = null;
+    if (this.continuationEnabled) {
+      sessionStorage.removeItem(SS_CONTINUE_KEY);
+    }
     this.clean();
   }
 
   /**
-   * (Re)starts assist after a manual stop(). No-op if the tracker itself
-   * isn't active yet (assist will start together with the tracker).
-   * Reuses the existing socket (and its handlers) when possible instead of
-   * re-running onStart, to avoid duplicating node/socket callbacks.
+   * (Re)starts assist. No-op if the tracker itself isn't active yet (assist
+   * will start together with the tracker). Reuses the existing socket (and
+   * its handlers) when possible instead of re-running onStart, to avoid
+   * duplicating node/socket callbacks. In Autostart.Continuation mode it
+   * persists a flag so assist auto-continues across page reloads.
    */
   public start = () => {
     this.userStopped = false;
     // an explicit start supersedes any ignoreAnonymous postponement
     this.pendingStart = null;
+    if (this.continuationEnabled) {
+      sessionStorage.setItem(SS_CONTINUE_KEY, "1");
+    }
     if (!this.app.active()) {
       return;
     }
@@ -279,7 +340,7 @@ export default class Assist {
       this.socket.connect();
       return;
     }
-    this.onStart();
+    this.beginAssist();
   }
 
   private emit(ev: string, args?: any): void {

--- a/tracker/tracker-assist/src/Assist.ts
+++ b/tracker/tracker-assist/src/Assist.ts
@@ -60,6 +60,17 @@ export interface Options {
    * @default 5000
    */
   compressionMinBatchSize: number;
+  /**
+   * Show only the first part of an agent's name in the call popup
+   * (e.g. "One Two" -> "One").
+   * @default false
+   */
+  agentShortNames: boolean;
+  /**
+   * Postpone assist start until a userID is set on the session.
+   * @default false
+   */
+  ignoreAnonymous: boolean;
 }
 
 enum CallingState {
@@ -84,6 +95,8 @@ export default class Assist {
   private canvasPeers: Map<string, RTCPeerConnection> = new Map();
   private canvasNodeCheckers: Map<number, any> = new Map();
   private assistDemandedRestart = false;
+  private userStopped = false;
+  private pendingStart: (() => void) | null = null;
   private callingState: CallingState = CallingState.False;
   private remoteControl: RemoteControl | null = null;
   private peerReconnectTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -122,6 +135,8 @@ export default class Assist {
         socketHost: "",
         compressionEnabled: false,
         compressionMinBatchSize: 5000,
+        agentShortNames: false,
+        ignoreAnonymous: false,
       },
       options,
     );
@@ -151,22 +166,34 @@ export default class Assist {
       new MutationObserver(() => {
         this.emit("UPDATE_SESSION", { pageTitle: document.title });
       });
-    app.attachStartCallback(() => {
-      if (this.assistDemandedRestart) {
-        return;
-      }
+    const beginAssist = () => {
       this.onStart();
-      this.publishState({ type: "assist_state_check" })
+      this.publishState({ type: "assist_state_check" });
       observer &&
         observer.observe(titleNode, {
           childList: true,
         });
+    };
+    app.attachStartCallback(() => {
+      if (this.assistDemandedRestart || this.userStopped) {
+        return;
+      }
+      // postpone start until a userID is attached to the session
+      if (this.options.ignoreAnonymous && !this.app.getSessionInfo().userID) {
+        this.pendingStart = beginAssist;
+        return;
+      }
+      beginAssist();
     });
     app.attachStopCallback(() => {
       if (this.assistDemandedRestart) {
         return;
       }
       this.clean();
+      // tracker stop => kill the connection completely; a genuine tracker
+      // restart must reconnect with a fresh socket (new session/tab identity)
+      // via onStart, not reuse this one.
+      this.socket = null;
       observer && observer.disconnect();
     });
     app.attachCommitCallback((messages) => {
@@ -213,9 +240,46 @@ export default class Assist {
         }
       }
     });
-    app.session.attachUpdateCallback((sessInfo) =>
-      this.emit("UPDATE_SESSION", sessInfo),
-    );
+    app.session.attachUpdateCallback((sessInfo) => {
+      // ignoreAnonymous: fire the postponed start once a userID arrives
+      if (this.pendingStart && sessInfo.userID) {
+        const begin = this.pendingStart;
+        this.pendingStart = null;
+        begin();
+      }
+      this.emit("UPDATE_SESSION", sessInfo);
+    });
+  }
+
+  /**
+   * Stops assist: disconnects the socket and cleans up all connections.
+   * Assist won't restart automatically on the next tracker start until
+   * start() is called.
+   */
+  public stop = () => {
+    this.userStopped = true;
+    this.pendingStart = null;
+    this.clean();
+  }
+
+  /**
+   * (Re)starts assist after a manual stop(). No-op if the tracker itself
+   * isn't active yet (assist will start together with the tracker).
+   * Reuses the existing socket (and its handlers) when possible instead of
+   * re-running onStart, to avoid duplicating node/socket callbacks.
+   */
+  public start = () => {
+    this.userStopped = false;
+    // an explicit start supersedes any ignoreAnonymous postponement
+    this.pendingStart = null;
+    if (!this.app.active()) {
+      return;
+    }
+    if (this.socket) {
+      this.socket.connect();
+      return;
+    }
+    this.onStart();
   }
 
   private emit(ev: string, args?: any): void {
@@ -303,7 +367,7 @@ export default class Assist {
 
     const onGrand = (id: string) => {
       if (!this.callUI) {
-        this.callUI = new CallWindow(app.debug.error, this.options.callUITemplate);
+        this.callUI = new CallWindow(app.debug.error, this.options.callUITemplate, this.options.agentShortNames);
       }
       if (this.remoteControl) {
         this.callUI?.showRemoteControl(this.remoteControl.releaseControl);
@@ -760,7 +824,7 @@ export default class Assist {
         this.calls.set(from, pc);
 
         if (!this.callUI) {
-          this.callUI = new CallWindow(app.debug.error, this.options.callUITemplate);
+          this.callUI = new CallWindow(app.debug.error, this.options.callUITemplate, this.options.agentShortNames);
           this.callUI.setVideoToggleCallback((args: { enabled: boolean }) => {
             this.emit("videofeed", { streamId: from, enabled: args.enabled });
           });
@@ -1052,7 +1116,7 @@ export default class Assist {
       if (msg.data.update === "call") {
         if (msg.data.isCallActive) {
           if (!this.callUI) {
-            this.callUI = new CallWindow(this.app.debug.error, this.options.callUITemplate);
+            this.callUI = new CallWindow(this.app.debug.error, this.options.callUITemplate, this.options.agentShortNames);
           }
           const initiateCallEnd = () => {
             this.emit("call_end");

--- a/tracker/tracker-assist/src/CallWindow.ts
+++ b/tracker/tracker-assist/src/CallWindow.ts
@@ -40,7 +40,7 @@ export default class CallWindow {
 
 	private readonly load: Promise<void>
 
-	constructor(private readonly logError: (...args: any[]) => void, private readonly callUITemplate?: string) {
+	constructor(private readonly logError: (...args: any[]) => void, private readonly callUITemplate?: string, private readonly agentShortNames = false) {
 		const iframe = (this.iframe = document.createElement('iframe'))
 		Object.assign(iframe.style, {
 			position: 'fixed',
@@ -241,7 +241,10 @@ export default class CallWindow {
 		this.load
 			.then(() => {
 				if (this.agentNameElem) {
-					const nameString = Array.from(callingAgents.values()).join(', ')
+					const names = Array.from(callingAgents.values()).map((name) =>
+						this.agentShortNames ? name.split(' ')[0] : name,
+					)
+					const nameString = names.join(', ')
 					const safeNames =
 						nameString.length > 20 ? nameString.substring(0, 20) + '...' : nameString
 					this.agentNameElem.innerText = safeNames

--- a/tracker/tracker-assist/src/index.ts
+++ b/tracker/tracker-assist/src/index.ts
@@ -2,7 +2,10 @@ import './_slim.js'
 
 import type { App, } from '@openreplay/tracker'
 import type { Options, } from './Assist.js'
-import Assist from './Assist.js'
+import Assist, { Autostart, } from './Assist.js'
+
+export { Autostart, }
+export type { Options, }
 
 
 export default function(opts?: Partial<Options>) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new Assist API in `@openreplay/tracker-assist` with explicit start/stop controls and flexible autostart modes. Enables delaying connections for anonymous users and cleaner agent names in the call UI.

- **New Features**
  - Added `start()` and `stop()` on the Assist instance.
  - Introduced `autostart` with `Autostart.Auto` (default), `Autostart.Disabled`, and `Autostart.Continuation` (persists across reloads).
  - Added `ignoreAnonymous` to connect only after a `userID` is set.
  - Added `agentShortNames` to show only the first part of agent names in the popup.

- **Migration**
  - No changes needed for existing setups; default behavior remains auto-connect.
  - To control connection, import `{ Autostart }`, set `autostart`, and call `assist.start()`/`assist.stop()` as needed.
  - If using `ignoreAnonymous`, ensure you call `tracker.setUserID(...)` when the user is identified.

<sup>Written for commit 46206a97ba0adb4b079fe03bdcdb78f693d6e1ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

