### PR TITLE
fix(gapi): fixed heatmap location operators

### DIFF
--- a/backend/pkg/analytics/charts/metric_heatmaps.go
+++ b/backend/pkg/analytics/charts/metric_heatmaps.go
@@ -106,6 +106,7 @@ func (h *HeatmapQueryBuilder) buildQuery(p *Payload) (string, error) {
 	if p.SampleRate > 0 && p.SampleRate < 100 {
 		base = append(base, fmt.Sprintf("e.sample_key < %d", p.SampleRate))
 	}
+	base = append(base, buildLocationConditions(filter.Filters, "e")...)
 
 	eventsWhere, filtersWhere, _, sessionsWhere := BuildWhere(filter.Filters, string(filter.EventsOrder), "l", "ls")
 

--- a/backend/pkg/analytics/charts/metric_heatmaps_session.go
+++ b/backend/pkg/analytics/charts/metric_heatmaps_session.go
@@ -150,14 +150,14 @@ func (h *HeatmapSessionQueryBuilder) buildQuery(p *Payload) (string, error) {
 	}
 	filters := []model.Filter{}
 	hasLocationFilter := false
-	var urlPath string
+	var locationFilter model.Filter
 
 	for _, filter := range series.Filter.Filters {
 		if filter.Name == "LOCATION" {
 			for _, nested := range filter.Filters {
 				if nested.Name == "url_path" && len(nested.Value) > 0 && nested.Value[0] != "" {
 					hasLocationFilter = true
-					urlPath = nested.Value[0]
+					locationFilter = nested
 					filters = append(filters, filter)
 				}
 			}
@@ -180,7 +180,9 @@ func (h *HeatmapSessionQueryBuilder) buildQuery(p *Payload) (string, error) {
 			fmt.Sprintf("e.project_id = %d", projectId),
 			fmt.Sprintf("e.created_at BETWEEN toDateTime(%d) AND toDateTime(%d)", startSec, endSec),
 			"e.`$event_name` = 'CLICK'",
-			fmt.Sprintf("$current_path = '%s'", urlPath),
+		}
+		if cond := buildCond(`e."$current_path"`, locationFilter.Value, locationFilter.Operator, false, "singleColumn"); cond != "" {
+			eventsWhere = append(eventsWhere, cond)
 		}
 		if p.SampleRate > 0 && p.SampleRate < 100 {
 			eventsWhere = append(eventsWhere, fmt.Sprintf("e.sample_key < %d", p.SampleRate))

--- a/backend/pkg/analytics/charts/query.go
+++ b/backend/pkg/analytics/charts/query.go
@@ -711,6 +711,31 @@ func BuildDurationWhere(filters []model.Filter, tableAlias ...string) ([]string,
 	return conds, rest
 }
 
+// buildLocationConditions extracts the url_path properties of LOCATION filters
+// and turns them into `$current_path` conditions on the given table alias.
+func buildLocationConditions(filters []model.Filter, tableAlias string) []string {
+	var conds []string
+	for _, f := range filters {
+		if f.Name != "LOCATION" {
+			continue
+		}
+		for _, nested := range f.Filters {
+			name := nested.Name
+			if nested.AutoCaptured {
+				name = CamelToSnake(name)
+			}
+			if name != "url_path" || len(nested.Value) == 0 || nested.Value[0] == "" {
+				continue
+			}
+			expr := fmt.Sprintf("%s.\"$current_path\"", tableAlias)
+			if c := buildCond(expr, nested.Value, nested.Operator, false, "singleColumn"); c != "" {
+				conds = append(conds, c)
+			}
+		}
+	}
+	return conds
+}
+
 func FilterOutTypes(filters []model.Filter, typesToRemove []string) (kept []model.Filter, removed []model.Filter) {
 	removeMap := make(map[string]struct{}, len(typesToRemove))
 	for _, t := range typesToRemove {


### PR DESCRIPTION
fix(gapi): fixed heatmap click locations
fixes #4792

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes heatmap click location filtering by applying `LOCATION.url_path` operators to `$current_path` in both event and session heatmap queries. Addresses Linear 4792 where location filters were treated as strict equality and returned incorrect results.

- **Bug Fixes**
  - Added `buildLocationConditions` to translate `LOCATION` filters into `$current_path` conditions on alias `e`.
  - Updated session heatmap to use `buildCond` for `$current_path` instead of a hardcoded equality.
  - Correctly handles operators (e.g., equals, contains, regex) and `AutoCaptured` field names.

<sup>Written for commit 763280a699f7c50cf9026841c2e36b9c5d8f9f15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

