### PR TITLE
feat(chalice): fixed projectKey-tenenat validation

### DIFF
--- a/ee/api/auth/auth_project.py
+++ b/ee/api/auth/auth_project.py
@@ -31,7 +31,6 @@ class ProjectAuthorizer:
         elif self.project_identifier == "projectKey":
             current_project = projects.get_by_project_key(project_key=value)
             if current_project is not None \
-                    and request.state.authorizer_identity == "jwt" \
                     and not projects.is_authorized(project_id=current_project["projectId"],
                                                    tenant_id=current_user.tenant_id,
                                                    user_id=user_id):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix `projectKey` tenant validation by removing the `request.state.authorizer_identity == 'jwt'` check so tenant authorization runs for all auth flows. Prevents cross-tenant access when non-JWT identities are used.

<sup>Written for commit 4e45c898287555a75a418e240cad310e49edb79a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

