### PR TITLE
Updated patch build from main bbc66a7b01513ae9fae3b91aef4a37140df09e03

### DIFF
--- a/scripts/helmcharts/openreplay/charts/api/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/api/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.7"
+AppVersion: "v1.27.8"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `openreplay` API Helm chart AppVersion from v1.27.7 to v1.27.8 to ship the latest patch build.

<sup>Written for commit e442e0bfe7bfab0d3dce99ce662d8c30d46fcffb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

