### PR TITLE
fix(kafka): surface producer fatal state in health check

### DIFF
--- a/ee/backend/pkg/kafka/producer.go
+++ b/ee/backend/pkg/kafka/producer.go
@@ -33,7 +33,6 @@ func NewProducer(messageSizeLimit int, useBatch bool) *Producer {
 		"batch.num.messages":                    1000,
 		"queue.buffering.max.messages":          50000,
 		"queue.buffering.max.kbytes":            131072, // 128 MiB un-acked buffer cap (default 1 GiB)
-		"retries":                               3,
 		"retry.backoff.ms":                      100,
 		"max.in.flight.requests.per.connection": 1,
 		"compression.type":                      env.String("COMPRESSION_TYPE"),
@@ -70,6 +69,10 @@ func (p *Producer) errorHandler() {
 			if ev.TopicPartition.Error != nil {
 				fmt.Printf("Delivery failed: topicPartition: %v, key: %d\n", ev.TopicPartition, decodeKey(ev.Key))
 			}
+		case kafka.Error:
+			if ev.IsFatal() {
+				log.Printf("kafka producer entered fatal state, all produce calls will fail until restart: %v\n", ev)
+			}
 		}
 	}
 }
@@ -82,6 +85,11 @@ func (p *Producer) produceWithRetry(msg *kafka.Message) error {
 		}
 		var kErr kafka.Error
 		if !errors.As(err, &kErr) || kErr.Code() != kafka.ErrQueueFull {
+			if kErr.Code() == kafka.ErrFatal {
+				if fatal := p.producer.GetFatalError(); fatal != nil {
+					return fatal
+				}
+			}
 			return err
 		}
 		time.Sleep(queueFullBackoff)
@@ -105,6 +113,9 @@ func (p *Producer) ProduceToPartition(topic string, partition, key uint64, value
 }
 
 func (p *Producer) Ping(ctx context.Context) error {
+	if err := p.producer.GetFatalError(); err != nil {
+		return err
+	}
 	timeoutMs := 5000
 	if deadline, ok := ctx.Deadline(); ok {
 		if ms := int(time.Until(deadline).Milliseconds()); ms > 0 {

--- a/ee/backend/pkg/kafka/producer.go
+++ b/ee/backend/pkg/kafka/producer.go
@@ -84,12 +84,16 @@ func (p *Producer) produceWithRetry(msg *kafka.Message) error {
 			return nil
 		}
 		var kErr kafka.Error
-		if !errors.As(err, &kErr) || kErr.Code() != kafka.ErrQueueFull {
-			if kErr.Code() == kafka.ErrFatal {
-				if fatal := p.producer.GetFatalError(); fatal != nil {
-					return fatal
-				}
+		if !errors.As(err, &kErr) {
+			return err
+		}
+		if kErr.Code() == kafka.ErrFatal {
+			if fatal := p.producer.GetFatalError(); fatal != nil {
+				return fatal
 			}
+			return err
+		}
+		if kErr.Code() != kafka.ErrQueueFull {
 			return err
 		}
 		time.Sleep(queueFullBackoff)


### PR DESCRIPTION
With enable.idempotence, retries=3 exhaustion during a broker hiccup puts librdkafka into a permanent fatal state: every Produce returns "Local: Fatal error" until restart, while Ping (GetMetadata) still reports healthy, so the http pod keeps serving 500s indefinitely.

Fail Ping via GetFatalError so k8s restarts the pod, log the fatal cause instead of discarding it, and drop the retries cap in favor of the idempotence-safe default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose and act on the Kafka producer fatal state in health checks and produce retries so pods restart quickly after broker hiccups instead of serving 500s.

- **Bug Fixes**
  - `Ping` and `produceWithRetry` fail fast when the producer is fatal by returning `GetFatalError`.
  - Log fatal transitions from `kafka.Error.IsFatal()` for better debugging.
  - Remove manual `retries=3`; rely on the idempotence-safe default.

<sup>Written for commit 7edd4a242ab50d5dcdb62024a9648d58ab500f98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

