### PR TITLE
ui: hide pending tab

### DIFF
--- a/frontend/app/components/Session/Player/SharedComponents/SessionTabs.tsx
+++ b/frontend/app/components/Session/Player/SharedComponents/SessionTabs.tsx
@@ -46,7 +46,7 @@ function SessionTabs({ isLive }: { isLive?: boolean }) {
   const { showModal, hideModal } = useModal();
   const { player, store } = React.useContext(PlayerContext);
   const {
-    tabs = new Set('back-compat'),
+    tabs = new Set(['back-compat']),
     currentTab,
     closedTabs,
     tabNames,
@@ -60,14 +60,13 @@ function SessionTabs({ isLive }: { isLive?: boolean }) {
   const shouldTruncate = tabsArr.length > DISPLAY_LIMIT;
   const actualTabs = shouldTruncate ? tabsArr.slice(0, DISPLAY_LIMIT) : tabsArr;
 
+  // currentTab is briefly unknown while assist re-adopts a reconnected session;
+  // appending it then would render a tab at index -1 ("Tab 0")
+  const currentTabIdx = tabsArr.findIndex((el) => el.tab === currentTab);
   const shownTabs =
-    actualTabs.findIndex((el) => el.tab === currentTab) !== -1
+    currentTabIdx === -1 || actualTabs.some((el) => el.tab === currentTab)
       ? actualTabs
-      : actualTabs.concat({
-          tab: currentTab,
-          isClosed: false,
-          idx: tabsArr.findIndex((tEl) => tEl.tab === currentTab),
-        });
+      : actualTabs.concat(tabsArr[currentTabIdx]);
   const changeTab = (tab: string) => {
     if (isLive) return;
     player.changeTab(tab);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide the transient pending/ghost tab in the session player by only appending the current tab when its index is known. Also correct the default tabs Set to use new Set(['back-compat']) to avoid creating a Set of characters.

<sup>Written for commit 03082c122324d32ce03031af9b913d981e0dfa39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

