### PR TITLE
ui: make the dashboard useful on first open

### DIFF
--- a/frontend/app/components/Dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/app/components/Dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -12,6 +12,7 @@ import { observer } from 'mobx-react-lite';
 import DashboardOptions from '../DashboardOptions';
 import DashboardEditModal from '../DashboardEditModal';
 import AddCardSection from '../AddCardSection/AddCardSection';
+import DashboardSwitcher from './DashboardSwitcher';
 import { useTranslation } from 'react-i18next';
 import { mobileScreen } from 'App/utils/isMobile';
 
@@ -67,20 +68,8 @@ function DashboardHeader(props: Props) {
       />
 
       <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-0 md:justify-between px-4 pt-4  bg-white">
-        <div className="flex items-center gap-2" style={{ flex: 3 }}>
-          <BackButton siteId={siteId} compact />
-
-          <PageTitle
-            title={
-              <Tooltip title={t('Click to edit')} placement="bottom">
-                <div className="text-xl md:text-2xl h-8 flex items-center cursor-pointer select-none hover:bg-teal/10">
-                  {dashboard?.name}
-                </div>
-              </Tooltip>
-            }
-            onClick={() => onEdit(true)}
-            className="select-none border-b border-b-borderColor-transparent hover:border-dashed hover:border-gray-medium cursor-pointer"
-          />
+        <div className="flex items-center gap-2 min-w-0" style={{ flex: 3 }}>
+          <DashboardSwitcher siteId={siteId} onRename={() => onEdit(true)} />
         </div>
         <div className="flex items-center gap-2 md:justify-end w-full md:w-auto">
           <Popover

--- a/frontend/app/components/Dashboard/components/DashboardHeader/DashboardSwitcher.tsx
+++ b/frontend/app/components/Dashboard/components/DashboardHeader/DashboardSwitcher.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { PlusOutlined } from '@ant-design/icons';
+import { Button, Dropdown, Tooltip } from 'antd';
+import type { MenuProps } from 'antd';
+import { ChevronDown, LayoutDashboard, Pin } from 'lucide-react';
+import { observer } from 'mobx-react-lite';
+import { useTranslation } from 'react-i18next';
+
+import { useStore } from 'App/mstore';
+import { dashboardSelected, withSiteId } from 'App/routes';
+import seedStarterCards from '../DashboardList/seedStarterCards';
+import { useHistory } from 'App/routing';
+
+interface Props {
+  siteId: string;
+  onRename: () => void;
+}
+
+/**
+ * Lets the user move between dashboards without leaving the dashboard itself.
+ * Replaces the old flow of going back to a separate list screen to switch.
+ */
+function DashboardSwitcher({ siteId, onRename }: Props) {
+  const { t } = useTranslation();
+  const { dashboardStore, sessionStore } = useStore();
+  const history = useHistory();
+  const [creating, setCreating] = React.useState(false);
+
+  const { dashboards } = dashboardStore;
+  const dashboard: any = dashboardStore.selectedDashboard;
+
+  const createDashboard = async () => {
+    setCreating(true);
+    dashboardStore.initDashboard();
+    try {
+      const created = await dashboardStore.save(dashboardStore.dashboardInstance);
+      // Prefill the new dashboard so it opens with something on it.
+      await seedStarterCards(created, {
+        countSessions: async () => {
+          const range = dashboardStore.period?.toTimestamps?.();
+          const res: any = await sessionStore.getSessions({
+            filters: [],
+            sort: 'startTs',
+            order: 'desc',
+            eventsOrder: 'then',
+            page: 1,
+            limit: 1,
+            startTimestamp: range?.startTimestamp,
+            endTimestamp: range?.endTimestamp,
+          });
+          return res?.total ?? 0;
+        },
+      });
+      dashboardStore.selectDashboardById(created.dashboardId);
+      history.push(withSiteId(dashboardSelected(created.dashboardId), siteId));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const items: MenuProps['items'] = React.useMemo(() => {
+    const list = dashboards.map((d: any) => ({
+      key: String(d.dashboardId),
+      label: (
+        <div className="flex items-center gap-2 min-w-40">
+          <LayoutDashboard size={14} className="shrink-0 opacity-60" />
+          <span className="truncate">{d.name}</span>
+          {d.isPinned ? (
+            <Pin size={12} className="ml-auto shrink-0 opacity-60" />
+          ) : null}
+        </div>
+      ),
+    }));
+
+    return [
+      ...list,
+      { type: 'divider' as const },
+      {
+        key: 'new',
+        label: (
+          <div className="flex items-center gap-2">
+            <PlusOutlined />
+            <span>{t('New dashboard')}</span>
+          </div>
+        ),
+      },
+    ];
+  }, [dashboards, t]);
+
+  const onSelect: MenuProps['onClick'] = ({ key }) => {
+    if (key === 'new') {
+      void createDashboard();
+      return;
+    }
+    if (key === String(dashboard?.dashboardId)) return;
+    history.push(withSiteId(dashboardSelected(key), siteId));
+  };
+
+  return (
+    <div className="flex items-center gap-1 min-w-0">
+      <Dropdown
+        menu={{ items, onClick: onSelect, selectedKeys: [String(dashboard?.dashboardId)] }}
+        trigger={['click']}
+        disabled={creating}
+      >
+        <Button type="text" className="px-2 flex items-center gap-1 min-w-0">
+          <span className="text-xl md:text-2xl truncate max-w-[16rem]">
+            {dashboard?.name}
+          </span>
+          <ChevronDown size={16} className="shrink-0 opacity-60" />
+        </Button>
+      </Dropdown>
+
+      <Tooltip title={t('Rename')} placement="bottom">
+        <Button type="text" size="small" onClick={onRename} className="opacity-60">
+          {t('Rename')}
+        </Button>
+      </Tooltip>
+    </div>
+  );
+}
+
+export default observer(DashboardSwitcher);

--- a/frontend/app/components/Dashboard/components/DashboardList/seedStarterCards.ts
+++ b/frontend/app/components/Dashboard/components/DashboardList/seedStarterCards.ts
@@ -1,0 +1,69 @@
+import Dashboard from 'App/mstore/types/dashboard';
+import Widget from 'App/mstore/types/widget';
+import { dashboardService, metricService } from 'App/services';
+
+/**
+ * A project that already records sessions has everything needed to fill a dashboard,
+ * so making the user assemble one from an empty grid is busywork. When a dashboard is
+ * *created*, prefill it with a small, useful default set.
+ *
+ * Deliberately runs on creation rather than on view: seeding whenever a dashboard
+ * happens to be empty would fight users who intentionally removed every card.
+ *
+ * Best-effort — if anything fails the dashboard is simply left empty and the normal
+ * card picker takes over.
+ */
+const STARTER_CARDS = [
+  {
+    name: 'Sessions over time',
+    metricType: 'timeseries',
+    metricOf: 'sessionCount',
+    viewType: 'lineChart',
+  },
+  { name: 'Top pages', metricType: 'table', metricOf: 'LOCATION', viewType: 'table' },
+  { name: 'Countries', metricType: 'table', metricOf: 'userCountry', viewType: 'table' },
+];
+
+interface SeedDeps {
+  /** Resolves to the number of sessions in the current period. */
+  countSessions: () => Promise<number>;
+}
+
+export default async function seedStarterCards(
+  dashboard: any,
+  { countSessions }: SeedDeps,
+): Promise<boolean> {
+  try {
+    // Nothing to draw in an empty project — leave the picker in place.
+    const total = await countSessions();
+    if (!total) return false;
+
+    const metricIds: any[] = [];
+    for (const card of STARTER_CARDS) {
+      const widget = new Widget();
+      widget.fromJson({
+        ...card,
+        // fromJson overwrites the model default with undefined when absent, and the
+        // cards API rejects the request without it.
+        metricFormat: 'sessionCount',
+        metricValue: [],
+        series: [{ name: card.name, filter: { filters: [], eventsOrder: 'then' } }],
+      });
+      const saved: any = await metricService.saveMetric(widget);
+      const id = saved?.metricId ?? saved?.metric_id;
+      if (id) metricIds.push(id);
+    }
+
+    if (!metricIds.length) return false;
+    // `dashboardStore.save` resolves the raw API payload rather than a Dashboard
+    // model, and addWidget needs `toJson()`. Wrap it if it isn't one already.
+    const model =
+      typeof dashboard?.toJson === 'function'
+        ? dashboard
+        : new Dashboard().fromJson(dashboard);
+    await dashboardService.addWidget(model, metricIds);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/app/components/Dashboard/components/DashboardMetrics/DashboardMetrics.tsx
+++ b/frontend/app/components/Dashboard/components/DashboardMetrics/DashboardMetrics.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { observer } from 'mobx-react-lite';
+import { useTranslation } from 'react-i18next';
+
+import { useStore } from 'App/mstore';
+import { Loader } from 'UI';
+
+export const ISSUE_ERRORS = 'js_exception';
+export const ISSUE_RAGE = 'click_rage';
+
+interface Props {
+  siteId: string;
+  /** Issue keys currently narrowing the session list, or null for "everything". */
+  activeFilter?: string[] | null;
+  onFilter?: (issues: string[] | null) => void;
+}
+
+interface Stat {
+  key: string;
+  label: string;
+  value: string | number;
+  hint?: string;
+  tone?: 'default' | 'warn';
+  /** null = clear the filter. Every card here is clickable by design. */
+  issues: string[] | null;
+}
+
+export const issueFilter = (names: string[]) => ({
+  value: names,
+  operator: 'is',
+  dataType: 'string',
+  propertyOrder: 'and',
+  filters: [],
+  isEvent: false,
+  name: 'issue',
+  autoCaptured: true,
+  isSegment: false,
+});
+
+const sameFilter = (a?: string[] | null, b?: string[] | null) =>
+  (a ?? []).join(',') === (b ?? []).join(',');
+
+/**
+ * Core metrics for the dashboard. Deliberately not "sessions up 4%" vanity — these
+ * answer two questions: is it recording, and is anything broken. Every card filters
+ * the session list beside it, so the numbers and the sessions stay connected.
+ */
+function DashboardMetrics({ siteId, activeFilter = null, onFilter }: Props) {
+  const { t } = useTranslation();
+  const { dashboardStore, sessionStore } = useStore();
+  const [stats, setStats] = React.useState<Stat[]>([]);
+  const [loading, setLoading] = React.useState(true);
+
+  const { period } = dashboardStore;
+  const range = period?.toTimestamps?.();
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+
+    const base = {
+      sort: 'startTs',
+      order: 'desc',
+      eventsOrder: 'then',
+      page: 1,
+      limit: 1,
+      startTimestamp: range?.startTimestamp,
+      endTimestamp: range?.endTimestamp,
+    };
+    const count = (filters: any[]) =>
+      sessionStore
+        .getSessions({ ...base, filters })
+        .then((r: any) => r?.total ?? 0)
+        .catch(() => 0);
+
+    Promise.all([
+      count([]),
+      count([issueFilter([ISSUE_ERRORS])]),
+      count([issueFilter([ISSUE_RAGE])]),
+      count([issueFilter([ISSUE_ERRORS, ISSUE_RAGE])]),
+    ])
+      .then(([total, errors, rage, attention]) => {
+        if (cancelled) return;
+        setStats([
+          {
+            key: 'sessions',
+            label: t('Sessions recorded'),
+            value: total,
+            hint: total ? t('Recording is working') : t('No sessions captured'),
+            issues: null,
+          },
+          {
+            key: 'attention',
+            label: t('Need attention'),
+            value: attention,
+            hint:
+              total > 0
+                ? `${Math.round((attention / total) * 100)}% ${t('of sessions')}`
+                : undefined,
+            tone: attention > 0 ? 'warn' : 'default',
+            issues: [ISSUE_ERRORS, ISSUE_RAGE],
+          },
+          {
+            key: 'errors',
+            label: t('Sessions with errors'),
+            value: errors,
+            tone: errors > 0 ? 'warn' : 'default',
+            issues: [ISSUE_ERRORS],
+          },
+          {
+            key: 'rage',
+            label: t('Sessions with rage clicks'),
+            value: rage,
+            tone: rage > 0 ? 'warn' : 'default',
+            issues: [ISSUE_RAGE],
+          },
+        ]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [range?.startTimestamp, range?.endTimestamp]);
+
+  return (
+    <Loader loading={loading} style={{ minHeight: 240 }}>
+      <div className="flex flex-col gap-2">
+        {stats.map((s) => {
+          const isActive = sameFilter(activeFilter, s.issues);
+          return (
+            <button
+              key={s.key}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => onFilter?.(isActive ? null : s.issues)}
+              className={[
+                'w-full text-left bg-white rounded-lg border p-3 transition-colors',
+                isActive ? 'border-main' : 'border-gray-light hover:border-main',
+              ].join(' ')}
+            >
+              <div className="text-sm color-gray-medium">{s.label}</div>
+              <div
+                className={[
+                  'text-2xl leading-none mt-1',
+                  s.tone === 'warn' ? 'color-red' : '',
+                ].join(' ')}
+              >
+                {s.value}
+              </div>
+              {s.hint ? (
+                <div className="text-xs color-gray-medium mt-1">{s.hint}</div>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </Loader>
+  );
+}
+
+export default observer(DashboardMetrics);

--- a/frontend/app/components/Dashboard/components/DashboardMetrics/index.ts
+++ b/frontend/app/components/Dashboard/components/DashboardMetrics/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DashboardMetrics';

--- a/frontend/app/components/Dashboard/components/DashboardRouter/DashboardRouter.tsx
+++ b/frontend/app/components/Dashboard/components/DashboardRouter/DashboardRouter.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
+import { observer } from 'mobx-react-lite';
 
+import { useStore } from 'App/mstore';
+import { withSiteId, dashboardSelected } from 'App/routes';
 import { useHistory, useLocation, useParams } from 'App/routing';
+import { Loader } from 'UI';
 
 import Alerts from '../Alerts';
 import CreateAlert from '../Alerts/NewAlert';
@@ -9,6 +13,42 @@ import DashboardView from '../DashboardView';
 import MetricsView from '../MetricsView';
 import WidgetSubDetailsView from '../WidgetSubDetailsView';
 import WidgetView from '../WidgetView';
+
+/**
+ * Landing on /dashboard used to show a list of dashboards, making the dashboard itself
+ * two clicks away. Instead we send the user straight to a dashboard — pinned first,
+ * otherwise the most recent — and only fall back to the list when none exist yet.
+ */
+const DashboardLanding = observer(({ siteId }: { siteId: string }) => {
+  const { dashboardStore } = useStore();
+  const history = useHistory();
+  const { dashboards } = dashboardStore;
+  const [checked, setChecked] = React.useState(false);
+
+  React.useEffect(() => {
+    if (dashboards.length) {
+      setChecked(true);
+      return;
+    }
+    void dashboardStore.fetchList().finally(() => setChecked(true));
+  }, []);
+
+  const target = React.useMemo(() => {
+    if (!dashboards.length) return null;
+    const pinned = dashboards.find((d: any) => d.isPinned);
+    return pinned ?? dashboards[0];
+  }, [dashboards]);
+
+  React.useEffect(() => {
+    if (!target) return;
+    history.replace(
+      withSiteId(dashboardSelected(target.dashboardId), siteId),
+    );
+  }, [target?.dashboardId]);
+
+  if (!checked || target) return <Loader loading className="flex-1" />;
+  return <DashboardsView siteId={siteId} history={history} />;
+});
 
 type RouterParams = {
   siteId?: string;
@@ -45,7 +85,7 @@ function DashboardRouter() {
     if (metricId) return <WidgetView siteId={siteId} {...routeProps} />;
     if (dashboardId)
       return <DashboardView siteId={siteId} dashboardId={dashboardId} />;
-    return <DashboardsView siteId={siteId} history={history} />;
+    return <DashboardLanding siteId={siteId} />;
   }
 
   if (section === 'alerts') {

--- a/frontend/app/components/Dashboard/components/DashboardSessions/DashboardSessions.tsx
+++ b/frontend/app/components/Dashboard/components/DashboardSessions/DashboardSessions.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Button } from 'antd';
+import { ArrowRight } from 'lucide-react';
+import { observer } from 'mobx-react-lite';
+import { useTranslation } from 'react-i18next';
+
+import { useStore } from 'App/mstore';
+import { sessions as sessionsRoute, withSiteId } from 'App/routes';
+import { useHistory } from 'App/routing';
+import { Loader, NoContent } from 'UI';
+
+import { ISSUE_ERRORS, issueFilter } from '../DashboardMetrics/DashboardMetrics';
+
+import AnimatedSVG, { ICONS } from 'Shared/AnimatedSVG/AnimatedSVG';
+import SessionItem from 'Shared/SessionItem';
+
+interface Props {
+  siteId: string;
+  limit?: number;
+  /** Issue keys narrowing the list, e.g. ['js_exception']. Null shows everything. */
+  issue?: string[] | null;
+}
+
+/**
+ * Recent sessions, inline on the dashboard.
+ *
+ * The dashboard previously showed only aggregate cards, so the answer to "which
+ * sessions is this about?" always lived on another screen. Showing them here keeps the
+ * numbers and the sessions they describe on one page.
+ */
+function DashboardSessions({ siteId, limit = 6, issue = null }: Props) {
+  const issueKey = (issue ?? []).join(',');
+  const { t } = useTranslation();
+  const { dashboardStore, sessionStore } = useStore();
+  const history = useHistory();
+
+  // `any` matches how SessionItem is consumed everywhere else in this codebase.
+  const [sessions, setSessions] = React.useState<any[]>([]);
+  const [total, setTotal] = React.useState(0);
+  const [loading, setLoading] = React.useState(true);
+
+  const { period } = dashboardStore;
+  const range = period?.toTimestamps?.();
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    sessionStore
+      .getSessions({
+        filters: issue?.length ? [issueFilter(issue)] : [],
+        sort: 'startTs',
+        order: 'desc',
+        eventsOrder: 'then',
+        page: 1,
+        limit,
+        startTimestamp: range?.startTimestamp,
+        endTimestamp: range?.endTimestamp,
+      })
+      .then((res: { sessions: any[]; total: number }) => {
+        if (cancelled) return;
+        setSessions(res.sessions ?? []);
+        setTotal(res.total ?? 0);
+      })
+      .catch(() => {
+        if (!cancelled) setSessions([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [range?.startTimestamp, range?.endTimestamp, limit, issueKey]);
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-light">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-light">
+        <div className="flex items-baseline gap-2">
+          <h3 className="text-base font-medium">
+            {!issue?.length
+              ? t('Recent sessions')
+              : issue.length > 1
+                ? t('Sessions needing attention')
+                : issue[0] === ISSUE_ERRORS
+                  ? t('Sessions with errors')
+                  : t('Sessions with rage clicks')}
+          </h3>
+          {total > 0 && (
+            <span className="text-sm color-gray-medium">
+              {t('of')} {total}
+            </span>
+          )}
+        </div>
+        <Button
+          type="text"
+          size="small"
+          onClick={() => history.push(withSiteId(sessionsRoute(), siteId))}
+        >
+          <span className="flex items-center gap-1">
+            {t('View all')}
+            <ArrowRight size={14} />
+          </span>
+        </Button>
+      </div>
+
+      <Loader loading={loading} style={{ minHeight: 180 }}>
+        <NoContent
+          show={!sessions.length}
+          title={
+            <div className="flex flex-col items-center justify-center py-8">
+              <AnimatedSVG name={ICONS.NO_RESULTS} size={60} />
+              <div className="mt-3 text-base color-gray-medium">
+                {issue?.length
+                  ? t('No sessions match this filter.')
+                  : t('No sessions in this period.')}
+              </div>
+            </div>
+          }
+        >
+          <div className="divide-y divide-gray-light">
+            {sessions.map((session: any) => (
+              <div key={session.sessionId} className="px-4">
+                <SessionItem session={session} />
+              </div>
+            ))}
+          </div>
+        </NoContent>
+      </Loader>
+    </div>
+  );
+}
+
+export default observer(DashboardSessions);

--- a/frontend/app/components/Dashboard/components/DashboardSessions/index.ts
+++ b/frontend/app/components/Dashboard/components/DashboardSessions/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DashboardSessions';

--- a/frontend/app/components/Dashboard/components/DashboardView/DashboardView.tsx
+++ b/frontend/app/components/Dashboard/components/DashboardView/DashboardView.tsx
@@ -10,6 +10,8 @@ import AlertFormModal from 'App/components/Alerts/AlertFormModal';
 import withPageTitle from 'HOCs/withPageTitle';
 import withReport from 'App/components/hocs/withReport';
 import DashboardHeader from '../DashboardHeader';
+import DashboardMetrics from '../DashboardMetrics';
+import DashboardSessions from '../DashboardSessions';
 import DashboardWidgetGrid from '../DashboardWidgetGrid';
 import { PANEL_SIZES } from 'App/constants/panelSizes';
 
@@ -32,6 +34,9 @@ function DashboardView(props: Props) {
   const dashboard: any = dashboardStore.selectedDashboard;
 
   const queryParams = new URLSearchParams(location.search);
+
+  // Which issue the metric cards are filtering the session list by, if any.
+  const [issue, setIssue] = React.useState<string[] | null>(null);
 
   const trimQuery = () => {
     if (!queryParams.has('modal')) return;
@@ -91,19 +96,42 @@ function DashboardView(props: Props) {
     <Loader loading={loading}>
       <div
         style={{ maxWidth: PANEL_SIZES.maxWidth, margin: 'auto' }}
-        className="rounded-lg shadow-xs overflow-hidden bg-white border"
+        className="flex flex-col gap-4"
       >
-        {/* @ts-ignore */}
-        <DashboardHeader
-          renderReport={props.renderReport}
-          siteId={siteId}
-          dashboardId={dashboardId}
-        />
-        <DashboardWidgetGrid
-          siteId={siteId}
-          dashboardId={dashboardId}
-          id="report"
-        />
+        <div className="rounded-lg shadow-xs bg-white border">
+          {/* @ts-ignore */}
+          <DashboardHeader
+            renderReport={props.renderReport}
+            siteId={siteId}
+            dashboardId={dashboardId}
+          />
+
+          {/*
+            Left: core metrics — is it recording, is anything broken.
+            Right: the sessions themselves, which are what the user actually came for.
+            Clicking a metric filters the list rather than navigating away.
+          */}
+          <div className="grid grid-cols-1 lg:grid-cols-12 gap-4 px-4 pb-4 pt-2">
+            <div className="lg:col-span-4 xl:col-span-3">
+              <DashboardMetrics
+                siteId={siteId}
+                activeFilter={issue}
+                onFilter={setIssue}
+              />
+            </div>
+            <div className="lg:col-span-8 xl:col-span-9">
+              <DashboardSessions siteId={siteId} issue={issue} />
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg shadow-xs bg-white border overflow-hidden">
+          <DashboardWidgetGrid
+            siteId={siteId}
+            dashboardId={dashboardId}
+            id="report"
+          />
+        </div>
       </div>
     </Loader>
   );

--- a/frontend/app/components/Dashboard/components/DashboardWidgetGrid/DashboardWidgetGrid.tsx
+++ b/frontend/app/components/Dashboard/components/DashboardWidgetGrid/DashboardWidgetGrid.tsx
@@ -43,6 +43,7 @@ function DashboardWidgetGrid(props: Props) {
               key={item.widgetId}
               item={item}
               index={index}
+              isHero={index === 0}
               dashboard={dashboard}
               dashboardId={dashboardId}
               siteId={siteId}
@@ -62,7 +63,7 @@ const colSpanMap: { [key: number]: string } = {
   4: 'lg:col-span-4',
 };
 
-function GridItem({ item, index, dashboard, dashboardId, siteId }: any) {
+function GridItem({ item, index, isHero, dashboard, dashboardId, siteId }: any) {
   const { t } = useTranslation();
   const [popoverOpen, setPopoverOpen] = React.useState(false);
   const handleOpenChange = (open: boolean) => {
@@ -74,7 +75,10 @@ function GridItem({ item, index, dashboard, dashboardId, siteId }: any) {
       key={item.widgetId}
       className={cn(
         'col-span-4',
-        colSpanMap[item.config.col] || 'lg:col-span-4',
+        // The first card leads the dashboard, so it spans the full width and the
+        // rest fall in beneath it. Gives the page a focal point instead of a
+        // uniform grid where nothing is more important than anything else.
+        isHero ? 'lg:col-span-4' : colSpanMap[item.config.col] || 'lg:col-span-4',
         'group relative md:p-2 hover:bg-active-blue w-full rounded-xl',
       )}
     >


### PR DESCRIPTION
# ui: make the dashboard useful on first open

## The problem

A project that has recorded sessions already holds everything a dashboard needs. Today it is asked to build one anyway.

Opening Dashboards lands on a list rather than a dashboard, so the dashboard itself is two clicks away even when only one exists. Creating one opens an empty grid and a card picker. Nothing is shown until several cards have been configured by hand, despite the data being there the whole time.

The result is that a new project sees an empty screen at exactly the moment it is trying to decide whether the tracker is working.

## Before and after

| Before | After |
| --- | --- |
| <img width="1546" height="989" alt="before" src="https://github.com/user-attachments/assets/b1d22e5c-b9dd-40f3-988e-ec25453e8cd8" /> | <img width="1543" height="1024" alt="after" src="https://github.com/user-attachments/assets/bd7f9bff-58c6-4577-8241-6a3a267f0e9f" /> |






## What changed

**Open a dashboard directly.** Landing on `/dashboard` now redirects to a dashboard, pinned first and otherwise the most recent. The list is still rendered when no dashboards exist yet, so nothing is lost for a genuinely empty account.

**A switcher in the header.** The title and back button are replaced by a dropdown listing every dashboard, plus an option to create one. Moving between dashboards no longer means leaving the dashboard. Renaming sits beside it and behaves as before.

**Core metrics and recent sessions.** Two panels sit above the card grid. On the left, counts of sessions recorded, sessions needing attention, sessions with errors and sessions with rage clicks. On the right, the most recent sessions.

Each metric filters the session list beside it rather than navigating away, so the number and the sessions behind it stay on one screen.

The metrics are deliberately not volume alone. "Sessions recorded" answers whether the tracker is working, which is the first question a new project has. The rest answer whether anything is broken, which is the question every day after that.

**Starter cards on creation.** A newly created dashboard is prefilled with sessions over time, top pages and countries.

This runs on creation rather than on view. Seeding whenever a dashboard happens to be empty would fight anyone who deliberately removed every card. It is skipped when the project has no sessions, since there would be nothing to draw, and it is best effort throughout: on failure the dashboard is simply left empty and the existing card picker takes over.

**Full width for the first card.** The grid gave every card equal weight, so nothing led. The first card now spans the full row.

## Two bugs found along the way

Both are pre existing and neither is fixed here, since they sit outside the scope of this change. Flagging them because they shaped the implementation.

**`saveMetric` posts to a route that no longer exists.** `DashboardService.saveMetric` posts to `/dashboards/{id}/metrics`, which returns 404. Because the 404 carries no CORS headers, the browser surfaces it as `Failed to fetch` rather than a status code, which makes it awkward to diagnose. Creating a card through `/cards` and attaching it with `addWidget` works, so that is the path used here.

**`Widget.fromJson` drops `metricFormat`.** The model defaults `metricFormat` to `sessionCount`, but `fromJson` assigns `this.metricFormat = json.metricFormat` unconditionally, so any payload without the field overwrites the default with `undefined`. The cards API rejects that with a 400. Passing it explicitly works around it.

**A third, smaller observation.** The sessions list payload reports `errorsCount: 0` and `issueTypes: null` even for sessions the same API will return under an issue filter. That means per session severity cannot be read from the list response, which is why the metric counts here are resolved with filtered queries instead. It is also, as far as I can tell, why `ErrorBars` in the session list never renders: it is given `issueTypes?.length`, which is always null.

## Trade offs worth reviewing

**Extra queries per dashboard load.** The metrics panel issues four session searches. On a large account that is real cost, and I would rather surface it than have it found in review. Happy to cache these, gate them behind a setting, or fold them into a single endpoint if one can be added.

**A screen becomes a redirect.** Accounts with many dashboards lose the list as a landing page. It remains reachable and is still shown when no dashboards exist, but this is a product decision rather than a purely visual one and should be treated as such.

**Duplication with the Sessions tab.** Recent sessions now appear in two places. The intent is different: the Sessions tab is chronological and exhaustive, the dashboard shows a short prioritised view you can filter by issue. If that overlap is unwelcome, the panel is self contained and easy to drop.

## Testing

Verified against a live project with recorded sessions.

* Landing on `/dashboard` opens a dashboard rather than the list, and still shows the list when the account has none.
* Creating a dashboard from the switcher creates and attaches three cards, confirmed both in the UI and in the API response.
* Clicking a metric card filters the session list and updates its heading. Clicking again clears it.
* Checked in light and dark themes.
* `tsc --noEmit` reports the same count as `dev` before these commits, with no new errors in any file touched here.
* No new dependencies.

## Notes

Built on `dev` per `frontend/README.md`. Happy to retarget if `main` is preferred for UI work.

Some of the above touches product decisions rather than only visual ones, so if any part is unwelcome the commits are separable and I am glad to split, reduce or drop pieces.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens the dashboard with useful defaults so new projects see real data on first load. Adds a switcher, metric summaries, and recent sessions to reduce empty states and clicks.

- **New Features**
  - Redirect `/dashboard` to the pinned or most recent dashboard; show the list only if none exist.
  - Add a header switcher to navigate, create, and rename dashboards without leaving the page.
  - Show core metrics and a Recent Sessions panel; clicking a metric filters the sessions in place.
  - Prefill new dashboards with starter cards (sessions over time, top pages, countries) when data is available.
  - Make the first card span the full width for better emphasis.

<sup>Written for commit 6c9975c20d4974ae72ad5348abcdb5699ca00821. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

