### PR TITLE
fix(api): scope assist records scope

### DIFF
--- a/ee/api/chalicelib/core/assist_records.py
+++ b/ee/api/chalicelib/core/assist_records.py
@@ -110,7 +110,12 @@ def get_record(project_id, record_id, context: schemas.CurrentContext):
 
 def update_record(project_id, record_id, data: schemas.AssistRecordUpdatePayloadSchema,
                   context: schemas.CurrentContext):
-    conditions = ["assist_records.record_id=%(record_id)s", "assist_records.deleted_at ISNULL"]
+    conditions = ["assist_records.record_id=%(record_id)s",
+                  "assist_records.deleted_at ISNULL",
+                  "assist_records.project_id=%(project_id)s",
+                  "projects.project_id=%(project_id)s",
+                  "projects.tenant_id=%(tenant_id)s",
+                  "projects.deleted_at ISNULL"]
     params = {"tenant_id": context.tenant_id, "project_id": project_id, "record_id": record_id, "name": data.name}
     with pg_client.PostgresClient() as cur:
         query = cur.mogrify(f"""UPDATE assist_records
@@ -119,9 +124,9 @@ def update_record(project_id, record_id, data: schemas.AssistRecordUpdatePayload
                                       FROM assist_records INNER JOIN users USING (user_id)
                                       WHERE record_id = %(record_id)s
                                         AND assist_records.deleted_at ISNULL
-                                      LIMIT 1) AS users
+                                      LIMIT 1) AS users, projects
                                 WHERE {" AND ".join(conditions)}
-                                RETURNING record_id, user_id, session_id, assist_records.created_at, 
+                                RETURNING record_id, user_id, session_id, assist_records.created_at,
                                        assist_records.name, duration, created_by, file_key;""", params)
         cur.execute(query)
         result = helper.dict_to_camel_case(cur.fetchone())
@@ -135,11 +140,16 @@ def update_record(project_id, record_id, data: schemas.AssistRecordUpdatePayload
 
 
 def delete_record(project_id, record_id, context: schemas.CurrentContext):
-    conditions = ["assist_records.record_id=%(record_id)s"]
+    conditions = ["assist_records.record_id=%(record_id)s",
+                  "assist_records.project_id=%(project_id)s",
+                  "projects.project_id=%(project_id)s",
+                  "projects.tenant_id=%(tenant_id)s",
+                  "projects.deleted_at ISNULL"]
     params = {"tenant_id": context.tenant_id, "project_id": project_id, "record_id": record_id}
     with pg_client.PostgresClient() as cur:
         query = cur.mogrify(f"""UPDATE assist_records
                                 SET deleted_at= (now() at time zone 'utc')
+                                FROM projects
                                 WHERE {" AND ".join(conditions)}
                                 RETURNING file_key;""", params)
         cur.execute(query)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Scoped assist record update/delete to the caller’s tenant and project to prevent cross-project or cross-tenant changes. Adds a `projects` join and guards to ensure the project matches and isn’t deleted.

- **Bug Fixes**
  - Added `projects` join and WHERE checks (`assist_records.project_id`, `projects.project_id`, `projects.tenant_id`, `projects.deleted_at ISNULL`) in both update_record and delete_record.

<sup>Written for commit 65edf2a40fe94f310b6f55fdf08c091f26e6a2c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

