### PR TITLE
ui: persist dashboard time range and configure series limit

### DIFF
--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -14,6 +14,10 @@ SENTRY_URL = ''
 CAPTCHA_ENABLED = false
 CAPTCHA_SITE_KEY = ''
 
+# DASHBOARD
+# Must be an integer from 1 to 5. Invalid values fall back to 5.
+DASHBOARD_SERIES_LIMIT = 5
+
 # APP and TRACKER VERSIONS
 VERSION = 1.27.0
 TRACKER_VERSION = '18.0.17'

--- a/frontend/app/components/Dashboard/components/WidgetForm/WidgetFormNew.tsx
+++ b/frontend/app/components/Dashboard/components/WidgetForm/WidgetFormNew.tsx
@@ -11,6 +11,7 @@ import {
   FUNNEL,
   HEATMAP,
   INSIGHTS,
+  MAX_DASHBOARD_SERIES,
   RETENTION,
   TABLE,
   TIMESERIES,
@@ -103,7 +104,7 @@ const FilterSection = observer(
     const isInsights = metric.metricType === INSIGHTS;
     const isPathAnalysis = metric.metricType === USER_PATH;
     const isWebVitals = metric.metricType === WEBVITALS;
-    const canAddSeries = metric.series.length < 3;
+    const canAddSeries = metric.series.length < MAX_DASHBOARD_SERIES;
 
     const isSingleSeries = checkIsSingleSeries(metric);
     const { t } = useTranslation();
@@ -198,7 +199,13 @@ const FilterSection = observer(
         {isSingleSeries ? null : (
           <div className="mx-auto flex items-center gap-2 w-fit">
             <Tooltip
-              title={canAddSeries ? '' : t('Maximum of 3 series reached.')}
+              title={
+                canAddSeries
+                  ? ''
+                  : t('Maximum of {{limit}} series reached.', {
+                      limit: MAX_DASHBOARD_SERIES,
+                    })
+              }
             >
               <Button
                 onClick={() => {

--- a/frontend/app/constants/card.ts
+++ b/frontend/app/constants/card.ts
@@ -1,7 +1,10 @@
-import { IconNames } from 'App/components/ui/SVG';
 import { FilterKey } from 'Types/filter/filterType';
-import { MetricType } from 'App/components/Dashboard/components/MetricTypeItem/MetricTypeItem';
 import { TFunction } from 'i18next';
+
+import { MetricType } from 'App/components/Dashboard/components/MetricTypeItem/MetricTypeItem';
+import { IconNames } from 'App/components/ui/SVG';
+
+import ENV from '../../env';
 
 export interface CardType {
   title: string;
@@ -24,6 +27,14 @@ export const RETENTION = 'retention';
 export const INSIGHTS = 'insights'; // SaaS and EE
 export const PERFORMANCE = 'performance';
 export const WEBVITALS = 'webVital';
+
+const BACKEND_MAX_DASHBOARD_SERIES = 5;
+const configuredSeriesLimit = Number(ENV.DASHBOARD_SERIES_LIMIT);
+
+export const MAX_DASHBOARD_SERIES =
+  Number.isInteger(configuredSeriesLimit) && configuredSeriesLimit > 0
+    ? Math.min(configuredSeriesLimit, BACKEND_MAX_DASHBOARD_SERIES)
+    : BACKEND_MAX_DASHBOARD_SERIES;
 
 export const CATEGORIES = {
   product_analytics: 'product_analytics',

--- a/frontend/app/constants/storageKeys.ts
+++ b/frontend/app/constants/storageKeys.ts
@@ -14,3 +14,4 @@ export const IFRAME = '__$session-iframe$__';
 export const JWT_PARAM = '__$session-jwt-param$__';
 export const MENU_COLLAPSED = '__$global-menuCollapsed$__';
 export const SPOT_ONBOARDING = '__$spot-onboarding$__';
+export const DASHBOARD_TIME_RANGE = '__$dashboard-timeRange$__';

--- a/frontend/app/locales/en.json
+++ b/frontend/app/locales/en.json
@@ -650,7 +650,7 @@
   "Cannot save funnel metric without at least 2 events": "Cannot save funnel metric without at least 2 events",
   "Create & Add to Dashboard": "Create & Add to Dashboard",
   "Undo": "Undo",
-  "Maximum of 3 series reached.": "Maximum of 3 series reached.",
+  "Maximum of {{limit}} series reached.": "Maximum of {{limit}} series reached.",
   "Add Series": "Add Series",
   "Expand": "Expand",
   "Collapse": "Collapse",

--- a/frontend/app/locales/es.json
+++ b/frontend/app/locales/es.json
@@ -650,7 +650,7 @@
   "Cannot save funnel metric without at least 2 events": "No se puede guardar la métrica del embudo sin al menos 2 eventos",
   "Create & Add to Dashboard": "Crear y añadir al panel",
   "Undo": "Deshacer",
-  "Maximum of 3 series reached.": "Máximo de 3 series alcanzado.",
+  "Maximum of {{limit}} series reached.": "Máximo de {{limit}} series alcanzado.",
   "Add Series": "Añadir serie",
   "Expand": "Expandir",
   "Collapse": "Colapsar",

--- a/frontend/app/locales/fr.json
+++ b/frontend/app/locales/fr.json
@@ -650,7 +650,7 @@
   "Cannot save funnel metric without at least 2 events": "Impossible d'enregistrer la métrique d'entonnoir sans au moins 2 évènements",
   "Create & Add to Dashboard": "Créer & ajouter au tableau de bord",
   "Undo": "Annuler",
-  "Maximum of 3 series reached.": "Maximum de 3 séries atteint.",
+  "Maximum of {{limit}} series reached.": "Maximum de {{limit}} séries atteint.",
   "Add Series": "Ajouter une série",
   "Expand": "Développer",
   "Collapse": "Réduire",

--- a/frontend/app/locales/ko.json
+++ b/frontend/app/locales/ko.json
@@ -650,7 +650,7 @@
   "Cannot save funnel metric without at least 2 events": "이벤트가 최소 2개 이상 있어야 퍼널 지표를 저장할 수 있습니다",
   "Create & Add to Dashboard": "생성 후 대시보드에 추가",
   "Undo": "실행 취소",
-  "Maximum of 3 series reached.": "최대 3개의 시리즈에 도달했습니다.",
+  "Maximum of {{limit}} series reached.": "최대 {{limit}}개의 시리즈에 도달했습니다.",
   "Add Series": "시리즈 추가",
   "Expand": "펼치기",
   "Collapse": "접기",

--- a/frontend/app/locales/ru.json
+++ b/frontend/app/locales/ru.json
@@ -651,7 +651,7 @@
   "Cannot save funnel metric without at least 2 events": "Невозможно сохранить метрику воронки без как минимум 2 событий",
   "Create & Add to Dashboard": "Создать и добавить в дашборд",
   "Undo": "Отменить",
-  "Maximum of 3 series reached.": "Достигнут максимум из 3 серий.",
+  "Maximum of {{limit}} series reached.": "Достигнут максимум из {{limit}} серий.",
   "Add Series": "Добавить серию",
   "Expand": "Развернуть",
   "Collapse": "Свернуть",

--- a/frontend/app/locales/zh.json
+++ b/frontend/app/locales/zh.json
@@ -650,7 +650,7 @@
   "Cannot save funnel metric without at least 2 events": "至少需要2个事件才能保存漏斗指标",
   "Create & Add to Dashboard": "创建并添加到仪表板",
   "Undo": "撤销",
-  "Maximum of 3 series reached.": "最多添加3个系列。",
+  "Maximum of {{limit}} series reached.": "最多添加{{limit}}个系列。",
   "Add Series": "添加系列",
   "Expand": "展开",
   "Collapse": "折叠",

--- a/frontend/app/mstore/dashboardStore.ts
+++ b/frontend/app/mstore/dashboardStore.ts
@@ -1,10 +1,11 @@
 import { calculateGranularities } from '@/components/Dashboard/components/WidgetDateRange/RangeGranularity';
 import { HEATMAP } from '@/constants/card';
-import { CUSTOM_RANGE } from '@/dateRange';
+import { CUSTOM_RANGE, dateRangeValues } from '@/dateRange';
 import Period, { LAST_24_HOURS } from 'Types/app/period';
 import { makeAutoObservable, reaction, runInAction } from 'mobx';
 import { toast } from 'react-toastify';
 
+import { DASHBOARD_TIME_RANGE } from 'App/constants/storageKeys';
 import { sessionStore } from 'App/mstore';
 import { dashboardService, metricService } from 'App/services';
 import { getRE } from 'App/utils';
@@ -12,6 +13,20 @@ import { getRE } from 'App/utils';
 import Dashboard from './types/dashboard';
 import Filter from './types/filter';
 import Widget from './types/widget';
+
+const DEFAULT_DASHBOARD_RANGE = LAST_24_HOURS;
+
+const getDashboardPeriod = () => {
+  const savedRangeName = localStorage.getItem(DASHBOARD_TIME_RANGE);
+  const rangeName =
+    savedRangeName &&
+    savedRangeName !== CUSTOM_RANGE &&
+    dateRangeValues.includes(savedRangeName)
+      ? savedRangeName
+      : DEFAULT_DASHBOARD_RANGE;
+
+  return Period({ rangeName });
+};
 
 interface DashboardFilter {
   query?: string;
@@ -27,10 +42,10 @@ export default class DashboardStore {
   currentWidget: Widget = new Widget();
   widgetCategories: any[] = [];
   widgets: Widget[] = [];
-  period: Record<string, any> = Period({ rangeName: LAST_24_HOURS });
+  period: Record<string, any> = getDashboardPeriod();
   drillDownFilter: Filter = new Filter();
   comparisonFilter: Filter = new Filter();
-  drillDownPeriod: Record<string, any> = Period({ rangeName: LAST_24_HOURS });
+  drillDownPeriod: Record<string, any> = getDashboardPeriod();
   selectedDensity: number = 7;
   comparisonPeriods: Record<string, any> = {};
   startTimestamp: number = 0;
@@ -475,15 +490,21 @@ export default class DashboardStore {
   resetPeriod = () => {
     if (this.period) {
       const range = this.period.rangeName;
-      if (range !== CUSTOM_RANGE) {
-        this.period = Period({ rangeName: this.period.rangeName });
-      } else {
-        this.period = Period({ rangeName: LAST_24_HOURS });
-      }
+      this.period =
+        range !== CUSTOM_RANGE
+          ? Period({ rangeName: range })
+          : getDashboardPeriod();
     }
   };
 
   setPeriod(period: any) {
+    if (
+      period.rangeName !== CUSTOM_RANGE &&
+      dateRangeValues.includes(period.rangeName)
+    ) {
+      localStorage.setItem(DASHBOARD_TIME_RANGE, period.rangeName);
+    }
+
     this.period = Period({
       start: period.start,
       end: period.end,

--- a/frontend/env.ts
+++ b/frontend/env.ts
@@ -24,6 +24,7 @@ const ENV = {
     : process.env.TEST_FOSS_PASSWORD,
   STRIPE_KEY: process.env.STRIPE_KEY,
   CRISP_KEY: process.env.CRISP_KEY,
+  DASHBOARD_SERIES_LIMIT: process.env.DASHBOARD_SERIES_LIMIT,
 };
 
 export default ENV;

--- a/frontend/tests/unit/dashboardSeriesLimit.test.ts
+++ b/frontend/tests/unit/dashboardSeriesLimit.test.ts
@@ -1,0 +1,61 @@
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+
+jest.mock(
+  'App/components/Dashboard/components/MetricTypeItem/MetricTypeItem',
+  () => ({}),
+);
+jest.mock('App/components/ui/SVG', () => ({}));
+
+const originalSeriesLimit = process.env.DASHBOARD_SERIES_LIMIT;
+
+const loadSeriesLimit = async () => {
+  const { MAX_DASHBOARD_SERIES } = await import('App/constants/card');
+  return MAX_DASHBOARD_SERIES;
+};
+
+describe('dashboard series limit configuration', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    delete process.env.DASHBOARD_SERIES_LIMIT;
+  });
+
+  afterAll(() => {
+    if (originalSeriesLimit === undefined) {
+      delete process.env.DASHBOARD_SERIES_LIMIT;
+    } else {
+      process.env.DASHBOARD_SERIES_LIMIT = originalSeriesLimit;
+    }
+  });
+
+  it('defaults to the backend maximum', async () => {
+    await expect(loadSeriesLimit()).resolves.toBe(5);
+  });
+
+  it('uses a configured limit below the backend maximum', async () => {
+    process.env.DASHBOARD_SERIES_LIMIT = '3';
+
+    await expect(loadSeriesLimit()).resolves.toBe(3);
+  });
+
+  it('caps a configured limit at the backend maximum', async () => {
+    process.env.DASHBOARD_SERIES_LIMIT = '10';
+
+    await expect(loadSeriesLimit()).resolves.toBe(5);
+  });
+
+  it.each(['0', '-1', '2.5', 'invalid'])(
+    'falls back for invalid value %s',
+    async (value) => {
+      process.env.DASHBOARD_SERIES_LIMIT = value;
+
+      await expect(loadSeriesLimit()).resolves.toBe(5);
+    },
+  );
+});

--- a/frontend/tests/unit/dashboardStore.test.ts
+++ b/frontend/tests/unit/dashboardStore.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { LAST_7_DAYS } from 'Types/app/period';
+
+import { DASHBOARD_TIME_RANGE } from 'App/constants/storageKeys';
+import { CUSTOM_RANGE } from 'App/dateRange';
+import DashboardStore from 'App/mstore/dashboardStore';
+
+jest.mock('@/mstore/index', () => ({
+  filterStore: {
+    findEvent: jest.fn(() => ({ filters: [] })),
+    getEventFilters: jest.fn(() => Promise.resolve([])),
+  },
+}));
+
+jest.mock('App/mstore', () => ({
+  filterStore: {
+    findEvent: jest.fn(() => ({ filters: [] })),
+    getEventFilters: jest.fn(() => Promise.resolve([])),
+  },
+  sessionStore: {},
+}));
+
+jest.mock('App/services', () => ({
+  dashboardService: {},
+  metricService: {},
+}));
+
+describe('DashboardStore time range preference', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('restores the saved preset for dashboard and drill-down periods', () => {
+    localStorage.setItem(DASHBOARD_TIME_RANGE, LAST_7_DAYS);
+
+    const store = new DashboardStore();
+
+    expect(store.period.rangeName).toBe(LAST_7_DAYS);
+    expect(store.drillDownPeriod.rangeName).toBe(LAST_7_DAYS);
+  });
+
+  it('persists a selected preset', () => {
+    const store = new DashboardStore();
+
+    store.setPeriod({ rangeName: LAST_7_DAYS });
+
+    expect(localStorage.getItem(DASHBOARD_TIME_RANGE)).toBe(LAST_7_DAYS);
+  });
+
+  it('returns to the last preset after a custom range', () => {
+    localStorage.setItem(DASHBOARD_TIME_RANGE, LAST_7_DAYS);
+    const store = new DashboardStore();
+    const end = Date.now();
+    const start = end - 7 * 24 * 60 * 60 * 1000;
+
+    store.setPeriod({
+      start,
+      end,
+      rangeName: CUSTOM_RANGE,
+    });
+    store.resetPeriod();
+
+    expect(localStorage.getItem(DASHBOARD_TIME_RANGE)).toBe(LAST_7_DAYS);
+    expect(store.period.rangeName).toBe(LAST_7_DAYS);
+  });
+});


### PR DESCRIPTION
## Changes

- Persist the selected dashboard preset time range in local storage and restore it for dashboard and drill-down periods.
- Keep the saved preset when a temporary custom time range is selected, so reset returns to the user's last preset.
- Allow deployments to configure the dashboard series limit with `DASHBOARD_SERIES_LIMIT` (1–5), defaulting to and capped at the backend-supported maximum of five.
- Use an interpolated translation string for the series-limit tooltip in all existing locales.
- Add focused unit coverage for restoring, persisting, and resetting the dashboard time-range preference.
- Add unit coverage for the default, configured, capped, and invalid dashboard series-limit values.

## Why

The dashboard always initialized to the last 24 hours, regardless of the user's previous preset selection. The widget editor also limited users to three series even though the backend accepts up to five.

## Validation

- [x] `yarn jest tests/unit/dashboardSeriesLimit.test.ts tests/unit/dashboardStore.test.ts --runInBand --no-cache`
- [x] Targeted Prettier check
- [x] Targeted ESLint check
- [x] `DASHBOARD_SERIES_LIMIT=3 yarn build`
- [ ] `yarn exec tsc --noEmit --incremental false` — the repository currently reports pre-existing TypeScript errors outside the modified hunks, including existing Select prop and store typing errors.
- [ ] Manual authenticated dashboard verification

Fixes #4037

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the user's dashboard preset time range across sessions and drill-downs. Make the dashboard series limit configurable and enforce it in the editor, capped at five.

- **New Features**
  - Save the selected preset to `localStorage` under `DASHBOARD_TIME_RANGE`, restore it on load for dashboard and drill-down, and keep it when a temporary custom range is used so reset returns to the last preset.
  - Configure the series limit via `DASHBOARD_SERIES_LIMIT` (1–5; invalid falls back to 5), enforce it with `MAX_DASHBOARD_SERIES`, and update the tooltip to a localized message showing the limit; add unit tests for time-range persistence and series-limit configuration.

<sup>Written for commit da629fdd278cf910fda39b94c44580efa4c11805. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

