### PR TITLE
[HTTP] added a new batch type support (visual = player+assets)

### DIFF
--- a/backend/pkg/sessions/api/web/handlers.go
+++ b/backend/pkg/sessions/api/web/handlers.go
@@ -352,22 +352,59 @@ func (e *handlersImpl) pushMessagesHandlerWeb(w http.ResponseWriter, r *http.Req
 	}
 	bodySize = len(bodyBytes)
 
-	topic := e.cfg.TopicRawWeb
-	switch batchType {
-	case "assets":
-		topic = e.cfg.TopicRawAssets
-	default: // "analytics", "devtools", "replay"
-		topic = e.cfg.TopicRawWeb
-	}
-	err = e.producer.Produce(topic, sessionData.ID, bodyBytes)
-	if err != nil {
-		e.log.Error(r.Context(), "can't send messages batch to queue: %s", err)
-		errCode := http.StatusInternalServerError
-		if tokenJustExpired {
-			errCode = http.StatusUnauthorized
+	if batchType == "visual" {
+		// parse split url parameter
+		splitString := r.URL.Query().Get("split")
+		if splitString == "" {
+			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusBadRequest, errors.New("split value is empty"), startTime, r.URL.Path, bodySize)
+			return
 		}
-		e.responser.ResponseWithError(e.log, r.Context(), w, errCode, errors.New("can't save message, try again"), startTime, r.URL.Path, bodySize)
-		return
+		split, err := strconv.Atoi(splitString)
+		if err != nil {
+			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusBadRequest, err, startTime, r.URL.Path, bodySize)
+			return
+		}
+		if split <= 0 || split >= bodySize {
+			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusBadRequest, errors.New("split value is out of range"), startTime, r.URL.Path, bodySize)
+			return
+		}
+
+		// split batches [player]split[assets] and send them to 2 different topics
+		errs := make([]error, 0)
+		if err = e.producer.Produce(e.cfg.TopicRawWeb, sessionData.ID, bodyBytes[:split]); err != nil {
+			errs = append(errs, err)
+		}
+		if err = e.producer.Produce(e.cfg.TopicRawAssets, sessionData.ID, bodyBytes[split:]); err != nil {
+			errs = append(errs, err)
+		}
+
+		if len(errs) > 0 {
+			errCode := http.StatusInternalServerError
+			if tokenJustExpired {
+				errCode = http.StatusUnauthorized
+			}
+			e.responser.ResponseWithError(e.log, r.Context(), w, errCode, errors.Join(errs...), startTime, r.URL.Path, bodySize)
+			return
+		}
+	} else {
+		topic := e.cfg.TopicRawWeb
+		switch batchType {
+		case "assets":
+			topic = e.cfg.TopicRawAssets
+		default: // "analytics", "devtools", "replay"
+			topic = e.cfg.TopicRawWeb
+		}
+
+		err = e.producer.Produce(topic, sessionData.ID, bodyBytes)
+		if err != nil {
+			e.log.Error(r.Context(), "can't send messages batch to queue: %s", err)
+			errCode := http.StatusInternalServerError
+			if tokenJustExpired {
+				errCode = http.StatusUnauthorized
+			}
+			e.responser.ResponseWithError(e.log, r.Context(), w, errCode, errors.New("can't save message, try again"), startTime, r.URL.Path, bodySize)
+			return
+		}
 	}
 
 	if tokenJustExpired {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for a new "visual" batch type in the HTTP messages API, letting clients send combined player+assets in one request. The server splits the payload and routes each part to the correct topic.

- **New Features**
  - Accepts `batchType=visual` with a required `split` query param.
  - Validates `split` (integer, >0, < body size); returns 400 on invalid.
  - Publishes `body[:split]` to `TopicRawWeb` and `body[split:]` to `TopicRawAssets`.
  - Aggregates produce errors and returns 500 (or 401 if the token just expired). Other batch types behave unchanged.

<sup>Written for commit fb08c5808cd98c95655da0d589b40517e9056596. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

