### PR TITLE
ui: fix metafilter parse

### DIFF
--- a/frontend/app/PrivateRoutes.tsx
+++ b/frontend/app/PrivateRoutes.tsx
@@ -172,7 +172,12 @@ function PrivateRoutes() {
         'userCity',
         'meta_',
       ];
-      const parsedFilters = supportedFilters.filter((f) => searchParams.has(f));
+      const searchParamsKeys = Array.from(searchParams.keys());
+      const parsedFilters = searchParamsKeys.filter((key) =>
+        supportedFilters.some((f) =>
+          f === 'meta_' ? key.startsWith('meta_') : key === f,
+        ),
+      );
 
       if (searchId) {
         searchStore
@@ -202,7 +207,10 @@ function PrivateRoutes() {
           const value = searchParams.get(f) as string;
           const isMeta = f.startsWith('meta_');
           const filterName = isMeta ? f.replace('meta_', '') : f;
-          const filter = filterStore.findEvent({ name: filterName });
+          const searchPayload = isMeta
+            ? { displayName: filterName }
+            : { name: filterName };
+          const filter = filterStore.findEvent(searchPayload);
           if (filter) {
             filter.value = [value];
           }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes metafilter parsing so dynamic `meta_` query params are detected and applied on load. Meta filters like `meta_color=red` now map to the correct filter and value.

- **Bug Fixes**
  - Detect any query key starting with `meta_` instead of checking only for a literal `meta_` key.
  - Look up meta filters by `displayName` in `filterStore` (non-meta still use `name`).

<sup>Written for commit 08cc13994e82542f91268708e2740e49205af65a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

