### PR TITLE
Updated patch build from main 588bc8de0e4b484acf203286b3d771e2cb92917a

### DIFF
--- a/scripts/helmcharts/openreplay/charts/http/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/http/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.2"
+AppVersion: "v1.27.3"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `http` Helm chart AppVersion from v1.27.2 to v1.27.3 so deployments use the latest patch image. Aligns the chart with the new patch build.

<sup>Written for commit 13a7583c799f59cdce6081b973514b2d4ac1109f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

