### PR TITLE
Updated patch build from main 68846ad58e8080c4ca3e134d7b33f8b736bc53b8

### DIFF
--- a/scripts/helmcharts/openreplay/charts/api/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/api/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.6"
+AppVersion: "v1.27.7"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `AppVersion` for the `scripts/helmcharts/openreplay/charts/api` Helm chart from v1.27.6 to v1.27.7 to match the latest patch build. Merging will trigger the tag update job; no chart template changes.

<sup>Written for commit 0469fdb24e1662c392131832fd40016bad1e27a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

