### PR TITLE
feat(api): segments/savedsearch to have iscapture flag

### DIFF
--- a/backend/pkg/analytics/model/model.go
+++ b/backend/pkg/analytics/model/model.go
@@ -211,10 +211,11 @@ type SeriesSessionData struct {
 }
 
 type SavedSearchRequest struct {
-	Name     *string         `json:"name" validate:"omitempty,max=255"`
-	IsPublic *bool           `json:"isPublic"`
-	IsShare  *bool           `json:"isShare"`
-	Data     SavedSearchData `json:"data" validate:"required"`
+	Name      *string         `json:"name" validate:"omitempty,max=255"`
+	IsPublic  *bool           `json:"isPublic"`
+	IsShare   *bool           `json:"isShare"`
+	IsCapture *bool           `json:"isCapture"`
+	Data      SavedSearchData `json:"data" validate:"required"`
 }
 
 type SavedSearchData struct {
@@ -236,6 +237,7 @@ type SavedSearch struct {
 	Name          *string         `json:"name,omitempty"`
 	IsPublic      bool            `json:"isPublic"`
 	IsShare       bool            `json:"isShare"`
+	IsCapture     bool            `json:"isCapture"`
 	Data          SavedSearchData `json:"data"`
 	CreatedAt     time.Time       `json:"createdAt"`
 	SessionsCount int64           `json:"sessionsCount"`
@@ -249,6 +251,7 @@ type SavedSearchResponse struct {
 	Name      *string         `json:"name,omitempty"`
 	IsPublic  bool            `json:"isPublic"`
 	IsShare   bool            `json:"isShare"`
+	IsCapture bool            `json:"isCapture"`
 	Data      SavedSearchData `json:"data"`
 	CreatedAt time.Time       `json:"createdAt"`
 }

--- a/backend/pkg/analytics/saved_searches/handlers.go
+++ b/backend/pkg/analytics/saved_searches/handlers.go
@@ -185,17 +185,18 @@ func (e *handlersImpl) listSavedSearches(w http.ResponseWriter, r *http.Request)
 		order = o
 	}
 
-	searches, total, err := e.savedSearches.List(r.Context(), projectID, currentUser.ID, limit, offset, sort, order)
+	searches, total, totalSessions, err := e.savedSearches.List(r.Context(), projectID, currentUser.ID, limit, offset, sort, order)
 	if err != nil {
 		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusInternalServerError, err, startTime, r.URL.Path, bodySize)
 		return
 	}
 
 	e.responser.ResponseWithJSON(e.log, r.Context(), w, map[string]interface{}{
-		"data":   searches,
-		"total":  total,
-		"limit":  limit,
-		"offset": offset,
+		"data":               searches,
+		"total":              total,
+		"totalSessionsCount": totalSessions,
+		"limit":              limit,
+		"offset":             offset,
 	}, startTime, r.URL.Path, bodySize)
 }
 

--- a/backend/pkg/analytics/saved_searches/saved_searches.go
+++ b/backend/pkg/analytics/saved_searches/saved_searches.go
@@ -88,6 +88,11 @@ func (s *savedSearchesImpl) Save(projectID int, userID uint64, req *model.SavedS
 		isPublic = *req.IsPublic
 	}
 
