### PR TITLE
Assist confirm

### DIFF
--- a/frontend/app/components/Assist/RequestingWindow/RequestingWindow.tsx
+++ b/frontend/app/components/Assist/RequestingWindow/RequestingWindow.tsx
@@ -9,7 +9,6 @@ import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
 
 interface Props {
-  userDisplayName: string;
   getWindowType: () => WindowType | null;
 }
 
@@ -17,12 +16,14 @@ export enum WindowType {
   Call,
   Control,
   Record,
+  SessionConfirm,
 }
 
 enum Actions {
   CallEnd,
   ControlEnd,
   RecordingEnd,
+  None,
 }
 
 const WIN_VARIANTS = (t: TFunction) => ({
@@ -44,6 +45,12 @@ const WIN_VARIANTS = (t: TFunction) => ({
     iconColor: 'red',
     action: Actions.RecordingEnd,
   },
+  [WindowType.SessionConfirm]: {
+    text: t('to allow viewing this session'),
+    icon: 'eye' as const,
+    iconColor: 'teal',
+    action: Actions.None,
+  },
 });
 
 function RequestingWindow({ getWindowType }: Props) {
@@ -63,6 +70,7 @@ function RequestingWindow({ getWindowType }: Props) {
     [Actions.CallEnd]: initiateCallEnd,
     [Actions.ControlEnd]: releaseRemoteControl,
     [Actions.RecordingEnd]: stopRecording,
+    [Actions.None]: undefined,
   };
   return (
     <div
@@ -85,12 +93,14 @@ function RequestingWindow({ getWindowType }: Props) {
         </div>
         <span>{WIN_VARIANTS(t)[windowType].text}</span>
         <Loader size={30} style={{ minHeight: 60 }} />
-        <Button
-          variant="text"
-          onClick={actions[WIN_VARIANTS(t)[windowType].action]}
-        >
-          {t('Cancel')}
-        </Button>
+        {actions[WIN_VARIANTS(t)[windowType].action] ? (
+          <Button
+            variant="text"
+            onClick={actions[WIN_VARIANTS(t)[windowType].action]}
+          >
+            {t('Cancel')}
+          </Button>
+        ) : null}
       </div>
     </div>
   );

--- a/frontend/app/components/Session/Player/LivePlayer/Overlay/LiveOverlay.tsx
+++ b/frontend/app/components/Session/Player/LivePlayer/Overlay/LiveOverlay.tsx
@@ -5,6 +5,7 @@ import {
   CallingState,
   ConnectionStatus,
   RemoteControlStatus,
+  SessionConfirmStatus,
 } from 'Player';
 
 import Loader from 'Components/Session_/Player/Overlay/Loader';
@@ -33,6 +34,7 @@ function Overlay({ closedLive }: Props) {
     calling,
     remoteControl,
     recordingState,
+    sessionConfirmation,
     tabStates,
     currentTab,
   } = store.get();
@@ -45,11 +47,15 @@ function Overlay({ closedLive }: Props) {
   const showLiveStatusText = livePlay && liveStatusText && !loading;
 
   const showRequestWindow =
+    sessionConfirmation === SessionConfirmStatus.Requesting ||
     calling === CallingState.Connecting ||
     remoteControl === RemoteControlStatus.Requesting ||
     recordingState === SessionRecordingStatus.Requesting;
 
   const getRequestWindowType = () => {
+    if (sessionConfirmation === SessionConfirmStatus.Requesting) {
+      return WindowType.SessionConfirm;
+    }
     if (calling === CallingState.Connecting) {
       return WindowType.Call;
     }

--- a/player/src/web/assist/AssistManager.ts
+++ b/player/src/web/assist/AssistManager.ts
@@ -32,7 +32,6 @@ export enum ConnectionStatus {
 export enum SessionConfirmStatus {
   None,
   Requesting,
-  Denied,
 }
 
 type StatsEvent =
@@ -328,7 +327,7 @@ export default class AssistManager {
       this.store.update({ sessionConfirmation: SessionConfirmStatus.None });
     });
     socket.on('session_confirm_rejected', () => {
-      this.store.update({ sessionConfirmation: SessionConfirmStatus.Denied });
+      this.store.update({ sessionConfirmation: SessionConfirmStatus.None });
       this.uiErrorHandler?.error('User denied the live session view request');
     });
     socket.on('SESSION_DISCONNECTED', (e) => {

--- a/player/src/web/assist/AssistManager.ts
+++ b/player/src/web/assist/AssistManager.ts
@@ -25,6 +25,16 @@ export enum ConnectionStatus {
   Closed,
 }
 
+/**
+ * State of the tracker-side session view confirmation
+ * (tracker-assist requestConfirm option)
+ */
+export enum SessionConfirmStatus {
+  None,
+  Requesting,
+  Denied,
+}
+
 type StatsEvent =
   | 's_call_started'
   | 's_call_ended'
@@ -67,6 +77,7 @@ export default class AssistManager {
   static readonly INITIAL_STATE = {
     peerConnectionStatus: ConnectionStatus.Connecting,
     assistStart: 0,
+    sessionConfirmation: SessionConfirmStatus.None,
     ...Call.INITIAL_STATE,
     ...RemoteControl.INITIAL_STATE,
     ...ScreenRecording.INITIAL_STATE,
@@ -307,6 +318,18 @@ export default class AssistManager {
         );
         this.agentIds = filteredAgentIds;
       }
+    });
+    socket.on('session_confirm_pending', () => {
+      this.store.update({
+        sessionConfirmation: SessionConfirmStatus.Requesting,
+      });
+    });
+    socket.on('session_confirm_accepted', () => {
+      this.store.update({ sessionConfirmation: SessionConfirmStatus.None });
+    });
+    socket.on('session_confirm_rejected', () => {
+      this.store.update({ sessionConfirmation: SessionConfirmStatus.Denied });
+      this.uiErrorHandler?.error('User denied the live session view request');
     });
     socket.on('SESSION_DISCONNECTED', (e) => {
       waitingForMessages = true;

--- a/tracker/tracker-assist/CHANGELOG.md
+++ b/tracker/tracker-assist/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 11.0.19
 
 - add an option to require user permission to view assist session
+- `requestConfirm` option: require user confirmation before anything is sent to agents; popup shown when first agent connects, approval remembered per-tab until `stop()`
+- `sessionConfirm` option to customize the confirmation popup text/style
+- `onSessionConfirmApprove`/`onSessionConfirmDeny` callbacks
 
 ## 11.0.18
 

--- a/tracker/tracker-assist/README.md
+++ b/tracker/tracker-assist/README.md
@@ -72,11 +72,14 @@ trackerAssist({
   onCallDeny?: () => any;
   onRemoteControlDeny?: (agentInfo: Record<string, any>) => any;
   onRecordingDeny?: (agentInfo: Record<string, any>) => any;
+  onSessionConfirmApprove?: (agentInfo: Record<string, any>) => any;
+  onSessionConfirmDeny?: (agentInfo: Record<string, any>) => any;
   session_calling_peer_key: string;
   session_control_peer_key: string;
   callConfirm: ConfirmOptions;
   controlConfirm: ConfirmOptions;
   recordingConfirm: ConfirmOptions;
+  sessionConfirm: ConfirmOptions;
   socketHost?: string;
   config: RTCConfiguration;
   serverURL: string
@@ -84,6 +87,7 @@ trackerAssist({
   agentShortNames?: boolean;
   ignoreAnonymous?: boolean;
   autostart?: Autostart; // 'disabled' | 'continuation' | 'auto'
+  requestConfirm?: boolean;
 })
 ```
 
@@ -93,6 +97,7 @@ trackerAssist({
   - `Autostart.Auto`: always connect on `tracker.start()` (legacy behavior).
   - `Autostart.Disabled`: never connect automatically; call `assist.start()` yourself.
   - `Autostart.Continuation`: connect only after `assist.start()` is called, but remember that choice in `sessionStorage` so assist auto-continues across page reloads until `assist.stop()` is called.
+- `requestConfirm`: When `true`, assist connects as usual but sends nothing to the agents until the user approves a confirmation popup, shown as soon as the first agent connects to the session. On approval, tracking restarts so agents receive a full snapshot; the approval is remembered per-tab (`sessionStorage`) until `assist.stop()` is called. On denial, the session stays connected but silent, and the popup is shown again on the next agent connection. Use `sessionConfirm` to customize the popup and `onSessionConfirmApprove`/`onSessionConfirmDeny` for callbacks. Defaults to `false`.
 
 #### Public methods
 
@@ -133,6 +138,7 @@ type ButtonOptions = HTMLButtonElement | string | {
 
 - `callConfirm`: Customize the text and/or layout of the call request popup.
 - `controlConfirm`: Customize the text and/or layout of the remote control request popup.
+- `sessionConfirm`: Customize the text and/or layout of the session view confirmation popup (`requestConfirm` mode).
 - `config`: Contains any custom ICE/TURN server configuration. Defaults to `{ 'iceServers': [{ 'urls': 'stun:stun.l.google.com:19302' }], 'sdpSemantics': 'unified-plan' }`.
 - `onAgentConnect: () => (()=>void | void)`: This callback function is fired when someone from OpenReplay UI connects to the current live session. It can return another function. In this case, returned callback will be called when the same agent connection gets closed.
 

--- a/tracker/tracker-assist/src/Assist.ts
+++ b/tracker/tracker-assist/src/Assist.ts
@@ -432,7 +432,11 @@ export default class Assist {
       this.sessionConfirmed = true;
       sessionStorage.setItem(SS_CONFIRM_KEY, "1");
       this.emit("session_confirm_accepted", undefined, true);
-      this.options.onSessionConfirmApprove?.(agentInfo || {});
+      try {
+        this.options.onSessionConfirmApprove?.(agentInfo || {});
+      } catch (e) {
+        this.app.debug.error(e);
+      }
       // everything before the approval was suppressed; restart tracking so
       // the agents receive a full snapshot
       this.restartTracking(() =>
@@ -440,7 +444,11 @@ export default class Assist {
       );
     } else {
       this.emit("session_confirm_rejected", undefined, true);
-      this.options.onSessionConfirmDeny?.(agentInfo || {});
+      try {
+        this.options.onSessionConfirmDeny?.(agentInfo || {});
+      } catch (e) {
+        this.app.debug.error(e);
+      }
     }
     if (!fromAnotherTab) {
       this.publishState({
@@ -456,11 +464,35 @@ export default class Assist {
     this.sessionConfirmWindow = null;
   };
 
-  /** Restarts the tracker app so agents receive a full DOM snapshot. */
+  private restartInProgress = false;
+  private pendingRestartCallbacks: (() => void)[] = [];
+
+  /**
+   * Restarts the tracker app so agents receive a full DOM snapshot.
+   * Requests arriving while a restart is in flight (e.g. a second agent
+   * connecting during the stop phase, when app.active() is false) don't
+   * start another one — their callbacks run when the current restart ends.
+   */
   private restartTracking(onRestarted?: () => void) {
+    if (this.restartInProgress) {
+      if (onRestarted) {
+        this.pendingRestartCallbacks.push(onRestarted);
+      }
+      return;
+    }
     if (!this.app.active()) {
       return;
     }
+    this.restartInProgress = true;
+    if (onRestarted) {
+      this.pendingRestartCallbacks.push(onRestarted);
+    }
+    const finish = () => {
+      this.restartInProgress = false;
+      const callbacks = this.pendingRestartCallbacks;
+      this.pendingRestartCallbacks = [];
+      return callbacks;
+    };
     this.assistDemandedRestart = true;
     this.app.stop(false);
     this.app.clearBuffers();
@@ -473,10 +505,17 @@ export default class Assist {
             this.assistDemandedRestart = false;
           })
           .then(() => {
-            onRestarted?.();
+            finish().forEach((cb) => {
+              try {
+                cb();
+              } catch (e) {
+                this.app.debug.error(e);
+              }
+            });
           })
           .catch((e) => {
             this.assistDemandedRestart = false;
+            finish();
             this.app.debug.error(e);
           });
       }, 100);

--- a/tracker/tracker-assist/src/Assist.ts
+++ b/tracker/tracker-assist/src/Assist.ts
@@ -10,7 +10,10 @@ import RemoteControl, { RCStatus } from "./RemoteControl.js";
 import CallWindow from "./CallWindow.js";
 import AnnotationCanvas from "./AnnotationCanvas.js";
 import ConfirmWindow from "./ConfirmWindow/ConfirmWindow.js";
-import { callConfirmDefault } from "./ConfirmWindow/defaults.js";
+import {
+  callConfirmDefault,
+  sessionConfirmDefault,
+} from "./ConfirmWindow/defaults.js";
 import type { Options as ConfirmOptions } from "./ConfirmWindow/defaults.js";
 import ScreenRecordingState from "./ScreenRecordingState.js";
 import { pkgVersion } from "./version.js";
@@ -21,6 +24,9 @@ const textEncoder = new TextEncoder();
 
 // sessionStorage flag used by Autostart.Continuation to survive page reloads
 const SS_CONTINUE_KEY = "__openreplay_assist_continue";
+// sessionStorage flag: user already approved session viewing (requestConfirm
+// mode), so a page reload doesn't re-prompt
+const SS_CONFIRM_KEY = "__openreplay_session_confirm";
 
 /**
  * Controls when assist connects to the server.
@@ -57,12 +63,18 @@ export interface Options {
   onCallDeny?: () => any;
   onRemoteControlDeny?: (agentInfo: Record<string, any>) => any;
   onRecordingDeny?: (agentInfo: Record<string, any>) => any;
+  /** Called when the user approves session viewing (requestConfirm mode). */
+  onSessionConfirmApprove?: (agentInfo: Record<string, any>) => any;
+  /** Called when the user denies session viewing (requestConfirm mode). */
+  onSessionConfirmDeny?: (agentInfo: Record<string, any>) => any;
   onDragCamera?: (dx: number, dy: number) => void;
   session_calling_peer_key: string;
   session_control_peer_key: string;
   callConfirm: ConfirmOptions;
   controlConfirm: ConfirmOptions;
   recordingConfirm: ConfirmOptions;
+  /** Text/style customization for the session view confirmation popup. */
+  sessionConfirm: ConfirmOptions;
   socketHost?: string;
 
   // @deprecated
@@ -98,6 +110,15 @@ export interface Options {
    * @default Autostart.Auto
    */
   autostart: Autostart;
+  /**
+   * Require explicit user confirmation before anything is shared with an
+   * agent: assist starts and opens the socket as usual, but no messages are
+   * sent through it until the user approves the confirmation popup, which is
+   * shown as soon as the first agent connects to the session. The approval
+   * is remembered per-tab (sessionStorage) until stop() is called.
+   * @default false
+   */
+  requestConfirm: boolean;
 }
 
 enum CallingState {
@@ -131,6 +152,8 @@ export default class Assist {
   private peerReconnectTimeout: ReturnType<typeof setTimeout> | null = null;
   private agents: Record<string, Agent> = {};
   private config: RTCIceServer[] | undefined;
+  private sessionConfirmed = false;
+  private sessionConfirmWindow: ConfirmWindow | null = null;
   private readonly options: Options;
   private readonly canvasMap: Map<number, Canvas> = new Map();
   private iceCandidatesBuffer: Map<string, RTCIceCandidateInit[]> = new Map();
@@ -161,6 +184,8 @@ export default class Assist {
         callConfirm: {},
         controlConfirm: {}, // TODO: clear options passing/merging/overwriting
         recordingConfirm: {},
+        sessionConfirm: {},
+        requestConfirm: false,
         socketHost: "",
         compressionEnabled: false,
         compressionMinBatchSize: 5000,
@@ -173,6 +198,10 @@ export default class Assist {
 
     if (this.app.options.assistSocketHost) {
       this.options.socketHost = this.app.options.assistSocketHost;
+    }
+
+    if (this.options.requestConfirm) {
+      this.sessionConfirmed = sessionStorage.getItem(SS_CONFIRM_KEY) === "1";
     }
 
     if (document.hidden !== undefined) {
@@ -224,7 +253,7 @@ export default class Assist {
       this.titleObserver?.disconnect();
     });
     app.attachCommitCallback((messages) => {
-      if (this.agentsConnected) {
+      if (this.agentsConnected && this.canSendMessages) {
         const batchSize = messages.length;
         // @ts-ignore No need in statistics messages. TODO proper filter
         if (
@@ -316,6 +345,11 @@ export default class Assist {
     if (this.continuationEnabled) {
       sessionStorage.removeItem(SS_CONTINUE_KEY);
     }
+    if (this.options.requestConfirm) {
+      // explicit stop revokes the approval; next start re-prompts
+      sessionStorage.removeItem(SS_CONFIRM_KEY);
+      this.sessionConfirmed = false;
+    }
     this.clean();
   }
 
@@ -343,12 +377,110 @@ export default class Assist {
     this.beginAssist();
   }
 
-  private emit(ev: string, args?: any): void {
+  private emit(ev: string, args?: any, force = false): void {
+    // requestConfirm mode: nothing leaves the socket until the user approves,
+    // except the confirmation-state events themselves (force)
+    if (!force && !this.canSendMessages) {
+      return;
+    }
     this.socket &&
       this.socket.emit(ev, {
         meta: { tabId: this.app.getTabId() },
         data: args,
       });
+  }
+
+  /** False only in requestConfirm mode while the user hasn't approved yet. */
+  private get canSendMessages(): boolean {
+    return !this.options.requestConfirm || this.sessionConfirmed;
+  }
+
+  /**
+   * requestConfirm mode: shows the confirmation popup (once) and tells the
+   * connected agents the session is waiting for the user's approval.
+   */
+  private requestSessionConfirm = (agentInfo?: AgentInfo) => {
+    if (this.canSendMessages) {
+      return;
+    }
+    // let every agent (including ones connecting while the popup is already
+    // shown) know the session is waiting for user confirmation
+    this.emit("session_confirm_pending", undefined, true);
+    if (this.sessionConfirmWindow) {
+      return;
+    }
+    this.sessionConfirmWindow = new ConfirmWindow(
+      sessionConfirmDefault(this.options.sessionConfirm),
+    );
+    this.playNotificationSound();
+    this.sessionConfirmWindow
+      .mount()
+      .then((answer) => this.answerSessionConfirm(answer, agentInfo))
+      .catch(() => {}); // window removed without an answer
+  };
+
+  private answerSessionConfirm = (
+    answer: boolean,
+    agentInfo?: AgentInfo,
+    fromAnotherTab = false,
+  ) => {
+    this.closeSessionConfirmWindow();
+    if (answer) {
+      if (this.sessionConfirmed) {
+        return;
+      }
+      this.sessionConfirmed = true;
+      sessionStorage.setItem(SS_CONFIRM_KEY, "1");
+      this.emit("session_confirm_accepted", undefined, true);
+      this.options.onSessionConfirmApprove?.(agentInfo || {});
+      // everything before the approval was suppressed; restart tracking so
+      // the agents receive a full snapshot
+      this.restartTracking(() =>
+        this.remoteControl?.reconnect(Object.keys(this.agents)),
+      );
+    } else {
+      this.emit("session_confirm_rejected", undefined, true);
+      this.options.onSessionConfirmDeny?.(agentInfo || {});
+    }
+    if (!fromAnotherTab) {
+      this.publishState({
+        type: "assist_state",
+        update: "confirm",
+        confirmAnswer: answer,
+      });
+    }
+  };
+
+  private closeSessionConfirmWindow = () => {
+    this.sessionConfirmWindow?.remove();
+    this.sessionConfirmWindow = null;
+  };
+
+  /** Restarts the tracker app so agents receive a full DOM snapshot. */
+  private restartTracking(onRestarted?: () => void) {
+    if (!this.app.active()) {
+      return;
+    }
+    this.assistDemandedRestart = true;
+    this.app.stop(false);
+    this.app.clearBuffers();
+    this.app.waitStatus(0).then(() => {
+      this.app.allowAppStart();
+      setTimeout(() => {
+        this.app
+          .start()
+          .then(() => {
+            this.assistDemandedRestart = false;
+          })
+          .then(() => {
+            onRestarted?.();
+          })
+          .catch((e) => {
+            this.assistDemandedRestart = false;
+            this.app.debug.error(e);
+          });
+      }, 100);
+    });
   }
 
   private get agentsConnected(): boolean {
@@ -502,6 +634,7 @@ export default class Assist {
     }
     if (this.remoteControl !== null) {
       socket.on("request_control", (agentId, dataObj) => {
+        if (!this.canSendMessages) return;
         processEvent(agentId, dataObj, this.remoteControl?.requestControl);
       });
       socket.on("release_control", (agentId, dataObj) => {
@@ -566,28 +699,13 @@ export default class Assist {
         onDisconnect: this.options.onAgentConnect?.(info),
         agentInfo: info, // TODO ?
       };
-      if (this.app.active()) {
-        this.assistDemandedRestart = true;
-        this.app.stop(false);
-        this.app.clearBuffers();
-        this.app.waitStatus(0).then(() => {
-          this.app.allowAppStart();
-          setTimeout(() => {
-            this.app
-              .start()
-              .then(() => {
-                this.assistDemandedRestart = false;
-              })
-              .then(() => {
-                this.remoteControl?.reconnect([id]);
-              })
-              .catch((e) => {
-                this.assistDemandedRestart = false;
-                app.debug.error(e);
-              });
-          }, 100);
-        });
+      if (!this.canSendMessages) {
+        // nothing goes out until the user approves; the restart (and full
+        // snapshot) happens on approval instead
+        this.requestSessionConfirm(info);
+        return;
       }
+      this.restartTracking(() => this.remoteControl?.reconnect([id]));
     });
 
     socket.on("AGENTS_INFO_CONNECTED", (agentsInfo: AgentInfo[]) => {
@@ -599,28 +717,13 @@ export default class Assist {
           onDisconnect: this.options.onAgentConnect?.(agentInfo),
         };
       });
-      if (this.app.active()) {
-        this.assistDemandedRestart = true;
-        this.app.stop(false);
-        this.app.clearBuffers();
-        this.app.waitStatus(0).then(() => {
-          this.app.allowAppStart();
-          setTimeout(() => {
-            this.app
-              .start()
-              .then(() => {
-                this.assistDemandedRestart = false;
-              })
-              .then(() => {
-                this.remoteControl?.reconnect(Object.keys(this.agents));
-              })
-              .catch((e) => {
-                this.assistDemandedRestart = false;
-                app.debug.error(e);
-              });
-          }, 100);
-        });
+      if (!this.canSendMessages) {
+        this.requestSessionConfirm(agentsInfo[0]);
+        return;
       }
+      this.restartTracking(() =>
+        this.remoteControl?.reconnect(Object.keys(this.agents)),
+      );
     });
 
     socket.on("AGENT_DISCONNECTED", (id) => {
@@ -634,6 +737,10 @@ export default class Assist {
 
       recordingState.stopAgentRecording(id);
       endAgentCall({ socketId: id });
+      if (!this.agentsConnected) {
+        // no one left waiting for an answer
+        this.closeSessionConfirmWindow();
+      }
     });
 
     socket.on("NO_AGENT", () => {
@@ -641,6 +748,7 @@ export default class Assist {
       this.cleanCanvasConnections();
       this.agents = {};
       if (recordingState.isActive) recordingState.stopRecording();
+      this.closeSessionConfirmWindow();
     });
 
     socket.on("call_end", (socketId, msg) => {
@@ -700,6 +808,7 @@ export default class Assist {
     });
 
     socket.on("request_recording", (id, info) => {
+      if (!this.canSendMessages) return;
       if (app.getTabId() !== info.meta.tabId) return;
       const agentData = info.data;
       if (!recordingState.isActive) {
@@ -721,6 +830,7 @@ export default class Assist {
     socket.on(
       "webrtc_call_offer",
       async (_, data: { from: string; offer: RTCSessionDescriptionInit }) => {
+        if (!this.canSendMessages) return;
         if (!this.calls.has(data.from)) {
           await handleIncomingCallOffer(data.from, data.offer);
         }
@@ -1022,6 +1132,9 @@ export default class Assist {
     };
 
     const startCanvasStream = async (stream: MediaStream, id: number) => {
+      // canvas streams go over WebRTC, not this.emit — gate them explicitly;
+      // the restart on approval re-triggers the node callbacks
+      if (!this.canSendMessages) return;
       for (const agent of Object.values(this.agents)) {
         if (!agent.agentInfo) continue;
 
@@ -1102,6 +1215,7 @@ export default class Assist {
 
   // clear all data
   private clean() {
+    this.closeSessionConfirmWindow();
     // sometimes means new agent connected, so we keep id for control
     this.remoteControl?.releaseControl(false, true);
     if (this.peerReconnectTimeout) {
@@ -1200,6 +1314,16 @@ export default class Assist {
           this.remoteControl?.grantControl(msg.data.rcActive, true);
         } else {
           this.remoteControl?.releaseControl(false, false, true);
+        }
+      }
+      if (msg.data.update === "confirm" && this.options.requestConfirm) {
+        // the user answered the session confirm popup in another tab
+        if (msg.data.confirmAnswer) {
+          if (!this.sessionConfirmed) {
+            this.answerSessionConfirm(true, undefined, true);
+          }
+        } else if (this.sessionConfirmWindow) {
+          this.answerSessionConfirm(false, undefined, true);
         }
       }
       Object.assign(this.tabState, msg.data);

--- a/tracker/tracker-assist/src/ConfirmWindow/defaults.ts
+++ b/tracker/tracker-assist/src/ConfirmWindow/defaults.ts
@@ -6,6 +6,7 @@ const TEXT_GRANT_REMORTE_ACCESS = 'Grant Remote Control'
 const TEXT_REJECT = 'Reject'
 const TEXT_ANSWER_CALL = 'Answer'
 const TEXT_ACCEPT_RECORDING = 'Allow Recording'
+const TEXT_ALLOW_SESSION = 'Allow'
 
 export type Options = string | Partial<ConfirmWindowOptions>;
 
@@ -48,4 +49,12 @@ export const recordRequestDefault = (opts: Options) =>
       TEXT_ACCEPT_RECORDING,
       TEXT_REJECT,
       'Agent requested to record activity in this browser tab.'
+    )
+
+export const sessionConfirmDefault = (opts: Options) =>
+    confirmDefault(
+      opts,
+      TEXT_ALLOW_SESSION,
+      TEXT_REJECT,
+      'Agent requested to view this session live. Allow?'
     )

--- a/tracker/tracker-assist/tests/Assist.test.ts
+++ b/tracker/tracker-assist/tests/Assist.test.ts
@@ -503,6 +503,41 @@ describe('Assist — requestConfirm popup flow (socket)', () => {
     expect(wrapper()).toBe(null)
   })
 
+  test('a throwing approve callback does not block the restart', async () => {
+    startAssist({
+      onSessionConfirmApprove: () => { throw new Error('boom') },
+    })
+    handlers.NEW_AGENT('agent-1', agentInfo)
+
+    clickConfirm()
+    await flush()
+
+    expect(fakeSocket.emit).toHaveBeenCalledWith('session_confirm_accepted', expect.anything())
+    expect(app.stop).toHaveBeenCalledWith(false)
+    expect(app.debug.error).toHaveBeenCalled()
+  })
+
+  test('NEW_AGENT during an in-flight restart queues its reconnect instead of dropping it', async () => {
+    let finishWait: () => void = () => {}
+    app.waitStatus = jest.fn(() => new Promise<void>((resolve) => { finishWait = resolve }))
+    startAssist({ requestConfirm: false, })
+    const reconnectSpy = jest
+      .spyOn(assist.remoteControl, 'reconnect')
+      .mockImplementation(() => {})
+
+    handlers.NEW_AGENT('agent-1', agentInfo)
+    // stop phase of the first restart: app is no longer active
+    app.active.mockReturnValue(false)
+    handlers.NEW_AGENT('agent-2', agentInfo)
+    expect(app.stop).toHaveBeenCalledTimes(1)
+
+    finishWait()
+    await new Promise((resolve) => setTimeout(resolve, 150)) // restart's 100ms delay
+
+    expect(reconnectSpy).toHaveBeenCalledWith(['agent-1',])
+    expect(reconnectSpy).toHaveBeenCalledWith(['agent-2',])
+  })
+
   test('pre-approval agent interactions are ignored while unconfirmed', () => {
     startAssist()
     handlers.NEW_AGENT('agent-1', agentInfo)

--- a/tracker/tracker-assist/tests/Assist.test.ts
+++ b/tracker/tracker-assist/tests/Assist.test.ts
@@ -4,7 +4,10 @@ jest.mock('@openreplay/tracker', () => ({ App: jest.fn(), }))
 jest.mock('socket.io-client', () => ({ connect: jest.fn(), }))
 jest.mock('fflate', () => ({ gzip: jest.fn(), }))
 
+import { connect } from 'socket.io-client'
 import Assist from '../src/Assist'
+
+const SS_CONFIRM_KEY = '__openreplay_session_confirm'
 
 const makeApp = () => ({
   options: { assistSocketHost: undefined, },
@@ -163,5 +166,352 @@ describe('Assist — stopCanvasStream', () => {
 
     expect(pcB.close).toHaveBeenCalledTimes(1)
     expect(assist.canvasPeers.has('peerB-2-canvas-5')).toBe(false)
+  })
+})
+
+describe('Assist — requestConfirm gating', () => {
+  let assist: any
+  let app: any
+  let socketEmit: ReturnType<typeof jest.fn>
+
+  const makeAssist = (options: Record<string, any> = {}) => {
+    const a: any = new Assist(app as any, { requestConfirm: true, ...options, })
+    socketEmit = jest.fn()
+    a.socket = { emit: socketEmit, disconnect: jest.fn(), } as any
+    a.tabBus = { postMessage: jest.fn(), addEventListener: jest.fn(), } as any
+    return a
+  }
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    document.body.innerHTML = ''
+    app = { ...makeApp(), getTabId: jest.fn(() => 'tab-1'), }
+    jest
+      .spyOn(Assist.prototype as any, 'playNotificationSound')
+      .mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  test('emit() sends normally when requestConfirm is off', () => {
+    assist = makeAssist({ requestConfirm: false, })
+    assist.emit('messages', [1,])
+    expect(socketEmit).toHaveBeenCalledWith('messages', {
+      meta: { tabId: 'tab-1', },
+      data: [1,],
+    })
+  })
+
+  test('emit() drops everything while unconfirmed, force bypasses the gate', () => {
+    assist = makeAssist()
+    assist.emit('messages', [1,])
+    assist.emit('UPDATE_SESSION', { active: true, })
+    expect(socketEmit).not.toHaveBeenCalled()
+
+    assist.emit('session_confirm_pending', undefined, true)
+    expect(socketEmit).toHaveBeenCalledTimes(1)
+    expect(socketEmit).toHaveBeenCalledWith('session_confirm_pending', {
+      meta: { tabId: 'tab-1', },
+      data: undefined,
+    })
+  })
+
+  test('constructor restores a persisted approval from sessionStorage', () => {
+    sessionStorage.setItem(SS_CONFIRM_KEY, '1')
+    assist = makeAssist()
+    assist.emit('messages', [1,])
+    expect(socketEmit).toHaveBeenCalledWith('messages', expect.anything())
+  })
+
+  test('stop() revokes the approval', () => {
+    sessionStorage.setItem(SS_CONFIRM_KEY, '1')
+    assist = makeAssist()
+    assist.stop()
+    expect(sessionStorage.getItem(SS_CONFIRM_KEY)).toBe(null)
+    expect(assist.sessionConfirmed).toBe(false)
+  })
+
+  test('answerSessionConfirm(true) confirms, persists, notifies agents and restarts tracking', () => {
+    const onSessionConfirmApprove = jest.fn()
+    assist = makeAssist({ onSessionConfirmApprove, })
+    const restartSpy = jest
+      .spyOn(assist, 'restartTracking')
+      .mockImplementation(() => {})
+    const agentInfo = { id: 1, name: 'Agent', }
+
+    assist.answerSessionConfirm(true, agentInfo)
+
+    expect(assist.sessionConfirmed).toBe(true)
+    expect(sessionStorage.getItem(SS_CONFIRM_KEY)).toBe('1')
+    expect(socketEmit).toHaveBeenCalledWith('session_confirm_accepted', expect.anything())
+    expect(onSessionConfirmApprove).toHaveBeenCalledWith(agentInfo)
+    expect(restartSpy).toHaveBeenCalledTimes(1)
+    expect(assist.tabBus.postMessage).toHaveBeenCalledWith({
+      type: 'assist_state',
+      update: 'confirm',
+      confirmAnswer: true,
+    })
+  })
+
+  test('answerSessionConfirm(false) notifies rejection and keeps the gate closed', () => {
+    const onSessionConfirmDeny = jest.fn()
+    assist = makeAssist({ onSessionConfirmDeny, })
+    const restartSpy = jest
+      .spyOn(assist, 'restartTracking')
+      .mockImplementation(() => {})
+
+    assist.answerSessionConfirm(false, { id: 1, })
+
+    expect(assist.sessionConfirmed).toBe(false)
+    expect(sessionStorage.getItem(SS_CONFIRM_KEY)).toBe(null)
+    expect(socketEmit).toHaveBeenCalledWith('session_confirm_rejected', expect.anything())
+    expect(onSessionConfirmDeny).toHaveBeenCalledWith({ id: 1, })
+    expect(restartSpy).not.toHaveBeenCalled()
+
+    assist.emit('messages', [1,])
+    expect(socketEmit).not.toHaveBeenCalledWith('messages', expect.anything())
+  })
+
+  test('approval from another tab is applied without re-broadcasting', () => {
+    assist = makeAssist()
+    const restartSpy = jest
+      .spyOn(assist, 'restartTracking')
+      .mockImplementation(() => {})
+
+    assist.handleTabStateMessage({
+      data: { type: 'assist_state', update: 'confirm', confirmAnswer: true, },
+    })
+
+    expect(assist.sessionConfirmed).toBe(true)
+    expect(socketEmit).toHaveBeenCalledWith('session_confirm_accepted', expect.anything())
+    expect(restartSpy).toHaveBeenCalledTimes(1)
+    expect(assist.tabBus.postMessage).not.toHaveBeenCalled()
+  })
+
+  test('denial from another tab closes the pending popup', () => {
+    const onSessionConfirmDeny = jest.fn()
+    assist = makeAssist({ onSessionConfirmDeny, })
+    const windowRemove = jest.fn()
+    assist.sessionConfirmWindow = { remove: windowRemove, }
+
+    assist.handleTabStateMessage({
+      data: { type: 'assist_state', update: 'confirm', confirmAnswer: false, },
+    })
+
+    expect(windowRemove).toHaveBeenCalledTimes(1)
+    expect(assist.sessionConfirmWindow).toBe(null)
+    expect(socketEmit).toHaveBeenCalledWith('session_confirm_rejected', expect.anything())
+    expect(onSessionConfirmDeny).toHaveBeenCalledWith({})
+    expect(assist.sessionConfirmed).toBe(false)
+  })
+
+  test('confirm messages from another tab are ignored when requestConfirm is off', () => {
+    assist = makeAssist({ requestConfirm: false, })
+    const restartSpy = jest
+      .spyOn(assist, 'restartTracking')
+      .mockImplementation(() => {})
+
+    assist.handleTabStateMessage({
+      data: { type: 'assist_state', update: 'confirm', confirmAnswer: true, },
+    })
+
+    expect(restartSpy).not.toHaveBeenCalled()
+    expect(socketEmit).not.toHaveBeenCalled()
+  })
+})
+
+describe('Assist — requestConfirm popup flow (socket)', () => {
+  let assist: any
+  let app: any
+  let handlers: Record<string, (...args: any[]) => void>
+  let fakeSocket: any
+
+  const agentInfo = {
+    config: '', email: 'a@a', id: 1, name: 'Agent', peerId: 'p', query: '',
+  }
+
+  const wrapper = () =>
+    document.getElementById('openreplay-confirm-window-wrapper')
+  const clickConfirm = () =>
+    (document.getElementById('openreplay-confirm-window-confirm-btn') as HTMLButtonElement).click()
+  const clickDecline = () =>
+    (document.getElementById('openreplay-confirm-window-decline-btn') as HTMLButtonElement).click()
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+  const makeSocketApp = () => ({
+    ...makeApp(),
+    active: jest.fn(() => true),
+    getSessionID: jest.fn(() => 'session-1'),
+    getProjectKey: jest.fn(() => 'project-1'),
+    getTabId: jest.fn(() => 'tab-1'),
+    getSessionInfo: jest.fn(() => ({})),
+    getHost: jest.fn(() => 'app.local'),
+    socketMode: false,
+    stop: jest.fn(),
+    start: jest.fn(() => Promise.resolve()),
+    clearBuffers: jest.fn(),
+    // freeze the restart before it reaches timers/app.start
+    waitStatus: jest.fn(() => new Promise(() => {})),
+    allowAppStart: jest.fn(),
+    nodes: { attachNodeCallback: jest.fn(), getID: jest.fn(), getNode: jest.fn(), },
+    sanitizer: { isHidden: jest.fn(() => false), },
+  })
+
+  const startAssist = (options: Record<string, any> = {}) => {
+    assist = new Assist(app as any, { requestConfirm: true, ...options, })
+    assist.onStart()
+    return assist
+  }
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    document.body.innerHTML = ''
+    app = makeSocketApp()
+    handlers = {}
+    fakeSocket = {
+      on: jest.fn((ev: string, cb: any) => { handlers[ev] = cb }),
+      onAny: jest.fn(),
+      emit: jest.fn(),
+      disconnect: jest.fn(),
+      connect: jest.fn(),
+    }
+    ;(connect as unknown as jest.Mock).mockReturnValue(fakeSocket)
+    jest
+      .spyOn(Assist.prototype as any, 'playNotificationSound')
+      .mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  test('NEW_AGENT while unconfirmed shows the popup, emits pending state and skips the restart', () => {
+    startAssist()
+
+    handlers.NEW_AGENT('agent-1', agentInfo)
+
+    expect(wrapper()).not.toBe(null)
+    expect(fakeSocket.emit).toHaveBeenCalledWith('session_confirm_pending', {
+      meta: { tabId: 'tab-1', },
+      data: undefined,
+    })
+    expect(app.stop).not.toHaveBeenCalled()
+
+    // a second agent re-emits pending but doesn't duplicate the popup
+    handlers.NEW_AGENT('agent-2', agentInfo)
+    expect(document.querySelectorAll('#openreplay-confirm-window-wrapper').length).toBe(1)
+  })
+
+  test('AGENTS_INFO_CONNECTED while unconfirmed shows the popup too', () => {
+    startAssist()
+
+    handlers.AGENTS_INFO_CONNECTED([{ ...agentInfo, socketId: 's-1', },])
+
+    expect(wrapper()).not.toBe(null)
+    expect(app.stop).not.toHaveBeenCalled()
+  })
+
+  test('approving the popup emits accepted, opens the gate and restarts tracking', async () => {
+    const onSessionConfirmApprove = jest.fn()
+    startAssist({ onSessionConfirmApprove, })
+    handlers.NEW_AGENT('agent-1', agentInfo)
+
+    clickConfirm()
+    await flush()
+
+    expect(wrapper()).toBe(null)
+    expect(sessionStorage.getItem(SS_CONFIRM_KEY)).toBe('1')
+    expect(fakeSocket.emit).toHaveBeenCalledWith('session_confirm_accepted', {
+      meta: { tabId: 'tab-1', },
+      data: undefined,
+    })
+    expect(onSessionConfirmApprove).toHaveBeenCalledWith(agentInfo)
+    // restart began: full snapshot will be resent to agents
+    expect(app.stop).toHaveBeenCalledWith(false)
+    expect(app.clearBuffers).toHaveBeenCalledTimes(1)
+
+    assist.emit('messages', [1,])
+    expect(fakeSocket.emit).toHaveBeenCalledWith('messages', expect.anything())
+  })
+
+  test('declining the popup emits rejected and keeps messages blocked', async () => {
+    const onSessionConfirmDeny = jest.fn()
+    startAssist({ onSessionConfirmDeny, })
+    handlers.NEW_AGENT('agent-1', agentInfo)
+
+    clickDecline()
+    await flush()
+
+    expect(wrapper()).toBe(null)
+    expect(sessionStorage.getItem(SS_CONFIRM_KEY)).toBe(null)
+    expect(fakeSocket.emit).toHaveBeenCalledWith('session_confirm_rejected', {
+      meta: { tabId: 'tab-1', },
+      data: undefined,
+    })
+    expect(onSessionConfirmDeny).toHaveBeenCalledWith(agentInfo)
+    expect(app.stop).not.toHaveBeenCalled()
+
+    assist.emit('messages', [1,])
+    expect(fakeSocket.emit).not.toHaveBeenCalledWith('messages', expect.anything())
+
+    // next agent connection re-prompts
+    handlers.NEW_AGENT('agent-2', agentInfo)
+    expect(wrapper()).not.toBe(null)
+  })
+
+  test('NEW_AGENT without requestConfirm restarts tracking immediately, no popup', () => {
+    startAssist({ requestConfirm: false, })
+
+    handlers.NEW_AGENT('agent-1', agentInfo)
+
+    expect(wrapper()).toBe(null)
+    expect(app.stop).toHaveBeenCalledWith(false)
+    expect(fakeSocket.emit).not.toHaveBeenCalledWith('session_confirm_pending', expect.anything())
+  })
+
+  test('NEW_AGENT with a persisted approval skips the popup and restarts', () => {
+    sessionStorage.setItem(SS_CONFIRM_KEY, '1')
+    startAssist()
+
+    handlers.NEW_AGENT('agent-1', agentInfo)
+
+    expect(wrapper()).toBe(null)
+    expect(app.stop).toHaveBeenCalledWith(false)
+  })
+
+  test('NO_AGENT removes the pending popup', () => {
+    startAssist()
+    handlers.NEW_AGENT('agent-1', agentInfo)
+    expect(wrapper()).not.toBe(null)
+
+    handlers.NO_AGENT()
+
+    expect(wrapper()).toBe(null)
+  })
+
+  test('AGENT_DISCONNECTED of the last agent removes the pending popup', () => {
+    startAssist()
+    handlers.NEW_AGENT('agent-1', agentInfo)
+    expect(wrapper()).not.toBe(null)
+
+    handlers.AGENT_DISCONNECTED('agent-1')
+
+    expect(wrapper()).toBe(null)
+  })
+
+  test('pre-approval agent interactions are ignored while unconfirmed', () => {
+    startAssist()
+    handlers.NEW_AGENT('agent-1', agentInfo)
+
+    handlers.request_control('agent-1', { meta: { tabId: 'tab-1', }, data: 'agent-1', })
+    handlers.request_recording('agent-1', { meta: { tabId: 'tab-1', }, data: '{}', })
+
+    // no control/recording confirm popups on top of the session confirm one
+    expect(document.querySelectorAll('#openreplay-confirm-window-wrapper').length).toBe(1)
+    expect(fakeSocket.emit).not.toHaveBeenCalledWith('recording_busy', expect.anything())
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a user-approval step before agents can view a live session. All socket messages and WebRTC actions are blocked until approval; the UI shows a pending state and handles accept/deny across tabs.

- **New Features**
  - `@openreplay/tracker-assist`:
    - `requestConfirm` gates all messages and WebRTC (calls, control, recording, canvas streams) until the user approves; emits `session_confirm_pending`/`accepted`/`rejected`. On approval, tracking restarts to send a full snapshot. Approval is remembered per tab (`sessionStorage`) until `assist.stop()`, and approval/denial is synced across tabs.
    - `sessionConfirm` to customize the popup; defaults updated (confirm label “Allow”). `onSessionConfirmApprove` and `onSessionConfirmDeny` callbacks.
  - Player/UI:
    - Add `SessionConfirmStatus`; handle `session_confirm_*` events in the Assist store and show an error toast on rejection.
    - Overlay shows a new “SessionConfirm” request window; the cancel button is hidden for this state.

- **Migration**
  - To enable: set `requestConfirm: true` in `trackerAssist({...})`.
  - Optional: customize with `sessionConfirm`, and handle `onSessionConfirmApprove`/`onSessionConfirmDeny`.
  - Defaults keep previous behavior when `requestConfirm` is false.

<sup>Written for commit 92d54b6e37fa3182838fe0fca3d377353e122861. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

