### PR TITLE
fix(analytics): include user_device_type and user_os_version in sessi…

### DIFF
--- a/backend/pkg/analytics/charts/metric_table.go
+++ b/backend/pkg/analytics/charts/metric_table.go
@@ -614,9 +614,11 @@ func (t *TableQueryBuilder) buildPrewhereConditions(r *Payload, eventsOrder mode
 // The list of session properties and its column names
 var sessionProperties = map[string]string{
 	"user_os":              "user_os",
+	"user_os_version":      "user_os_version",
 	"user_browser":         "user_browser",
 	"user_browser_version": "user_browser_version",
 	"user_device":          "user_device",
+	"user_device_type":     "user_device_type",
 	"user_country":         "user_country",
 	"user_city":            "user_city",
 	"user_state":           "user_state",


### PR DESCRIPTION
…onProperties so filters aren't dropped

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include `user_device_type` and `user_os_version` in the sessionProperties map used by the metric table query builder. This prevents filters on these fields from being dropped and ensures correct analytics filtering.

<sup>Written for commit 20d0d13d9eca64cb5ba69a090dab4d9213a2f56b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