+	isCapture := false
+	if req.IsCapture != nil {
+		isCapture = *req.IsCapture
+	}
+
 	var expiresAt *time.Time
 	if isShare {
 		exp := time.Now().AddDate(0, expiryMonths, 0)
@@ -96,8 +101,8 @@ func (s *savedSearchesImpl) Save(projectID int, userID uint64, req *model.SavedS
 
 	const insertQuery = `
 		INSERT INTO public.saved_searches (
-			project_id, user_id, name, is_public, is_share, search_data, expires_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7)
+			project_id, user_id, name, is_public, is_share, is_capture, search_data, expires_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		RETURNING search_id, created_at
 	`
 
@@ -110,6 +115,7 @@ func (s *savedSearchesImpl) Save(projectID int, userID uint64, req *model.SavedS
 		req.Name,
 		isPublic,
 		isShare,
+		isCapture,
 		searchDataJSON,
 		expiresAt,
 	).Scan(&searchID, &createdAt)
@@ -124,6 +130,7 @@ func (s *savedSearchesImpl) Save(projectID int, userID uint64, req *model.SavedS
 		Name:      req.Name,
 		IsPublic:  isPublic,
 		IsShare:   isShare,
+		IsCapture: isCapture,
 		Data:      req.Data,
 		CreatedAt: createdAt,
 	}, nil
@@ -133,8 +140,8 @@ func (s *savedSearchesImpl) Get(projectID int, searchID string) (*model.SavedSea
 	ctx := context.Background()
 
 	const selectQuery = `
-		SELECT 
-			search_id, project_id, user_id, name, is_public, is_share, search_data, created_at, expires_at, deleted_at
+		SELECT
+			search_id, project_id, user_id, name, is_public, is_share, is_capture, search_data, created_at, expires_at, deleted_at
 		FROM public.saved_searches
 		WHERE search_id=$1 AND project_id=$2 AND deleted_at IS NULL
 			AND (expires_at IS NULL OR expires_at > NOW())
@@ -150,6 +157,7 @@ func (s *savedSearchesImpl) Get(projectID int, searchID string) (*model.SavedSea
 		&savedSearch.Name,
 		&savedSearch.IsPublic,
 		&savedSearch.IsShare,
+		&savedSearch.IsCapture,
 		&searchDataJSON,
 		&savedSearch.CreatedAt,
 		&savedSearch.ExpiresAt,
@@ -193,7 +201,7 @@ func (s *savedSearchesImpl) List(ctx context.Context, projectID int, userID uint
 
 	selectQuery := fmt.Sprintf(`
 		SELECT
-			ss.search_id, ss.project_id, ss.user_id, u.name AS user_name, ss.name, ss.is_public, ss.is_share,
+			ss.search_id, ss.project_id, ss.user_id, u.name AS user_name, ss.name, ss.is_public, ss.is_share, ss.is_capture,
 			ss.search_data, ss.created_at, ss.expires_at, ss.deleted_at,
 			COUNT(*) OVER() AS total_count
 		FROM public.saved_searches ss
@@ -227,6 +235,7 @@ func (s *savedSearchesImpl) List(ctx context.Context, projectID int, userID uint
 			&savedSearch.Name,
 			&savedSearch.IsPublic,
 			&savedSearch.IsShare,
+			&savedSearch.IsCapture,
 			&searchDataJSON,
 			&savedSearch.CreatedAt,
 			&savedSearch.ExpiresAt,
@@ -323,10 +332,15 @@ func (s *savedSearchesImpl) Update(projectID int, userID uint64, searchID string
 		isPublic = *req.IsPublic
 	}
 
+	isCapture := false
+	if req.IsCapture != nil {
+		isCapture = *req.IsCapture
+	}
+
 	const updateQuery = `
 		UPDATE public.saved_searches
-		SET name=$1, is_public=$2, search_data=$3
-		WHERE search_id=$4 AND project_id=$5 AND deleted_at IS NULL
+		SET name=$1, is_public=$2, is_capture=$3, search_data=$4
+		WHERE search_id=$5 AND project_id=$6 AND deleted_at IS NULL
 		RETURNING is_share, created_at
 	`
 
@@ -336,6 +350,7 @@ func (s *savedSearchesImpl) Update(projectID int, userID uint64, searchID string
 		updateQuery,
 		req.Name,
 		isPublic,
+		isCapture,
 		searchDataJSON,
 		searchID,
 		projectID,
@@ -354,6 +369,7 @@ func (s *savedSearchesImpl) Update(projectID int, userID uint64, searchID string
 		Name:      req.Name,
 		IsPublic:  isPublic,
 		IsShare:   isShare,
+		IsCapture: isCapture,
 		Data:      req.Data,
 		CreatedAt: createdAt,
 	}, nil

--- a/backend/pkg/analytics/saved_searches/saved_searches.go
+++ b/backend/pkg/analytics/saved_searches/saved_searches.go
@@ -38,7 +38,7 @@ type SegmentsListItem struct {
 type SavedSearches interface {
 	Save(projectID int, userID uint64, req *model.SavedSearchRequest) (*model.SavedSearchResponse, error)
 	Get(projectID int, searchID string) (*model.SavedSearch, error)
-	List(ctx context.Context, projectID int, userID uint64, limit, offset int, sort, order string) ([]*model.SavedSearch, int, error)
+	List(ctx context.Context, projectID int, userID uint64, limit, offset int, sort, order string) ([]*model.SavedSearch, int, int64, error)
 	Update(projectID int, userID uint64, searchID string, req *model.SavedSearchRequest) (*model.SavedSearchResponse, error)
 	Delete(projectID int, userID uint64, searchID string) error
 	ListForFilters(projectID, userID int) ([]SegmentsListItem, error)
@@ -189,7 +189,7 @@ var sortColumns = map[string]string{
 	"userName":  "u.name",
 }
 
-func (s *savedSearchesImpl) List(ctx context.Context, projectID int, userID uint64, limit, offset int, sort, order string) ([]*model.SavedSearch, int, error) {
+func (s *savedSearchesImpl) List(ctx context.Context, projectID int, userID uint64, limit, offset int, sort, order string) ([]*model.SavedSearch, int, int64, error) {
 	column, ok := sortColumns[sort]
 	if !ok {
 		column = sortColumns["createdAt"]
@@ -216,7 +216,7 @@ func (s *savedSearchesImpl) List(ctx context.Context, projectID int, userID uint
 	rows, err := s.pgconn.Query(selectQuery, projectID, userID, limit, offset)
 	if err != nil {
 		s.log.Error(ctx, "list saved searches: %v", err)
-		return nil, 0, fmt.Errorf("list saved searches: %w", err)
+		return nil, 0, 0, fmt.Errorf("list saved searches: %w", err)
 	}
 	defer rows.Close()
 
@@ -245,11 +245,11 @@ func (s *savedSearchesImpl) List(ctx context.Context, projectID int, userID uint
 
 		if err != nil {
 			s.log.Error(ctx, "scan saved search: %v", err)
-			return nil, 0, fmt.Errorf("scan saved search: %w", err)
+			return nil, 0, 0, fmt.Errorf("scan saved search: %w", err)
 		}
 
 		if err := json.Unmarshal(searchDataJSON, &savedSearch.Data); err != nil {
-			return nil, 0, fmt.Errorf("unmarshal search data: %w", err)
+			return nil, 0, 0, fmt.Errorf("unmarshal search data: %w", err)
 		}
 
 		searches = append(searches, &savedSearch)
@@ -257,7 +257,7 @@ func (s *savedSearchesImpl) List(ctx context.Context, projectID int, userID uint
 
 	if err := rows.Err(); err != nil {
 		s.log.Error(ctx, "rows error: %v", err)
-		return nil, 0, fmt.Errorf("rows error: %w", err)
+		return nil, 0, 0, fmt.Errorf("rows error: %w", err)
 	}
 
 	for _, ss := range searches {
@@ -269,7 +269,40 @@ func (s *savedSearchesImpl) List(ctx context.Context, projectID int, userID uint
 		ss.UsersCount = stats.UsersCount
 	}
 
-	return searches, total, nil
+	totalSessions := s.getTotalSessions(ctx, projectID)
+
+	return searches, total, totalSessions, nil
+}
+
+func (s *savedSearchesImpl) getTotalSessions(ctx context.Context, projectID int) int64 {
+	if s.search == nil {
+		return 0
+	}
+
+	cacheKey := fmt.Sprintf("saved_search_stats:%d:total", projectID)
+	if cached, ok := s.statsCache.GetAndRefresh(cacheKey); ok {
+		if v, ok := cached.(searchStats); ok && time.Since(v.ComputedAt) < statsFreshnessWindow {
+			return v.SessionsCount
+		}
+	}
+
+	now := time.Now()
+	req := &model.SessionsSearchRequest{
+		StartDate: now.AddDate(0, 0, -statsWindowDays).UnixMilli(),
+		EndDate:   now.UnixMilli(),
+	}
+
+	qctx, cancel := context.WithTimeout(ctx, statsQueryTimeout)
+	defer cancel()
+
+	sessionsCount, _, err := s.search.GetCounts(qctx, projectID, req)
+	if err != nil {
+		s.log.Warn(ctx, "saved search total sessions: %.200s", err)
+		return 0
+	}
+
+	s.statsCache.Set(cacheKey, searchStats{SessionsCount: sessionsCount, ComputedAt: time.Now()})
+	return sessionsCount
 }
 
 func (s *savedSearchesImpl) getSearchStats(ctx context.Context, projectID int, data *model.SavedSearchData) searchStats {

--- a/ee/scripts/schema/db/init_dbs/postgresql/1.28.0/1.28.0.sql
+++ b/ee/scripts/schema/db/init_dbs/postgresql/1.28.0/1.28.0.sql
@@ -30,6 +30,9 @@ DROP TYPE IF EXISTS error_status;
 ALTER TABLE IF EXISTS public.scim_auth_codes
     ADD COLUMN IF NOT EXISTS used_for_jwt bool DEFAULT NULL;
 
+ALTER TABLE IF EXISTS public.saved_searches
+    ADD COLUMN IF NOT EXISTS is_capture boolean NOT NULL DEFAULT FALSE;
+
 COMMIT;
 
 \elif :is_next

--- a/ee/scripts/schema/db/init_dbs/postgresql/init_schema.sql
+++ b/ee/scripts/schema/db/init_dbs/postgresql/init_schema.sql
@@ -1285,6 +1285,7 @@ CREATE TABLE IF NOT EXISTS public.saved_searches
     name        varchar(255)                         DEFAULT NULL,
     is_public   boolean                     NOT NULL DEFAULT FALSE,
     is_share    boolean                     NOT NULL DEFAULT FALSE,
+    is_capture  boolean                     NOT NULL DEFAULT FALSE,
     search_data jsonb                       NOT NULL,
     created_at  timestamp without time zone NOT NULL DEFAULT timezone('utc'::text, now()),
     expires_at  timestamp without time zone NULL     DEFAULT NULL,

--- a/scripts/schema/db/init_dbs/postgresql/1.28.0/1.28.0.sql
+++ b/scripts/schema/db/init_dbs/postgresql/1.28.0/1.28.0.sql
@@ -26,6 +26,9 @@ DROP TABLE IF EXISTS public.errors;
 DROP TYPE IF EXISTS error_source;
 DROP TYPE IF EXISTS error_status;
 
+ALTER TABLE IF EXISTS public.saved_searches
+    ADD COLUMN IF NOT EXISTS is_capture boolean NOT NULL DEFAULT FALSE;
+
 
 COMMIT;
 

--- a/scripts/schema/db/init_dbs/postgresql/init_schema.sql
+++ b/scripts/schema/db/init_dbs/postgresql/init_schema.sql
@@ -1157,6 +1157,7 @@ CREATE TABLE IF NOT EXISTS public.saved_searches
     name        varchar(255)                         DEFAULT NULL,
     is_public   boolean                     NOT NULL DEFAULT FALSE,
     is_share    boolean                     NOT NULL DEFAULT FALSE,
+    is_capture  boolean                     NOT NULL DEFAULT FALSE,
     search_data jsonb                       NOT NULL,
     created_at  timestamp without time zone NOT NULL DEFAULT timezone('utc'::text, now()),
     expires_at  timestamp without time zone NULL     DEFAULT NULL,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an `isCapture` flag to saved searches and returns `totalSessionsCount` in the list API to support capture-based segments and show project-wide session totals.

- **New Features**
  - API: `SavedSearchRequest` supports optional `isCapture`; responses include it. Save/Get/List/Update read/write the flag. List now returns `totalSessionsCount`.
  - DB: Adds `is_capture boolean NOT NULL DEFAULT FALSE` to `public.saved_searches` (init and 1.28.0 migrations).
  - Backward compatible: existing rows default to false; clients can ignore the new response fields.

<sup>Written for commit d6fc9b92e35715cdb842ed4473ba03bbc9f4b5eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

