### PR TITLE
Add cache headers for static assets

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,10 +6,14 @@ ARG NODE_OPTIONS="--max-old-space-size=10240"
 ENV NODE_OPTIONS=$NODE_OPTIONS
 RUN yarn 
 RUN yarn build
+# Normalize mtimes so ETag/Last-Modified are deterministic across replicas
+# and builds instead of drifting with build wall-clock time.
+RUN find public -exec touch -t 202001010000 {} +
 
 FROM nginx:alpine as cicd
 LABEL maintainer=Rajesh<rajesh@openreplay.com>
 COPY public /var/www/openreplay
+RUN find /var/www/openreplay -exec touch -t 202001010000 {} +
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -2,10 +2,22 @@ server {
   listen 8080 default_server;
   root /var/www/openreplay;
   index index.html;
+
+  location ^~ /assets/ {
+    try_files $uri =404;
+    add_header Cache-Control "public, max-age=86400, must-revalidate" always;
+  }
+
+  location ~* \.(?:js|css|woff2?|ttf|eot|otf|png|jpe?g|gif|svg|ico|webp)$ {
+    try_files $uri =404;
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+  }
+
   location / {
     try_files $uri $uri/ =404;
     rewrite ^((?!.(js|css|png|svg|jpg|woff|woff2)).)*$ /index.html break;
     proxy_intercept_errors on; # see frontend://nginx.org/en/docs/frontend/ngx_frontend_proxy_module.html#proxy_intercept_errors
     error_page 404 =200 /index.html;
+    add_header Cache-Control "no-cache, must-revalidate" always;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add HTTP caching for static assets and make ETag/Last-Modified deterministic by normalizing file mtimes. This speeds up repeat loads and reduces bandwidth.

- **New Features**
  - nginx: cache `/assets/` for 1 day (must-revalidate); cache static files (`js`, `css`, fonts, images) for 1 year (immutable); mark HTML/SPA responses as no-cache.
  - Docker build: set fixed mtimes on `public` and deployed files to keep ETag/Last-Modified consistent across replicas.

<sup>Written for commit 69ca59359a3c3f99313f09ed85902def4bd84fe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

