### PR TITLE
support native dialog api

### DIFF
--- a/player/src/web/managers/DOM/DOMManager.ts
+++ b/player/src/web/managers/DOM/DOMManager.ts
@@ -57,6 +57,9 @@ export default class DOMManager extends ListWalker<Message> {
   private readonly vElements: Map<number, VElement> = new Map();
   private readonly olVRoots: Map<number, OnloadVRoot> = new Map();
   private readonly pendingSelectValues: Map<number, string> = new Map();
+  /** nodeId -> native <dialog> top-layer mode ('modal' | 'nonmodal' | 'closed'),
+   * applied after the tree is flushed so the node is connected (see flushPendingDialogModes) */
+  private readonly pendingDialogModes: Map<number, string> = new Map();
   private flushScheduled = false;
   /** required to keep track of iframes, frameId : vnodeId */
   private readonly iframeRoots: Record<number, number> = {};
@@ -236,6 +239,14 @@ export default class DOMManager extends ListWalker<Message> {
       return;
     }
 
+    // Synthetic marker for native <dialog> top-layer state (see tracker observer).
+    // Not a real attribute: defer it until the tree is flushed and the node is
+    // connected, then replay showModal()/show()/close() in flushPendingDialogModes.
+    if (name === '__openreplay_dialog') {
+      this.pendingDialogModes.set(msg.id, value);
+      return;
+    }
+
     // Untrusted stream: drop event handlers, script-scheme URLs and iframe
     // navigation sources before they ever reach the real element (see sanitize.ts).
     const sanitized = sanitizeAttribute(vn.tagName, name, value);
@@ -320,6 +331,7 @@ export default class DOMManager extends ListWalker<Message> {
         this.olStyleSheets.clear();
         this.pendingStyleRules.clear();
         this.pendingSelectValues.clear();
+        this.pendingDialogModes.clear();
         this.flushScheduled = false;
         this.stylesManager.reset();
         return;
@@ -734,6 +746,44 @@ export default class DOMManager extends ListWalker<Message> {
     }
   };
 
+  /**
+   * Restores native <dialog> top-layer state recorded by the tracker. Runs after
+   * the VDOM is flushed so the element is connected (showModal() throws otherwise).
+   * Entries whose node isn't connected yet are kept and retried on the next flush.
+   */
+  private flushPendingDialogModes = (): void => {
+    if (this.pendingDialogModes.size === 0) return;
+    this.pendingDialogModes.forEach((mode, id) => {
+      const vElem = this.vElements.get(id);
+      if (!vElem) {
+        this.pendingDialogModes.delete(id);
+        return;
+      }
+      const node = vElem.node;
+      if (!(node instanceof HTMLDialogElement) || !node.isConnected) {
+        // Not mounted yet — leave it queued for the next flush.
+        return;
+      }
+      this.pendingDialogModes.delete(id);
+      try {
+        if (mode === 'modal') {
+          // showModal() throws if the `open` attribute is already set (the tracker
+          // also replays it as a plain attribute), so clear it first.
+          if (node.hasAttribute('open')) node.removeAttribute('open');
+          node.showModal();
+        } else if (mode === 'nonmodal') {
+          if (!node.open) node.show();
+        } else if (node.open) {
+          // 'closed' — removing the `open` attribute alone does not exit the top
+          // layer; only close() does.
+          node.close();
+        }
+      } catch (e) {
+        logger.log('Dialog top-layer replay failed', id, mode, e);
+      }
+    });
+  };
+
   private flushPendingSelectValues = (): void => {
     this.flushScheduled = false;
     if (this.pendingSelectValues.size === 0) return;
@@ -770,6 +820,8 @@ export default class DOMManager extends ListWalker<Message> {
   async moveReady(t: number): Promise<void> {
     this.moveApply(t, this.applyMessage);
     this.olVRoots.forEach((rt) => rt.applyChanges());
+    // Tree is now connected — safe to (re-)enter the <dialog> top layer.
+    this.flushPendingDialogModes();
     if (this.pendingSelectValues.size > 0 && !this.flushScheduled) {
       this.flushScheduled = true;
       setTimeout(this.flushPendingSelectValues, 0);

--- a/player/src/web/managers/DOM/DOMManager.ts
+++ b/player/src/web/managers/DOM/DOMManager.ts
@@ -752,11 +752,7 @@ export default class DOMManager extends ListWalker<Message> {
     }
   };
 
-  /**
-   * Restores native <dialog> top-layer state recorded by the tracker. Runs after
-   * the VDOM is flushed so the element is connected (showModal() throws otherwise).
-   * Entries whose node isn't connected yet are kept and retried on the next flush.
-   */
+  /** Re-assert recorded <dialog> top-layer state (showModal/show/close) once the node is connected. */
   private reconcileDialogModes = (): void => {
     this.dialogFlushScheduled = false;
     if (this.dialogModes.size === 0) return;

--- a/player/src/web/managers/DOM/DOMManager.ts
+++ b/player/src/web/managers/DOM/DOMManager.ts
@@ -57,9 +57,9 @@ export default class DOMManager extends ListWalker<Message> {
   private readonly vElements: Map<number, VElement> = new Map();
   private readonly olVRoots: Map<number, OnloadVRoot> = new Map();
   private readonly pendingSelectValues: Map<number, string> = new Map();
-  /** nodeId -> native <dialog> top-layer mode ('modal' | 'nonmodal' | 'closed'),
-   * applied after the tree is flushed so the node is connected (see flushPendingDialogModes) */
-  private readonly pendingDialogModes: Map<number, string> = new Map();
+  /** nodeId -> desired <dialog> top-layer mode; re-asserted every flush (see reconcileDialogModes). */
+  private readonly dialogModes: Map<number, string> = new Map();
+  private dialogFlushScheduled = false;
   private flushScheduled = false;
   /** required to keep track of iframes, frameId : vnodeId */
   private readonly iframeRoots: Record<number, number> = {};
@@ -239,11 +239,16 @@ export default class DOMManager extends ListWalker<Message> {
       return;
     }
 
-    // Synthetic marker for native <dialog> top-layer state (see tracker observer).
-    // Not a real attribute: defer it until the tree is flushed and the node is
-    // connected, then replay showModal()/show()/close() in flushPendingDialogModes.
+    // Synthetic <dialog> top-layer state, not a real attribute (see reconcileDialogModes).
     if (name === '__openreplay_dialog') {
-      this.pendingDialogModes.set(msg.id, value);
+      this.dialogModes.set(msg.id, value);
+      return;
+    }
+
+    // Synthetic marker: force recorded color-scheme on the root (inherits) so UA-painted
+    // surfaces (e.g. <dialog> Canvas bg) don't follow the replayer's OS theme.
+    if (name === '__openreplay_color_scheme') {
+      (vn.node as HTMLElement).style.colorScheme = value;
       return;
     }
 
@@ -331,7 +336,8 @@ export default class DOMManager extends ListWalker<Message> {
         this.olStyleSheets.clear();
         this.pendingStyleRules.clear();
         this.pendingSelectValues.clear();
-        this.pendingDialogModes.clear();
+        this.dialogModes.clear();
+        this.dialogFlushScheduled = false;
         this.flushScheduled = false;
         this.stylesManager.reset();
         return;
@@ -751,32 +757,38 @@ export default class DOMManager extends ListWalker<Message> {
    * the VDOM is flushed so the element is connected (showModal() throws otherwise).
    * Entries whose node isn't connected yet are kept and retried on the next flush.
    */
-  private flushPendingDialogModes = (): void => {
-    if (this.pendingDialogModes.size === 0) return;
-    this.pendingDialogModes.forEach((mode, id) => {
+  private reconcileDialogModes = (): void => {
+    this.dialogFlushScheduled = false;
+    if (this.dialogModes.size === 0) return;
+    this.dialogModes.forEach((mode, id) => {
       const vElem = this.vElements.get(id);
       if (!vElem) {
-        this.pendingDialogModes.delete(id);
+        this.dialogModes.delete(id);
         return;
       }
       const node = vElem.node;
       if (!(node instanceof HTMLDialogElement) || !node.isConnected) {
-        // Not mounted yet — leave it queued for the next flush.
-        return;
+        return; // not mounted yet — retry next flush
       }
-      this.pendingDialogModes.delete(id);
+      // `:modal` is the only reliable read of top-layer membership (`open` is set for both).
+      let isModal = false;
+      try {
+        isModal = node.matches('dialog:modal');
+      } catch (e) {
+        /* :modal unsupported */
+      }
       try {
         if (mode === 'modal') {
-          // showModal() throws if the `open` attribute is already set (the tracker
-          // also replays it as a plain attribute), so clear it first.
-          if (node.hasAttribute('open')) node.removeAttribute('open');
-          node.showModal();
+          if (!isModal) {
+            if (node.hasAttribute('open')) node.removeAttribute('open'); // showModal() throws if already open
+            node.showModal();
+          }
         } else if (mode === 'nonmodal') {
+          if (isModal) node.close();
           if (!node.open) node.show();
-        } else if (node.open) {
-          // 'closed' — removing the `open` attribute alone does not exit the top
-          // layer; only close() does.
-          node.close();
+        } else {
+          if (node.open || isModal) node.close();
+          this.dialogModes.delete(id); // 'closed' is terminal
         }
       } catch (e) {
         logger.log('Dialog top-layer replay failed', id, mode, e);
@@ -820,8 +832,11 @@ export default class DOMManager extends ListWalker<Message> {
   async moveReady(t: number): Promise<void> {
     this.moveApply(t, this.applyMessage);
     this.olVRoots.forEach((rt) => rt.applyChanges());
-    // Tree is now connected — safe to (re-)enter the <dialog> top layer.
-    this.flushPendingDialogModes();
+    // applyChanges() mutates the DOM on a microtask; reconcile dialogs after it (macrotask).
+    if (this.dialogModes.size > 0 && !this.dialogFlushScheduled) {
+      this.dialogFlushScheduled = true;
+      setTimeout(this.reconcileDialogModes, 0);
+    }
     if (this.pendingSelectValues.size > 0 && !this.flushScheduled) {
       this.flushScheduled = true;
       setTimeout(this.flushPendingSelectValues, 0);

--- a/tracker/tracker/src/main/app/guards.ts
+++ b/tracker/tracker/src/main/app/guards.ts
@@ -46,6 +46,7 @@ type TagTypeMap = {
   link: HTMLLinkElement
   canvas: HTMLCanvasElement
   slot: HTMLSlotElement
+  dialog: HTMLDialogElement
 }
 export function hasTag<T extends keyof TagTypeMap>(
   el: Node,

--- a/tracker/tracker/src/main/app/observer/observer.ts
+++ b/tracker/tracker/src/main/app/observer/observer.ts
@@ -405,12 +405,8 @@ export default abstract class Observer {
       }
       return
     }
-    // Native <dialog> top-layer state. The raw `open` attribute is identical for
-    // showModal() (modal, top layer) and show()/`<dialog open>` (non-modal), so
-    // the player can't tell them apart and never re-enters the top layer, losing
-    // backdrop/stacking. Emit the recorded mode next to the normal `open` attr so
-    // the player can replay showModal()/show()/close() (see DOMManager). Sent in
-    // addition to `open` to keep older players on their current behaviour.
+    // `open` alone can't tell showModal() (modal/top-layer) from show()/`<dialog open>`
+    // (non-modal); emit the mode alongside it so the player replays the right call (see DOMManager).
     if (name === 'open' && hasTag(node, 'dialog')) {
       let mode: 'modal' | 'nonmodal' | 'closed'
       if (value === null) {

--- a/tracker/tracker/src/main/app/observer/observer.ts
+++ b/tracker/tracker/src/main/app/observer/observer.ts
@@ -405,6 +405,27 @@ export default abstract class Observer {
       }
       return
     }
+    // Native <dialog> top-layer state. The raw `open` attribute is identical for
+    // showModal() (modal, top layer) and show()/`<dialog open>` (non-modal), so
+    // the player can't tell them apart and never re-enters the top layer, losing
+    // backdrop/stacking. Emit the recorded mode next to the normal `open` attr so
+    // the player can replay showModal()/show()/close() (see DOMManager). Sent in
+    // addition to `open` to keep older players on their current behaviour.
+    if (name === 'open' && hasTag(node, 'dialog')) {
+      let mode: 'modal' | 'nonmodal' | 'closed'
+      if (value === null) {
+        mode = 'closed'
+      } else {
+        let isModal = false
+        try {
+          isModal = (node as HTMLDialogElement).matches('dialog:modal')
+        } catch (e) {
+          /* :modal pseudo-class unsupported on this browser */
+        }
+        mode = isModal ? 'modal' : 'nonmodal'
+      }
+      this.app.send(SetNodeAttribute(id, '__openreplay_dialog', mode))
+    }
     if (
       name === 'src' ||
       name === 'srcset' ||

--- a/tracker/tracker/src/main/app/observer/top_observer.ts
+++ b/tracker/tracker/src/main/app/observer/top_observer.ts
@@ -246,6 +246,36 @@ export default class TopObserver extends Observer {
     // "DOM parsed" signal: observeRoot sent the full initial tree synchronously above.
     // The worker keys on this attribute (BatchWriter) to finalize the visual batch.
     this.app.send(SetNodeAttribute(0, 'orloaded', 'true'))
+
+    // Record used color-scheme so the player can force it on replay (see sendColorScheme).
+    this.sendColorScheme()
+    if (IN_BROWSER && window.matchMedia) {
+      this.colorSchemeMQL = window.matchMedia('(prefers-color-scheme: dark)')
+      this.colorSchemeListener = this.app.safe(() => this.sendColorScheme())
+      this.colorSchemeMQL.addEventListener?.('change', this.colorSchemeListener)
+    }
+  }
+
+  private colorSchemeMQL: MediaQueryList | null = null
+  private colorSchemeListener: ((e: MediaQueryListEvent) => void) | null = null
+
+  /** Send resolved used color-scheme ('dark'|'light'|'normal') for the player to force on replay. */
+  private sendColorScheme(): void {
+    if (!IN_BROWSER) return
+    const root = document.documentElement
+    let declared = getComputedStyle(root).colorScheme
+    if (!declared || declared === 'normal') {
+      const meta = document.querySelector('meta[name="color-scheme" i]')
+      const content = meta && meta.getAttribute('content')
+      if (content) declared = content
+    }
+    let used = 'normal'
+    if (declared && declared !== 'normal') {
+      const prefersDark = !!window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+      // resolve declared support against OS preference into the concrete used scheme
+      used = declared.includes('dark') && (prefersDark || !declared.includes('light')) ? 'dark' : 'light'
+    }
+    this.app.send(SetNodeAttribute(0, '__openreplay_color_scheme', used))
   }
 
   crossdomainObserve(rootNodeId: number, frameOder: number, frameLevel: number) {
@@ -267,6 +297,11 @@ export default class TopObserver extends Observer {
   }
 
   disconnect() {
+    if (this.colorSchemeMQL && this.colorSchemeListener) {
+      this.colorSchemeMQL.removeEventListener?.('change', this.colorSchemeListener)
+    }
+    this.colorSchemeMQL = null
+    this.colorSchemeListener = null
     this.iframeOffsets.clear()
     Element.prototype.attachShadow = attachShadowNativeFn
     this.iframeObserversArr.forEach((observer) => observer.disconnect())

--- a/tracker/tracker/src/main/app/observer/top_observer.ts
+++ b/tracker/tracker/src/main/app/observer/top_observer.ts
@@ -243,12 +243,13 @@ export default class TopObserver extends Observer {
       window.document.documentElement,
     )
 
+    // Send before `orloaded` so it lands in the initial visual batch (see sendColorScheme).
+    this.sendColorScheme()
+
     // "DOM parsed" signal: observeRoot sent the full initial tree synchronously above.
     // The worker keys on this attribute (BatchWriter) to finalize the visual batch.
     this.app.send(SetNodeAttribute(0, 'orloaded', 'true'))
 
-    // Record used color-scheme so the player can force it on replay (see sendColorScheme).
-    this.sendColorScheme()
     if (IN_BROWSER && window.matchMedia) {
       this.colorSchemeMQL = window.matchMedia('(prefers-color-scheme: dark)')
       this.colorSchemeListener = this.app.safe(() => this.sendColorScheme())


### PR DESCRIPTION
closes #4797 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add full support for the native `<dialog>` API in recording and replay, including correct modal vs non‑modal behavior and consistent color scheme rendering. Closes #4797.

- **New Features**
  - Track and replay dialog mode: when `open` changes on `dialog`, tracker sends `__openreplay_dialog` with `modal` | `nonmodal` | `closed`; player re-applies via `showModal()`/`show()`/`close()` after mount.
  - Consistent color scheme: tracker resolves used scheme from CSS/meta + OS preference and sends `__openreplay_color_scheme`; player sets `documentElement.style.colorScheme` to match UA-painted surfaces (e.g., dialog backdrop) and updates on changes.
  - Add `dialog` to element tag guards.

<sup>Written for commit d3cc25ca7ba5ffb86868de869489c20df3d65783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

