### PR TITLE
fix(nginx): allow larger Spot video uploads

### DIFF
--- a/scripts/docker-compose/nginx.conf
+++ b/scripts/docker-compose/nginx.conf
@@ -26,7 +26,7 @@ server {
 
     # Match ingress-nginx defaults used by OpenReplay helm chart
     client_body_buffer_size 512k;
-    client_max_body_size 10m;
+    client_max_body_size 100m;
 
     proxy_buffer_size 64k;
     proxy_buffers 32 64k;


### PR DESCRIPTION
## Changes

- Increase the Docker Compose Nginx `client_max_body_size` from `10m` to `100m`.
- Align the Docker Compose limit with the value used by the OpenReplay Helm chart.
- Allow larger Spot `video.webm` uploads to reach the object storage proxy.

## Root cause

Spot videos are uploaded through the Docker Compose Nginx `/spots/` proxy. The proxy currently caps request bodies at 10 MiB, so larger recordings can be rejected before reaching RustFS. The Spot service is then notified that the upload completed, but the expected video object is missing, causing the transcoder to fail with `NoSuchKey`.

## Impact

Docker Compose installations can accept Spot recording uploads up to 100 MiB, consistent with the Helm chart configuration.

## Validation

- [x] `git diff --check`
- [x] `docker compose config --quiet`
- [x] `nginx -t` using the repository configuration and `nginx:latest`
- [ ] Verify a Spot recording larger than 10 MiB uploads successfully in a running OpenReplay installation
- [ ] Verify the tested recording no longer produces a transcoder `NoSuchKey` error

Fixes #4695


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Docker Compose `nginx` `client_max_body_size` from 10m to 100m for the `/spots/` proxy to allow larger Spot `video.webm` uploads and match the Helm chart. Prevents uploads >10 MiB from being rejected before reaching `RustFS`, avoiding downstream transcoder NoSuchKey errors.

<sup>Written for commit d38862775ea5f1b77c841ad93fe3c14c951c420d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

