### PR TITLE
support native dialog api (#4799)

### DIFF
--- a/player/src/web/managers/DOM/DOMManager.ts
+++ b/player/src/web/managers/DOM/DOMManager.ts
@@ -57,6 +57,9 @@ export default class DOMManager extends ListWalker<Message> {
   private readonly vElements: Map<number, VElement> = new Map();
   private readonly olVRoots: Map<number, OnloadVRoot> = new Map();
   private readonly pendingSelectValues: Map<number, string> = new Map();
+  /** nodeId -> desired <dialog> top-layer mode; re-asserted every flush (see reconcileDialogModes). */
+  private readonly dialogModes: Map<number, string> = new Map();
+  private dialogFlushScheduled = false;
   private flushScheduled = false;
   /** required to keep track of iframes, frameId : vnodeId */
   private readonly iframeRoots: Record<number, number> = {};
@@ -236,6 +239,19 @@ export default class DOMManager extends ListWalker<Message> {
       return;
     }
 
+    // Synthetic <dialog> top-layer state, not a real attribute (see reconcileDialogModes).
+    if (name === '__openreplay_dialog') {
+      this.dialogModes.set(msg.id, value);
+      return;
+    }
+
+    // Synthetic marker: force recorded color-scheme on the root (inherits) so UA-painted
+    // surfaces (e.g. <dialog> Canvas bg) don't follow the replayer's OS theme.
+    if (name === '__openreplay_color_scheme') {
+      (vn.node as HTMLElement).style.colorScheme = value;
+      return;
+    }
+
     // Untrusted stream: drop event handlers, script-scheme URLs and iframe
     // navigation sources before they ever reach the real element (see sanitize.ts).
     const sanitized = sanitizeAttribute(vn.tagName, name, value);
@@ -320,6 +336,8 @@ export default class DOMManager extends ListWalker<Message> {
         this.olStyleSheets.clear();
         this.pendingStyleRules.clear();
         this.pendingSelectValues.clear();
+        this.dialogModes.clear();
+        this.dialogFlushScheduled = false;
         this.flushScheduled = false;
         this.stylesManager.reset();
         return;
@@ -734,6 +752,46 @@ export default class DOMManager extends ListWalker<Message> {
     }
   };
 
+  /** Re-assert recorded <dialog> top-layer state (showModal/show/close) once the node is connected. */
+  private reconcileDialogModes = (): void => {
+    this.dialogFlushScheduled = false;
+    if (this.dialogModes.size === 0) return;
+    this.dialogModes.forEach((mode, id) => {
+      const vElem = this.vElements.get(id);
+      if (!vElem) {
+        this.dialogModes.delete(id);
+        return;
+      }
+      const node = vElem.node;
+      if (!(node instanceof HTMLDialogElement) || !node.isConnected) {
+        return; // not mounted yet — retry next flush
+      }
+      // `:modal` is the only reliable read of top-layer membership (`open` is set for both).
+      let isModal = false;
+      try {
+        isModal = node.matches('dialog:modal');
+      } catch (e) {
+        /* :modal unsupported */
+      }
+      try {
+        if (mode === 'modal') {
+          if (!isModal) {
+            if (node.hasAttribute('open')) node.removeAttribute('open'); // showModal() throws if already open
+            node.showModal();
+          }
+        } else if (mode === 'nonmodal') {
+          if (isModal) node.close();
+          if (!node.open) node.show();
+        } else {
+          if (node.open || isModal) node.close();
+          this.dialogModes.delete(id); // 'closed' is terminal
+        }
+      } catch (e) {
+        logger.log('Dialog top-layer replay failed', id, mode, e);
+      }
+    });
+  };
+
   private flushPendingSelectValues = (): void => {
     this.flushScheduled = false;
     if (this.pendingSelectValues.size === 0) return;
@@ -770,6 +828,11 @@ export default class DOMManager extends ListWalker<Message> {
   async moveReady(t: number): Promise<void> {
     this.moveApply(t, this.applyMessage);
     this.olVRoots.forEach((rt) => rt.applyChanges());
+    // applyChanges() mutates the DOM on a microtask; reconcile dialogs after it (macrotask).
+    if (this.dialogModes.size > 0 && !this.dialogFlushScheduled) {
+      this.dialogFlushScheduled = true;
+      setTimeout(this.reconcileDialogModes, 0);
+    }
     if (this.pendingSelectValues.size > 0 && !this.flushScheduled) {
       this.flushScheduled = true;
       setTimeout(this.flushPendingSelectValues, 0);

--- a/tracker/tracker/src/main/app/guards.ts
+++ b/tracker/tracker/src/main/app/guards.ts
@@ -46,6 +46,7 @@ type TagTypeMap = {
   link: HTMLLinkElement
   canvas: HTMLCanvasElement
   slot: HTMLSlotElement
+  dialog: HTMLDialogElement
 }
 export function hasTag<T extends keyof TagTypeMap>(
   el: Node,

--- a/tracker/tracker/src/main/app/observer/observer.ts
+++ b/tracker/tracker/src/main/app/observer/observer.ts
@@ -369,6 +369,23 @@ export default abstract class Observer {
       }
       return
     }
+    // `open` alone can't tell showModal() (modal/top-layer) from show()/`<dialog open>`
+    // (non-modal); emit the mode alongside it so the player replays the right call (see DOMManager).
+    if (name === 'open' && hasTag(node, 'dialog')) {
+      let mode: 'modal' | 'nonmodal' | 'closed'
+      if (value === null) {
+        mode = 'closed'
+      } else {
+        let isModal = false
+        try {
+          isModal = (node as HTMLDialogElement).matches('dialog:modal')
+        } catch (e) {
+          /* :modal pseudo-class unsupported on this browser */
+        }
+        mode = isModal ? 'modal' : 'nonmodal'
+      }
+      this.app.send(SetNodeAttribute(id, '__openreplay_dialog', mode))
+    }
     if (
       name === 'src' ||
       name === 'srcset' ||

--- a/tracker/tracker/src/main/app/observer/top_observer.ts
+++ b/tracker/tracker/src/main/app/observer/top_observer.ts
@@ -241,6 +241,44 @@ export default class TopObserver extends Observer {
       },
       window.document.documentElement,
     )
+<<<<<<< HEAD
+=======
+
+    // Send before `orloaded` so it lands in the initial visual batch (see sendColorScheme).
+    this.sendColorScheme()
+
+    // "DOM parsed" signal: observeRoot sent the full initial tree synchronously above.
+    // The worker keys on this attribute (BatchWriter) to finalize the visual batch.
+    this.app.send(SetNodeAttribute(0, 'orloaded', 'true'))
+
+    if (IN_BROWSER && window.matchMedia) {
+      this.colorSchemeMQL = window.matchMedia('(prefers-color-scheme: dark)')
+      this.colorSchemeListener = this.app.safe(() => this.sendColorScheme())
+      this.colorSchemeMQL.addEventListener?.('change', this.colorSchemeListener)
+    }
+  }
+
+  private colorSchemeMQL: MediaQueryList | null = null
+  private colorSchemeListener: ((e: MediaQueryListEvent) => void) | null = null
+
+  /** Send resolved used color-scheme ('dark'|'light'|'normal') for the player to force on replay. */
+  private sendColorScheme(): void {
+    if (!IN_BROWSER) return
+    const root = document.documentElement
+    let declared = getComputedStyle(root).colorScheme
+    if (!declared || declared === 'normal') {
+      const meta = document.querySelector('meta[name="color-scheme" i]')
+      const content = meta && meta.getAttribute('content')
+      if (content) declared = content
+    }
+    let used = 'normal'
+    if (declared && declared !== 'normal') {
+      const prefersDark = !!window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+      // resolve declared support against OS preference into the concrete used scheme
+      used = declared.includes('dark') && (prefersDark || !declared.includes('light')) ? 'dark' : 'light'
+    }
+    this.app.send(SetNodeAttribute(0, '__openreplay_color_scheme', used))
+>>>>>>> 157b3322e (support native dialog api (#4799))
   }
 
   crossdomainObserve(rootNodeId: number, frameOder: number, frameLevel: number) {
@@ -262,6 +300,11 @@ export default class TopObserver extends Observer {
   }
 
   disconnect() {
+    if (this.colorSchemeMQL && this.colorSchemeListener) {
+      this.colorSchemeMQL.removeEventListener?.('change', this.colorSchemeListener)
+    }
+    this.colorSchemeMQL = null
+    this.colorSchemeListener = null
     this.iframeOffsets.clear()
     Element.prototype.attachShadow = attachShadowNativeFn
     this.iframeObserversArr.forEach((observer) => observer.disconnect())


### PR DESCRIPTION
* tracker: support ionic dialog open/close

* ui: adjust player for new param

* ui, tracker: improve color scheme support

* ui, tracker: minor codestyle fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native `<dialog>` support so recordings capture and replay modal vs non‑modal state accurately. Also lock the recorded color scheme during replay to avoid OS‑dependent UI differences.

- **New Features**
  - Tracker records dialog mode via `__openreplay_dialog` (`modal` | `nonmodal` | `closed`) using `:modal` when available.
  - Player replays dialog state with `showModal()`, `show()`, or `close()` after mount, using a scheduled reconciliation pass.
  - Tracker sends the resolved color scheme for the session; player forces it on the root via `__openreplay_color_scheme` to keep UA‑painted surfaces consistent.
  - Added `dialog` to `hasTag` guard and cleaned up color‑scheme listeners on disconnect.

<sup>Written for commit 6a8794b456f41954f5e09ab1c583e4870234f008. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

