### PR TITLE
End zero-duration sessions + EFS cleanup reaper safety net

### DIFF
--- a/backend/cmd/ender/main.go
+++ b/backend/cmd/ender/main.go
@@ -10,6 +10,7 @@ import (
 	config "openreplay/backend/internal/config/ender"
 	"openreplay/backend/internal/ender"
 	"openreplay/backend/pkg/cleanup"
+	"openreplay/backend/pkg/cleanup/registry"
 	"openreplay/backend/pkg/db/postgres/pool"
 	"openreplay/backend/pkg/db/redis"
 	"openreplay/backend/pkg/health"
@@ -67,6 +68,13 @@ func main() {
 	h.Register("producer", func(ctx context.Context) error {
 		return producer.Ping(ctx)
 	})
+
+	cleanupRegistry := registry.New(log, redisClient)
+	cleanupDispatcher, err := cleanup.NewDispatcher(log, cfg, producer, pgConn, redisClient)
+	if err != nil {
+		log.Fatal(ctx, "can't init cleanup dispatcher: %s", err)
+	}
+
 	consumer, err := queue.NewConsumer(
 		log,
 		cfg.GroupEnder,
@@ -84,9 +92,11 @@ func main() {
 		func(t types.RebalanceType, partitions []uint64) {
 			if t == types.RebalanceTypeRevoke {
 				sessionEndGenerator.Disable()
+				cleanupDispatcher.ActivePartitions(nil)
 			} else {
 				sessionEndGenerator.ActivePartitions(partitions)
 				sessionEndGenerator.Enable()
+				cleanupDispatcher.ActivePartitions(partitions)
 			}
 		},
 		-ender.EVENTS_BACK_COMMIT_GAP,
@@ -97,11 +107,6 @@ func main() {
 	h.Register("consumer", func(ctx context.Context) error {
 		return consumer.Ping(ctx)
 	})
-
-	cleanupDispatcher, err := cleanup.NewDispatcher(log, cfg, producer)
-	if err != nil {
-		log.Fatal(ctx, "can't init cleanup dispatcher: %s", err)
-	}
 
 	log.Info(ctx, "Ender service started")
 
@@ -123,7 +128,7 @@ func main() {
 		case <-tick:
 			details := ender.NewLogDetails()
 			sessionEndGenerator.HandleEndedSessions(func(candidates map[uint64]uint64) map[uint64]bool {
-				return processEndedBatch(ctx, candidates, sessManager, producer, cfg, log, details)
+				return processEndedBatch(ctx, candidates, sessManager, producer, cfg, log, details, cleanupRegistry)
 			})
 			details.Log(log, ctx)
 			producer.Flush(cfg.ProducerTimeout)
@@ -146,6 +151,7 @@ func processEndedBatch(
 	cfg *config.Config,
 	log logger.Logger,
 	details *ender.LogDetails,
+	cleanupReg registry.Registry,
 ) map[uint64]bool {
 	if len(candidates) == 0 {
 		return map[uint64]bool{}
@@ -159,5 +165,5 @@ func processEndedBatch(
 		log.Error(ctx, "can't get sessions from database: %s", err)
 		return map[uint64]bool{}
 	}
-	return ender.ProcessEndedSessions(ctx, candidates, loaded, sessManager, producer, cfg, log, details)
+	return ender.ProcessEndedSessions(ctx, candidates, loaded, sessManager, producer, cfg, log, details, cleanupReg)
 }

--- a/backend/internal/config/ender/config.go
+++ b/backend/internal/config/ender/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	TopicRawAssets    string        `env:"TOPIC_RAW_ASSETS,required"`
 	GroupCleanup      string        `env:"GROUP_CLEANUP,required"`
 	CleanupReadGap    time.Duration `env:"CLEANUP_READ_GAP,default=24h"`
+	CleanupReaperTick time.Duration `env:"CLEANUP_REAPER_TICK,default=2m"`
 	ProducerTimeout   int           `env:"PRODUCER_TIMEOUT,default=2000"`
 	PartitionsNumber  int           `env:"PARTITIONS_NUMBER,required"`
 	UseEncryption     bool          `env:"USE_ENCRYPTION,default=false"`

--- a/backend/internal/ender/processor.go
+++ b/backend/internal/ender/processor.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	config "openreplay/backend/internal/config/ender"
+	"openreplay/backend/pkg/cleanup/registry"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/messages"
 	"openreplay/backend/pkg/queue/types"
@@ -22,6 +23,7 @@ func ProcessEndedSessions(
 	cfg *config.Config,
 	log logger.Logger,
 	details *LogDetails,
+	cleanupReg registry.Registry,
 ) map[uint64]bool {
 	completed := make(map[uint64]bool, len(candidates))
 	toUpdate := make(map[uint64]uint64, len(candidates)) // sessionID -> timestamp
@@ -40,9 +42,12 @@ func ProcessEndedSessions(
 		}
 		newDur := timestamp - sess.Timestamp
 		if currDuration == newDur {
-			details.Duplicated[sessionID] = currDuration
-			completed[sessionID] = true
-			continue
+			if currDuration != 0 {
+				details.Duplicated[sessionID] = currDuration
+				completed[sessionID] = true
+				continue
+			}
+			log.Info(ctx, "ending zero-duration session, sessID: %d", sessionID)
 		}
 		if currDuration > newDur {
 			details.Shorter[sessionID] = int64(currDuration) - int64(newDur)
@@ -62,7 +67,7 @@ func ProcessEndedSessions(
 		log.Error(ctx, "batch duration update failed, falling back per-session: %s", err)
 		for sessionID, timestamp := range toUpdate {
 			sessCtx := context.WithValue(ctx, "sessionID", fmt.Sprintf("%d", sessionID))
-			if ProcessEndedSession(sessCtx, sessionID, timestamp, loaded[sessionID], sessManager, producer, cfg, log, details) {
+			if ProcessEndedSession(sessCtx, sessionID, timestamp, loaded[sessionID], sessManager, producer, cfg, log, details, cleanupReg) {
 				completed[sessionID] = true
 			}
 		}
@@ -78,7 +83,7 @@ func ProcessEndedSessions(
 			continue
 		}
 		sessCtx := context.WithValue(ctx, "sessionID", fmt.Sprintf("%d", sessionID))
-		if emitSessionEnd(sessCtx, sessionID, timestamp, loaded[sessionID], prevDur[sessionID], newDuration, sessManager, producer, cfg, log, details) {
+		if emitSessionEnd(sessCtx, sessionID, timestamp, loaded[sessionID], prevDur[sessionID], newDuration, sessManager, producer, cfg, log, details, cleanupReg) {
 			completed[sessionID] = true
 		}
 	}
@@ -95,6 +100,7 @@ func ProcessEndedSession(
 	cfg *config.Config,
 	log logger.Logger,
 	details *LogDetails,
+	cleanupReg registry.Registry,
 ) bool {
 	if sess == nil {
 		details.NotFound[sessionID] = timestamp
@@ -107,8 +113,11 @@ func ProcessEndedSession(
 	}
 	newDur := timestamp - sess.Timestamp
 	if currDuration == newDur {
-		details.Duplicated[sessionID] = currDuration
-		return true
+		if currDuration != 0 {
+			details.Duplicated[sessionID] = currDuration
+			return true
+		}
+		log.Info(ctx, "ending zero-duration session, sessID: %d", sessionID)
 	}
 	if currDuration > newDur {
 		details.Shorter[sessionID] = int64(currDuration) - int64(newDur)
@@ -131,7 +140,7 @@ func ProcessEndedSession(
 		log.Error(ctx, "can't update session duration, err: %s", err)
 		return false
 	}
-	return emitSessionEnd(ctx, sessionID, timestamp, sess, currDuration, newDuration, sessManager, producer, cfg, log, details)
+	return emitSessionEnd(ctx, sessionID, timestamp, sess, currDuration, newDuration, sessManager, producer, cfg, log, details, cleanupReg)
 }
 
 func emitSessionEnd(
@@ -146,9 +155,10 @@ func emitSessionEnd(
 	cfg *config.Config,
 	log logger.Logger,
 	details *LogDetails,
+	cleanupReg registry.Registry,
 ) bool {
 	// Re-check after the update — could have raced with another path.
-	if currDuration == newDuration {
+	if currDuration == newDuration && currDuration != 0 {
 		details.Duplicated[sessionID] = currDuration
 		return true
 	}
@@ -182,6 +192,8 @@ func emitSessionEnd(
 			log.Error(ctx, "can't send sessionEnd signal to canvas topic: %s", err)
 		}
 	}
+
+	cleanupReg.Done(sessionID)
 
 	if currDuration != 0 {
 		details.Diff[sessionID] = int64(newDuration) - int64(currDuration)

--- a/backend/internal/ender/processor.go
+++ b/backend/internal/ender/processor.go
@@ -42,7 +42,7 @@ func ProcessEndedSessions(
 		}
 		newDur := timestamp - sess.Timestamp
 		if currDuration == newDur {
-			if currDuration != 0 {
+			if sess.Duration != nil {
 				details.Duplicated[sessionID] = currDuration
 				completed[sessionID] = true
 				continue
@@ -113,7 +113,7 @@ func ProcessEndedSession(
 	}
 	newDur := timestamp - sess.Timestamp
 	if currDuration == newDur {
-		if currDuration != 0 {
+		if sess.Duration != nil {
 			details.Duplicated[sessionID] = currDuration
 			return true
 		}

--- a/backend/internal/http/services/services.go
+++ b/backend/internal/http/services/services.go
@@ -4,6 +4,7 @@ import (
 	"openreplay/backend/internal/config/http"
 	"openreplay/backend/internal/http/geoip"
 	"openreplay/backend/internal/http/uaparser"
+	"openreplay/backend/pkg/cleanup/registry"
 	"openreplay/backend/pkg/conditions"
 	conditionsAPI "openreplay/backend/pkg/conditions/api"
 	"openreplay/backend/pkg/db/postgres/pool"
@@ -52,11 +53,12 @@ func New(log logger.Logger, cfg *http.Config, webMetrics web.Web, dbMetrics data
 	sessions := sessions.New(log, pgconn, projs, redis, dbMetrics, sessions.DoNotIgnoreInactiveProjects)
 	tags := tags.New(log, pgconn)
 	responser := api.NewResponser(webMetrics)
+	cleanupReg := registry.New(log, redis)
 	builder := &serviceBuilder{}
-	if builder.webAPI, err = websessions.NewHandlers(cfg, log, responser, producer, projs, sessions, uaModule, geoModule, tokenizer, conditions, flaker); err != nil {
+	if builder.webAPI, err = websessions.NewHandlers(cfg, log, responser, producer, projs, sessions, uaModule, geoModule, tokenizer, conditions, flaker, cleanupReg); err != nil {
 		return nil, err
 	}
-	if builder.mobileAPI, err = mobilesessions.NewHandlers(cfg, log, responser, producer, projs, sessions, uaModule, geoModule, tokenizer, conditions, flaker); err != nil {
+	if builder.mobileAPI, err = mobilesessions.NewHandlers(cfg, log, responser, producer, projs, sessions, uaModule, geoModule, tokenizer, conditions, flaker, cleanupReg); err != nil {
 		return nil, err
 	}
 	if builder.conditionsAPI, err = conditionsAPI.NewHandlers(log, responser, tokenizer, conditions); err != nil {

--- a/backend/pkg/canvases/api/handlers.go
+++ b/backend/pkg/canvases/api/handlers.go
@@ -16,6 +16,7 @@ import (
 
 	config "openreplay/backend/internal/config/canvases"
 	"openreplay/backend/internal/http/util"
+	"openreplay/backend/pkg/cleanup/registry"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/queue/types"
 	"openreplay/backend/pkg/server/api"
@@ -24,22 +25,24 @@ import (
 )
 
 type handlersImpl struct {
-	log       logger.Logger
-	cfg       *config.Config
-	responser api.Responser
-	tokenizer *token.Tokenizer
-	sessions  sessions.Sessions
-	producer  types.Producer
+	log        logger.Logger
+	cfg        *config.Config
+	responser  api.Responser
+	tokenizer  *token.Tokenizer
+	sessions   sessions.Sessions
+	producer   types.Producer
+	cleanupReg registry.Registry
 }
 
-func NewHandlers(cfg *config.Config, log logger.Logger, responser api.Responser, tokenizer *token.Tokenizer, sessions sessions.Sessions, producer types.Producer) (api.Handlers, error) {
+func NewHandlers(cfg *config.Config, log logger.Logger, responser api.Responser, tokenizer *token.Tokenizer, sessions sessions.Sessions, producer types.Producer, cleanupReg registry.Registry) (api.Handlers, error) {
 	return &handlersImpl{
-		log:       log,
-		cfg:       cfg,
-		responser: responser,
-		tokenizer: tokenizer,
-		sessions:  sessions,
-		producer:  producer,
+		log:        log,
+		cfg:        cfg,
+		responser:  responser,
+		tokenizer:  tokenizer,
+		sessions:   sessions,
+		producer:   producer,
+		cleanupReg: cleanupReg,
 	}, nil
 }
 
@@ -86,6 +89,10 @@ func (h *handlersImpl) imagesUploaderHandlerWeb(w http.ResponseWriter, r *http.R
 	isFrames := false
 	if len(r.MultipartForm.Value["type"]) > 0 && r.MultipartForm.Value["type"][0] == "frames" {
 		isFrames = true
+	}
+
+	if len(r.MultipartForm.File) > 0 {
+		h.cleanupReg.Register(sessionData.ID, false, sessionData.ExpTime+registry.DeadlineGraceMs)
 	}
 
 	frames := bytes.NewBuffer([]byte{})

--- a/backend/pkg/canvases/builder.go
+++ b/backend/pkg/canvases/builder.go
@@ -3,6 +3,7 @@ package canvases
 import (
 	"openreplay/backend/internal/config/canvases"
 	canvasAPI "openreplay/backend/pkg/canvases/api"
+	"openreplay/backend/pkg/cleanup/registry"
 	"openreplay/backend/pkg/db/postgres/pool"
 	"openreplay/backend/pkg/db/redis"
 	"openreplay/backend/pkg/logger"
@@ -31,7 +32,8 @@ func NewServiceBuilder(log logger.Logger, cfg *canvases.Config, webMetrics web.W
 	sessions := sessions.New(log, pgconn, projs, redis, dbMetrics, sessions.DoNotIgnoreInactiveProjects)
 	tokenizer := token.NewTokenizer(cfg.TokenSecret)
 	responser := api.NewResponser(webMetrics)
-	if builder.api, err = canvasAPI.NewHandlers(cfg, log, responser, tokenizer, sessions, producer); err != nil {
+	cleanupReg := registry.New(log, redis)
+	if builder.api, err = canvasAPI.NewHandlers(cfg, log, responser, tokenizer, sessions, producer, cleanupReg); err != nil {
 		return nil, err
 	}
 	return builder, nil

--- a/backend/pkg/cleanup/dispatcher.go
+++ b/backend/pkg/cleanup/dispatcher.go
@@ -2,6 +2,8 @@ package cleanup
 
 import (
 	config "openreplay/backend/internal/config/ender"
+	"openreplay/backend/pkg/db/postgres/pool"
+	"openreplay/backend/pkg/db/redis"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/queue/types"
 )
@@ -10,11 +12,14 @@ type dispatcherMock struct {
 }
 
 type Dispatcher interface {
+	ActivePartitions(parts []uint64)
 	Close()
 }
 
-func NewDispatcher(log logger.Logger, cfg *config.Config, producer types.Producer) (Dispatcher, error) {
+func NewDispatcher(log logger.Logger, cfg *config.Config, producer types.Producer, db pool.Pool, redisClient *redis.Client) (Dispatcher, error) {
 	return &dispatcherMock{}, nil
 }
+
+func (d *dispatcherMock) ActivePartitions(parts []uint64) {}
 
 func (d *dispatcherMock) Close() {}

--- a/backend/pkg/cleanup/reaper/reaper.go
+++ b/backend/pkg/cleanup/reaper/reaper.go
@@ -1,0 +1,153 @@
+package reaper
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"openreplay/backend/pkg/cleanup/registry"
+	"openreplay/backend/pkg/logger"
+	"openreplay/backend/pkg/messages"
+	"openreplay/backend/pkg/queue/types"
+)
+
+const batchLimit = 1000
+
+type PendingStore interface {
+	Due(nowMs int64, limit int64) ([]string, error)
+	Remove(members ...string) error
+}
+
+type DurationSource interface {
+	Durations(sessionIDs []uint64) (map[uint64]*uint64, error)
+}
+
+type Config struct {
+	TopicTrigger      string
+	TopicRawImages    string
+	TopicCanvasImages string
+	PartitionsNumber  uint64
+	ProducerTimeout   int
+}
+
+type Reaper struct {
+	log      logger.Logger
+	store    PendingStore
+	sessions DurationSource
+	producer types.Producer
+	cfg      Config
+
+	mu     sync.RWMutex
+	active map[uint64]bool
+}
+
+func New(log logger.Logger, store PendingStore, sessions DurationSource, producer types.Producer, cfg Config) *Reaper {
+	return &Reaper{
+		log:      log,
+		store:    store,
+		sessions: sessions,
+		producer: producer,
+		cfg:      cfg,
+	}
+}
+
+func (r *Reaper) ActivePartitions(parts []uint64) {
+	active := make(map[uint64]bool, len(parts))
+	for _, p := range parts {
+		active[p] = true
+	}
+	r.mu.Lock()
+	r.active = active
+	r.mu.Unlock()
+}
+
+func (r *Reaper) owns(sessionID uint64) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.active) > 0 && r.active[sessionID%r.cfg.PartitionsNumber]
+}
+
+func (r *Reaper) Tick(nowMs int64) {
+	ctx := context.Background()
+	members, err := r.store.Due(nowMs, batchLimit)
+	if err != nil {
+		r.log.Error(ctx, "reaper: can't read pending sessions: %s", err)
+		return
+	}
+	if len(members) == 0 {
+		return
+	}
+
+	type entry struct {
+		member    string
+		sessionID uint64
+		isMobile  bool
+	}
+	entries := make([]entry, 0, len(members))
+	ids := make([]uint64, 0, len(members))
+	var malformed []string
+	for _, m := range members {
+		sessionID, isMobile, err := registry.ParseMember(m)
+		if err != nil {
+			r.log.Warn(ctx, "reaper: %s, removing", err)
+			malformed = append(malformed, m)
+			continue
+		}
+		// Skip members owned by other instances (or everything before the first Assign).
+		if !r.owns(sessionID) {
+			continue
+		}
+		entries = append(entries, entry{member: m, sessionID: sessionID, isMobile: isMobile})
+		ids = append(ids, sessionID)
+	}
+	if len(malformed) > 0 {
+		if err := r.store.Remove(malformed...); err != nil {
+			r.log.Warn(ctx, "reaper: can't remove malformed members: %s", err)
+		}
+	}
+	if len(entries) == 0 {
+		return
+	}
+
+	durations, err := r.sessions.Durations(ids)
+	if err != nil {
+		r.log.Error(ctx, "reaper: can't load session durations: %s", err)
+		return
+	}
+
+	toRemove := make([]string, 0, len(entries))
+	cleaned := 0
+	for _, e := range entries {
+		if dur, ok := durations[e.sessionID]; ok && dur != nil {
+			toRemove = append(toRemove, e.member)
+			continue
+		}
+		sessCtx := context.WithValue(ctx, "sessionID", fmt.Sprintf("%d", e.sessionID))
+		if err := r.clean(e.sessionID, e.isMobile); err != nil {
+			r.log.Error(sessCtx, "reaper: can't send CleanSession, will retry: %s", err)
+			continue // keep the member for the next tick
+		}
+		r.log.Info(sessCtx, "reaper: session has no sessionEnd, dispatching EFS cleanup")
+		toRemove = append(toRemove, e.member)
+		cleaned++
+	}
+	if cleaned > 0 {
+		r.producer.Flush(r.cfg.ProducerTimeout)
+	}
+	if len(toRemove) > 0 {
+		if err := r.store.Remove(toRemove...); err != nil {
+			r.log.Warn(ctx, "reaper: can't remove processed members: %s", err)
+		}
+	}
+}
+
+func (r *Reaper) clean(sessionID uint64, isMobile bool) error {
+	msg := &messages.CleanSession{}
+	if isMobile {
+		return r.producer.Produce(r.cfg.TopicRawImages, sessionID, msg.Encode())
+	}
+	if err := r.producer.Produce(r.cfg.TopicCanvasImages, sessionID, msg.Encode()); err != nil {
+		return err
+	}
+	return r.producer.Produce(r.cfg.TopicTrigger, sessionID, msg.Encode())
+}

--- a/backend/pkg/cleanup/reaper/reaper.go
+++ b/backend/pkg/cleanup/reaper/reaper.go
@@ -143,10 +143,11 @@ func (r *Reaper) Tick(nowMs int64) {
 
 func (r *Reaper) clean(sessionID uint64, isMobile bool) error {
 	msg := &messages.CleanSession{}
+	imagesTopic := r.cfg.TopicCanvasImages
 	if isMobile {
-		return r.producer.Produce(r.cfg.TopicRawImages, sessionID, msg.Encode())
+		imagesTopic = r.cfg.TopicRawImages
 	}
-	if err := r.producer.Produce(r.cfg.TopicCanvasImages, sessionID, msg.Encode()); err != nil {
+	if err := r.producer.Produce(imagesTopic, sessionID, msg.Encode()); err != nil {
 		return err
 	}
 	return r.producer.Produce(r.cfg.TopicTrigger, sessionID, msg.Encode())

--- a/backend/pkg/cleanup/reaper/store.go
+++ b/backend/pkg/cleanup/reaper/store.go
@@ -1,0 +1,79 @@
+package reaper
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/lib/pq"
+	goredis "github.com/redis/go-redis/v9"
+
+	"openreplay/backend/pkg/cleanup/registry"
+	"openreplay/backend/pkg/db/postgres/pool"
+	"openreplay/backend/pkg/db/redis"
+)
+
+const opTimeout = 5 * time.Second
+
+func NewRedisStore(client *redis.Client) PendingStore {
+	if client == nil || client.Redis == nil {
+		return nil
+	}
+	return &redisStore{redis: client.Redis}
+}
+
+type redisStore struct {
+	redis *goredis.Client
+}
+
+func (s *redisStore) Due(nowMs int64, limit int64) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+	defer cancel()
+	return s.redis.ZRangeByScore(ctx, registry.PendingKey, &goredis.ZRangeBy{
+		Min:    "-inf",
+		Max:    strconv.FormatInt(nowMs, 10),
+		Offset: 0,
+		Count:  limit,
+	}).Result()
+}
+
+func (s *redisStore) Remove(members ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+	defer cancel()
+	args := make([]interface{}, len(members))
+	for i, m := range members {
+		args[i] = m
+	}
+	return s.redis.ZRem(ctx, registry.PendingKey, args...).Err()
+}
+
+func NewPGSource(db pool.Pool) DurationSource {
+	return &pgSource{db: db}
+}
+
+type pgSource struct {
+	db pool.Pool
+}
+
+func (s *pgSource) Durations(sessionIDs []uint64) (map[uint64]*uint64, error) {
+	rows, err := s.db.Query(`
+		SELECT session_id, duration
+		FROM sessions
+		WHERE session_id = ANY($1)`, pq.Array(sessionIDs))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	res := make(map[uint64]*uint64, len(sessionIDs))
+	for rows.Next() {
+		var (
+			sessionID uint64
+			duration  *uint64
+		)
+		if err := rows.Scan(&sessionID, &duration); err != nil {
+			return nil, err
+		}
+		res[sessionID] = duration
+	}
+	return res, rows.Err()
+}

--- a/backend/pkg/cleanup/registry/member.go
+++ b/backend/pkg/cleanup/registry/member.go
@@ -1,0 +1,31 @@
+package registry
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	PendingKey            = "cleanup:pending"
+	DeadlineGraceMs int64 = 10 * 60 * 1000
+)
+
+func Member(sessionID uint64, isMobile bool) string {
+	if isMobile {
+		return strconv.FormatUint(sessionID, 10) + ":m"
+	}
+	return strconv.FormatUint(sessionID, 10) + ":w"
+}
+
+func ParseMember(member string) (sessionID uint64, isMobile bool, err error) {
+	parts := strings.Split(member, ":")
+	if len(parts) != 2 || (parts[1] != "w" && parts[1] != "m") {
+		return 0, false, fmt.Errorf("malformed cleanup member: %s", member)
+	}
+	sessionID, err = strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("malformed cleanup member: %s", member)
+	}
+	return sessionID, parts[1] == "m", nil
+}

--- a/backend/pkg/cleanup/registry/registry.go
+++ b/backend/pkg/cleanup/registry/registry.go
@@ -1,0 +1,117 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"openreplay/backend/pkg/cache"
+	"openreplay/backend/pkg/db/redis"
+	"openreplay/backend/pkg/logger"
+)
+
+const (
+	PendingKey            = "cleanup:pending"
+	DeadlineGraceMs int64 = 10 * 60 * 1000
+	opTimeout             = 500 * time.Millisecond
+)
+
+type Registry interface {
+	Register(sessionID uint64, isMobile bool, deadlineMs int64)
+	Done(sessionID uint64)
+}
+
+type store interface {
+	add(member string, score int64) error
+	remove(members ...string) error
+}
+
+type registryImpl struct {
+	log  logger.Logger
+	db   store
+	seen cache.Cache // local dedup to avoid a ZADD on every batch of a session
+}
+
+func New(log logger.Logger, client *redis.Client) Registry {
+	var db store
+	if client != nil && client.Redis != nil {
+		db = &redisStore{redis: client.Redis}
+	}
+	return newWithStore(log, db)
+}
+
+func newWithStore(log logger.Logger, db store) Registry {
+	return &registryImpl{
+		log:  log,
+		db:   db,
+		seen: cache.New(10*time.Minute, time.Hour),
+	}
+}
+
+func Member(sessionID uint64, isMobile bool) string {
+	if isMobile {
+		return strconv.FormatUint(sessionID, 10) + ":m"
+	}
+	return strconv.FormatUint(sessionID, 10) + ":w"
+}
+
+func ParseMember(member string) (sessionID uint64, isMobile bool, err error) {
+	parts := strings.Split(member, ":")
+	if len(parts) != 2 || (parts[1] != "w" && parts[1] != "m") {
+		return 0, false, fmt.Errorf("malformed cleanup member: %s", member)
+	}
+	sessionID, err = strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("malformed cleanup member: %s", member)
+	}
+	return sessionID, parts[1] == "m", nil
+}
+
+func (r *registryImpl) Register(sessionID uint64, isMobile bool, deadlineMs int64) {
+	if r.db == nil || sessionID == 0 {
+		return
+	}
+	if _, ok := r.seen.Get(sessionID); ok {
+		return
+	}
+	if err := r.db.add(Member(sessionID, isMobile), deadlineMs); err != nil {
+		ctx := context.WithValue(context.Background(), "sessionID", fmt.Sprintf("%d", sessionID))
+		r.log.Warn(ctx, "failed to register session for cleanup: %s", err)
+		return
+	}
+	r.seen.Set(sessionID, struct{}{})
+}
+
+func (r *registryImpl) Done(sessionID uint64) {
+	if r.db == nil || sessionID == 0 {
+		return
+	}
+	if err := r.db.remove(Member(sessionID, false), Member(sessionID, true)); err != nil {
+		ctx := context.WithValue(context.Background(), "sessionID", fmt.Sprintf("%d", sessionID))
+		r.log.Warn(ctx, "failed to deregister session from cleanup: %s", err)
+	}
+}
+
+type redisStore struct {
+	redis *goredis.Client
+}
+
+func (s *redisStore) add(member string, score int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+	defer cancel()
+	return s.redis.ZAddNX(ctx, PendingKey, goredis.Z{Score: float64(score), Member: member}).Err()
+}
+
+func (s *redisStore) remove(members ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+	defer cancel()
+	args := make([]interface{}, len(members))
+	for i, m := range members {
+		args[i] = m
+	}
+	return s.redis.ZRem(ctx, PendingKey, args...).Err()
+}

--- a/backend/pkg/cleanup/registry/registry.go
+++ b/backend/pkg/cleanup/registry/registry.go
@@ -1,117 +1,22 @@
 package registry
 
 import (
-	"context"
-	"fmt"
-	"strconv"
-	"strings"
-	"time"
-
-	goredis "github.com/redis/go-redis/v9"
-
-	"openreplay/backend/pkg/cache"
 	"openreplay/backend/pkg/db/redis"
 	"openreplay/backend/pkg/logger"
 )
 
-const (
-	PendingKey            = "cleanup:pending"
-	DeadlineGraceMs int64 = 10 * 60 * 1000
-	opTimeout             = 500 * time.Millisecond
-)
+type registryMock struct {
+}
 
 type Registry interface {
 	Register(sessionID uint64, isMobile bool, deadlineMs int64)
 	Done(sessionID uint64)
 }
 
-type store interface {
-	add(member string, score int64) error
-	remove(members ...string) error
-}
-
-type registryImpl struct {
-	log  logger.Logger
-	db   store
-	seen cache.Cache // local dedup to avoid a ZADD on every batch of a session
-}
-
 func New(log logger.Logger, client *redis.Client) Registry {
-	var db store
-	if client != nil && client.Redis != nil {
-		db = &redisStore{redis: client.Redis}
-	}
-	return newWithStore(log, db)
+	return &registryMock{}
 }
 
-func newWithStore(log logger.Logger, db store) Registry {
-	return &registryImpl{
-		log:  log,
-		db:   db,
-		seen: cache.New(10*time.Minute, time.Hour),
-	}
-}
+func (r *registryMock) Register(sessionID uint64, isMobile bool, deadlineMs int64) {}
 
-func Member(sessionID uint64, isMobile bool) string {
-	if isMobile {
-		return strconv.FormatUint(sessionID, 10) + ":m"
-	}
-	return strconv.FormatUint(sessionID, 10) + ":w"
-}
-
-func ParseMember(member string) (sessionID uint64, isMobile bool, err error) {
-	parts := strings.Split(member, ":")
-	if len(parts) != 2 || (parts[1] != "w" && parts[1] != "m") {
-		return 0, false, fmt.Errorf("malformed cleanup member: %s", member)
-	}
-	sessionID, err = strconv.ParseUint(parts[0], 10, 64)
-	if err != nil {
-		return 0, false, fmt.Errorf("malformed cleanup member: %s", member)
-	}
-	return sessionID, parts[1] == "m", nil
-}
-
-func (r *registryImpl) Register(sessionID uint64, isMobile bool, deadlineMs int64) {
-	if r.db == nil || sessionID == 0 {
-		return
-	}
-	if _, ok := r.seen.Get(sessionID); ok {
-		return
-	}
-	if err := r.db.add(Member(sessionID, isMobile), deadlineMs); err != nil {
-		ctx := context.WithValue(context.Background(), "sessionID", fmt.Sprintf("%d", sessionID))
-		r.log.Warn(ctx, "failed to register session for cleanup: %s", err)
-		return
-	}
-	r.seen.Set(sessionID, struct{}{})
-}
-
-func (r *registryImpl) Done(sessionID uint64) {
-	if r.db == nil || sessionID == 0 {
-		return
-	}
-	if err := r.db.remove(Member(sessionID, false), Member(sessionID, true)); err != nil {
-		ctx := context.WithValue(context.Background(), "sessionID", fmt.Sprintf("%d", sessionID))
-		r.log.Warn(ctx, "failed to deregister session from cleanup: %s", err)
-	}
-}
-
-type redisStore struct {
-	redis *goredis.Client
-}
-
-func (s *redisStore) add(member string, score int64) error {
-	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
-	defer cancel()
-	return s.redis.ZAddNX(ctx, PendingKey, goredis.Z{Score: float64(score), Member: member}).Err()
-}
-
-func (s *redisStore) remove(members ...string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
-	defer cancel()
-	args := make([]interface{}, len(members))
-	for i, m := range members {
-		args[i] = m
-	}
-	return s.redis.ZRem(ctx, PendingKey, args...).Err()
-}
+func (r *registryMock) Done(sessionID uint64) {}

--- a/backend/pkg/images/api/handlers.go
+++ b/backend/pkg/images/api/handlers.go
@@ -18,6 +18,7 @@ import (
 	gzip "github.com/klauspost/pgzip"
 
 	config "openreplay/backend/internal/config/images"
+	"openreplay/backend/pkg/cleanup/registry"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/queue/types"
 	"openreplay/backend/pkg/server/api"
@@ -26,22 +27,24 @@ import (
 )
 
 type handlersImpl struct {
-	log       logger.Logger
-	cfg       *config.Config
-	responser api.Responser
-	tokenizer *token.Tokenizer
-	sessions  sessions.Sessions
-	producer  types.Producer
+	log        logger.Logger
+	cfg        *config.Config
+	responser  api.Responser
+	tokenizer  *token.Tokenizer
+	sessions   sessions.Sessions
+	producer   types.Producer
+	cleanupReg registry.Registry
 }
 
-func NewHandlers(cfg *config.Config, log logger.Logger, responser api.Responser, tokenizer *token.Tokenizer, sessions sessions.Sessions, producer types.Producer) (api.Handlers, error) {
+func NewHandlers(cfg *config.Config, log logger.Logger, responser api.Responser, tokenizer *token.Tokenizer, sessions sessions.Sessions, producer types.Producer, cleanupReg registry.Registry) (api.Handlers, error) {
 	return &handlersImpl{
-		log:       log,
-		cfg:       cfg,
-		responser: responser,
-		tokenizer: tokenizer,
-		sessions:  sessions,
-		producer:  producer,
+		log:        log,
+		cfg:        cfg,
+		responser:  responser,
+		tokenizer:  tokenizer,
+		sessions:   sessions,
+		producer:   producer,
+		cleanupReg: cleanupReg,
 	}, nil
 }
 
@@ -89,6 +92,10 @@ func (e *handlersImpl) imagesUploaderHandlerMobile(w http.ResponseWriter, r *htt
 	isFrames := false
 	if len(r.MultipartForm.Value["type"]) > 0 && r.MultipartForm.Value["type"][0] == "frames" {
 		isFrames = true
+	}
+
+	if len(r.MultipartForm.File) > 0 {
+		e.cleanupReg.Register(sessionData.ID, true, sessionData.ExpTime+registry.DeadlineGraceMs)
 	}
 
 	for _, fileHeaderList := range r.MultipartForm.File {

--- a/backend/pkg/images/builder.go
+++ b/backend/pkg/images/builder.go
@@ -2,6 +2,7 @@ package images
 
 import (
 	"openreplay/backend/internal/config/images"
+	"openreplay/backend/pkg/cleanup/registry"
 	"openreplay/backend/pkg/db/postgres/pool"
 	"openreplay/backend/pkg/db/redis"
 	imageAPI "openreplay/backend/pkg/images/api"
@@ -31,7 +32,8 @@ func NewServiceBuilder(log logger.Logger, cfg *images.Config, webMetrics web.Web
 	sessions := sessions.New(log, pgconn, projs, redis, dbMetrics, sessions.DoNotIgnoreInactiveProjects)
 	tokenizer := token.NewTokenizer(cfg.TokenSecret)
 	responser := api.NewResponser(webMetrics)
-	if builder.api, err = imageAPI.NewHandlers(cfg, log, responser, tokenizer, sessions, producer); err != nil {
+	cleanupReg := registry.New(log, redis)
+	if builder.api, err = imageAPI.NewHandlers(cfg, log, responser, tokenizer, sessions, producer, cleanupReg); err != nil {
 		return nil, err
 	}
 	return builder, nil

--- a/backend/pkg/sessions/api/mobile/handlers.go
+++ b/backend/pkg/sessions/api/mobile/handlers.go
@@ -20,6 +20,7 @@ import (
 	"openreplay/backend/internal/http/ios"
 	"openreplay/backend/internal/http/uaparser"
 	"openreplay/backend/internal/http/uuid"
+	"openreplay/backend/pkg/cleanup/registry"
 	"openreplay/backend/pkg/conditions"
 	"openreplay/backend/pkg/db/postgres"
 	"openreplay/backend/pkg/flakeid"
@@ -61,11 +62,12 @@ type handlersImpl struct {
 	tokenizer  *token.Tokenizer
 	conditions conditions.Conditions
 	flaker     *flakeid.Flaker
+	cleanupReg registry.Registry
 }
 
 func NewHandlers(cfg *httpCfg.Config, log logger.Logger, responser api.Responser, producer types.Producer, projects projects.Projects,
 	sessions sessions.Sessions, uaParser *uaparser.UAParser, geoIP geoip.GeoParser, tokenizer *token.Tokenizer,
-	conditions conditions.Conditions, flaker *flakeid.Flaker) (api.Handlers, error) {
+	conditions conditions.Conditions, flaker *flakeid.Flaker, cleanupReg registry.Registry) (api.Handlers, error) {
 	return &handlersImpl{
 		log:        log,
 		cfg:        cfg,
@@ -78,6 +80,7 @@ func NewHandlers(cfg *httpCfg.Config, log logger.Logger, responser api.Responser
 		tokenizer:  tokenizer,
 		conditions: conditions,
 		flaker:     flaker,
+		cleanupReg: cleanupReg,
 	}, nil
 }
 
@@ -256,7 +259,7 @@ func (e *handlersImpl) pushMobileMessagesHandler(w http.ResponseWriter, r *http.
 		r = r.WithContext(context.WithValue(r.Context(), "projectID", fmt.Sprintf("%d", info.ProjectID)))
 	}
 
-	e.pushMessages(w, r, sessionData.ID, e.cfg.TopicRawMobile)
+	e.pushMessages(w, r, sessionData, e.cfg.TopicRawMobile)
 }
 
 func (e *handlersImpl) pushMobileLateMessagesHandler(w http.ResponseWriter, r *http.Request) {
@@ -271,10 +274,10 @@ func (e *handlersImpl) pushMobileLateMessagesHandler(w http.ResponseWriter, r *h
 		return
 	}
 	// Check timestamps here?
-	e.pushMessages(w, r, sessionData.ID, e.cfg.TopicRawMobile)
+	e.pushMessages(w, r, sessionData, e.cfg.TopicRawMobile)
 }
 
-func (e *handlersImpl) pushMessages(w http.ResponseWriter, r *http.Request, sessionID uint64, topicName string) {
+func (e *handlersImpl) pushMessages(w http.ResponseWriter, r *http.Request, sessionData *token.TokenData, topicName string) {
 	start := time.Now()
 	body := http.MaxBytesReader(w, r.Body, e.cfg.BeaconSizeLimit)
 	defer body.Close()
@@ -298,7 +301,10 @@ func (e *handlersImpl) pushMessages(w http.ResponseWriter, r *http.Request, sess
 		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusInternalServerError, err, start, r.URL.Path, 0)
 		return
 	}
-	if err := e.producer.Produce(topicName, sessionID, buf); err != nil {
+	if len(buf) > 0 {
+		e.cleanupReg.Register(sessionData.ID, true, sessionData.ExpTime+registry.DeadlineGraceMs)
+	}
+	if err := e.producer.Produce(topicName, sessionData.ID, buf); err != nil {
 		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusInternalServerError, err, start, r.URL.Path, 0)
 		return
 	}

--- a/backend/pkg/sessions/api/web/handlers.go
+++ b/backend/pkg/sessions/api/web/handlers.go
@@ -17,6 +17,7 @@ import (
 	"openreplay/backend/internal/http/geoip"
 	"openreplay/backend/internal/http/uaparser"
 	"openreplay/backend/internal/http/uuid"
+	"openreplay/backend/pkg/cleanup/registry"
 	"openreplay/backend/pkg/conditions"
 	"openreplay/backend/pkg/db/postgres"
 	"openreplay/backend/pkg/flakeid"
@@ -43,11 +44,12 @@ type handlersImpl struct {
 	conditions      conditions.Conditions
 	flaker          *flakeid.Flaker
 	beaconSizeCache *beacons.BeaconCache
+	cleanupReg      registry.Registry
 }
 
 func NewHandlers(cfg *httpCfg.Config, log logger.Logger, responser api.Responser, producer types.Producer, projects projects.Projects,
 	sessions sessions.Sessions, uaParser *uaparser.UAParser, geoIP geoip.GeoParser, tokenizer *token.Tokenizer,
-	conditions conditions.Conditions, flaker *flakeid.Flaker) (api.Handlers, error) {
+	conditions conditions.Conditions, flaker *flakeid.Flaker, cleanupReg registry.Registry) (api.Handlers, error) {
 	return &handlersImpl{
 		log:             log,
 		cfg:             cfg,
@@ -61,6 +63,7 @@ func NewHandlers(cfg *httpCfg.Config, log logger.Logger, responser api.Responser
 		conditions:      conditions,
 		flaker:          flaker,
 		beaconSizeCache: beacons.NewBeaconCache(cfg.BeaconSizeLimit),
+		cleanupReg:      cleanupReg,
 	}, nil
 }
 
@@ -351,6 +354,10 @@ func (e *handlersImpl) pushMessagesHandlerWeb(w http.ResponseWriter, r *http.Req
 		return
 	}
 	bodySize = len(bodyBytes)
+
+	if len(bodyBytes) > 0 {
+		e.cleanupReg.Register(sessionData.ID, false, sessionData.ExpTime+registry.DeadlineGraceMs)
+	}
 
 	if batchType == "visual" {
 		// parse split url parameter

--- a/backend/pkg/sessions/storage.go
+++ b/backend/pkg/sessions/storage.go
@@ -135,7 +135,7 @@ type scannable interface {
 }
 
 const sessionColumns = `session_id, platform,
-	CASE WHEN duration IS NULL OR duration < 0 THEN 0 ELSE duration END,
+	CASE WHEN duration < 0 THEN 0 ELSE duration END, -- keep NULL: it marks a session that was never ended
 	project_id, start_ts, timezone,
 	user_uuid, user_os, user_os_version,
 	user_device, user_device_type, user_country, user_state, user_city,

--- a/ee/backend/pkg/cleanup/dispatcher.go
+++ b/ee/backend/pkg/cleanup/dispatcher.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	config "openreplay/backend/internal/config/ender"
+	"openreplay/backend/pkg/cleanup/reaper"
+	"openreplay/backend/pkg/db/postgres/pool"
+	"openreplay/backend/pkg/db/redis"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/messages"
 	"openreplay/backend/pkg/queue"
@@ -17,13 +21,16 @@ type dispatcherImpl struct {
 	cfg      *config.Config
 	consumer types.Consumer
 	producer types.Producer
+	reaper   *reaper.Reaper
+	stop     chan struct{}
 }
 
 type Dispatcher interface {
+	ActivePartitions(parts []uint64)
 	Close()
 }
 
-func NewDispatcher(log logger.Logger, cfg *config.Config, producer types.Producer) (Dispatcher, error) {
+func NewDispatcher(log logger.Logger, cfg *config.Config, producer types.Producer, db pool.Pool, redisClient *redis.Client) (Dispatcher, error) {
 	switch {
 	case log == nil:
 		return nil, errors.New("nil logger")
@@ -36,6 +43,7 @@ func NewDispatcher(log logger.Logger, cfg *config.Config, producer types.Produce
 		log:      log,
 		cfg:      cfg,
 		producer: producer,
+		stop:     make(chan struct{}),
 	}
 	consumer, err := queue.NewConsumer(
 		log,
@@ -58,6 +66,20 @@ func NewDispatcher(log logger.Logger, cfg *config.Config, producer types.Produce
 	d.consumer = consumer
 	go d.run()
 	log.Info(context.Background(), "cleanup dispatcher started with readGap=%s", cfg.CleanupReadGap)
+
+	if store := reaper.NewRedisStore(redisClient); store != nil && db != nil {
+		d.reaper = reaper.New(log, store, reaper.NewPGSource(db), producer, reaper.Config{
+			TopicTrigger:      cfg.TopicTrigger,
+			TopicRawImages:    cfg.TopicRawImages,
+			TopicCanvasImages: cfg.TopicCanvasImages,
+			PartitionsNumber:  uint64(cfg.PartitionsNumber),
+			ProducerTimeout:   cfg.ProducerTimeout,
+		})
+		go d.reap()
+		log.Info(context.Background(), "cleanup reaper started with tick=%s", cfg.CleanupReaperTick)
+	} else {
+		log.Warn(context.Background(), "cleanup reaper is disabled: no redis connection")
+	}
 	return d, nil
 }
 
@@ -93,6 +115,26 @@ func (d *dispatcherImpl) run() {
 	}
 }
 
+func (d *dispatcherImpl) reap() {
+	ticker := time.NewTicker(d.cfg.CleanupReaperTick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-d.stop:
+			return
+		case <-ticker.C:
+			d.reaper.Tick(time.Now().UnixMilli())
+		}
+	}
+}
+
+func (d *dispatcherImpl) ActivePartitions(parts []uint64) {
+	if d.reaper != nil {
+		d.reaper.ActivePartitions(parts)
+	}
+}
+
 func (d *dispatcherImpl) Close() {
+	close(d.stop)
 	d.consumer.Close()
 }

--- a/ee/backend/pkg/cleanup/registry/registry.go
+++ b/ee/backend/pkg/cleanup/registry/registry.go
@@ -1,0 +1,92 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"openreplay/backend/pkg/cache"
+	"openreplay/backend/pkg/db/redis"
+	"openreplay/backend/pkg/logger"
+)
+
+const opTimeout = 500 * time.Millisecond
+
+type Registry interface {
+	Register(sessionID uint64, isMobile bool, deadlineMs int64)
+	Done(sessionID uint64)
+}
+
+type store interface {
+	add(member string, score int64) error
+	remove(members ...string) error
+}
+
+type registryImpl struct {
+	log  logger.Logger
+	db   store
+	seen cache.Cache // local dedup to avoid a ZADD on every batch of a session
+}
+
+func New(log logger.Logger, client *redis.Client) Registry {
+	var db store
+	if client != nil && client.Redis != nil {
+		db = &redisStore{redis: client.Redis}
+	}
+	return newWithStore(log, db)
+}
+
+func newWithStore(log logger.Logger, db store) Registry {
+	return &registryImpl{
+		log:  log,
+		db:   db,
+		seen: cache.New(10*time.Minute, time.Hour),
+	}
+}
+
+func (r *registryImpl) Register(sessionID uint64, isMobile bool, deadlineMs int64) {
+	if r.db == nil || sessionID == 0 {
+		return
+	}
+	if _, ok := r.seen.Get(sessionID); ok {
+		return
+	}
+	if err := r.db.add(Member(sessionID, isMobile), deadlineMs); err != nil {
+		ctx := context.WithValue(context.Background(), "sessionID", fmt.Sprintf("%d", sessionID))
+		r.log.Warn(ctx, "failed to register session for cleanup: %s", err)
+		return
+	}
+	r.seen.Set(sessionID, struct{}{})
+}
+
+func (r *registryImpl) Done(sessionID uint64) {
+	if r.db == nil || sessionID == 0 {
+		return
+	}
+	if err := r.db.remove(Member(sessionID, false), Member(sessionID, true)); err != nil {
+		ctx := context.WithValue(context.Background(), "sessionID", fmt.Sprintf("%d", sessionID))
+		r.log.Warn(ctx, "failed to deregister session from cleanup: %s", err)
+	}
+}
+
+type redisStore struct {
+	redis *goredis.Client
+}
+
+func (s *redisStore) add(member string, score int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+	defer cancel()
+	return s.redis.ZAddNX(ctx, PendingKey, goredis.Z{Score: float64(score), Member: member}).Err()
+}
+
+func (s *redisStore) remove(members ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+	defer cancel()
+	args := make([]interface{}, len(members))
+	for i, m := range members {
+		args[i] = m
+	}
+	return s.redis.ZRem(ctx, PendingKey, args...).Err()
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
End zero-duration sessions and add a Redis-backed cleanup safety net so sessions that never emit sessionEnd don’t leave orphaned EFS assets. Also fixes a goroutine leak in the EE cleanup dispatcher.

- **New Features**
  - Ender now ends zero-duration sessions and deregisters cleanup on sessionEnd.
  - Preserve NULL durations to flag sessions without sessionEnd; used by the reaper.
  - EE-only cleanup registry + reaper: track sessions in Redis `cleanup:pending`; handlers register on first web/mobile messages or image uploads (deadline = `token.expTime + 10m`); reaper scans overdue entries by partition and emits `CleanSession` to `TopicTrigger`, `TopicRawImages`, and `TopicCanvasImages`.

- **Migration**
  - Optional: enable Redis to use the registry and reaper; configure `CLEANUP_REAPER_TICK` (default 2m).

<sup>Written for commit f3a342fb3ac92bef0e3e7029e54d0d32e797ad0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

