### PR TITLE
refactor(chalice): prevent SSRF for webhooks

### DIFF
--- a/api/chalicelib/core/webhook.py
+++ b/api/chalicelib/core/webhook.py
@@ -1,7 +1,12 @@
+import ipaddress
 import logging
+import socket
 from typing import Optional
+from urllib.parse import urlparse, urlunparse
 
 import requests
+from decouple import config
+from requests.adapters import HTTPAdapter
 import schemas
 from chalicelib.utils import pg_client, helper
 from chalicelib.utils.TimeUTC import TimeUTC
@@ -163,16 +168,77 @@ def trigger_batch(data_list):
         if webhooks_map[w["destination"]] is None:
             logger.error(f"!!Error webhook not found: webhook_id={w['destination']}")
         else:
-            __trigger(hook=webhooks_map[w["destination"]], data=w["data"])
+            try:
+                __trigger(hook=webhooks_map[w["destination"]], data=w["data"])
+            except Exception:
+                logger.exception(f"!!Error while triggering webhook_id={w['destination']}")
+
+
+def __get_allowed_hosts():
+    return {h.strip().lower() for h in config("WEBHOOK_ALLOWED_HOSTS", default="").split(",") if h.strip()}
+
+
+def __resolve_public_ip(endpoint):
+    """Validates that the endpoint resolves to public IPs only and returns one of them,
+    so the request can be pinned to it (protects against DNS-rebinding between check and request).
+    Returns None (no validation, no pinning) for hosts listed in WEBHOOK_ALLOWED_HOSTS."""
+    parsed = urlparse(endpoint)
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError(f"webhook endpoint has no valid hostname: {endpoint}")
+    if hostname.lower() in __get_allowed_hosts():
+        return None
+    try:
+        resolved = socket.getaddrinfo(hostname, parsed.port or (443 if parsed.scheme == "https" else 80),
+                                      proto=socket.IPPROTO_TCP)
+    except socket.gaierror as e:
+        raise ValueError(f"webhook endpoint hostname could not be resolved: {hostname}") from e
+    ips = []
+    for family, _, _, _, sockaddr in resolved:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if not ip.is_global:
+            raise ValueError(f"webhook endpoint resolves to a non-public IP address: {hostname} -> {ip}")
+        ips.append(ip)
+    return str(ips[0])
+
+
+class _PinnedHostHTTPSAdapter(HTTPAdapter):
+    """Keeps TLS SNI and certificate validation bound to the original hostname
+    while the connection itself targets a pre-resolved IP."""
+
+    def __init__(self, hostname, **kwargs):
+        self._hostname = hostname
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs["server_hostname"] = self._hostname
+        kwargs["assert_hostname"] = self._hostname
+        super().init_poolmanager(*args, **kwargs)
+
+
+def __post(endpoint, pinned_ip, json_data, headers):
+    if pinned_ip is None:
+        return requests.post(url=endpoint, json=json_data, headers=headers, allow_redirects=False)
+    parsed = urlparse(endpoint)
+    hostname = parsed.hostname
+    ip_host = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
+    netloc = ip_host if parsed.port is None else f"{ip_host}:{parsed.port}"
+    pinned_url = urlunparse(parsed._replace(netloc=netloc))
+    headers = {**headers, "Host": hostname if parsed.port is None else f"{hostname}:{parsed.port}"}
+    with requests.Session() as s:
+        if parsed.scheme == "https":
+            s.mount("https://", _PinnedHostHTTPSAdapter(hostname))
+        return s.post(url=pinned_url, json=json_data, headers=headers, allow_redirects=False)
 
 
 def __trigger(hook, data):
     if hook is not None and hook["type"] == 'webhook':
+        pinned_ip = __resolve_public_ip(hook["endpoint"])
         headers = {}
         if hook["authHeader"] is not None and len(hook["authHeader"]) > 0:
             headers = {"Authorization": hook["authHeader"]}
 
-        r = requests.post(url=hook["endpoint"], json=data, headers=headers)
+        r = __post(endpoint=hook["endpoint"], pinned_ip=pinned_ip, json_data=data, headers=headers)
         if r.status_code != 200:
             logger.error("=======> webhook: something went wrong for:")
             logger.error(hook)

--- a/ee/api/chalicelib/core/webhook.py
+++ b/ee/api/chalicelib/core/webhook.py
@@ -1,8 +1,13 @@
+import ipaddress
 import logging
+import socket
 from typing import Optional
+from urllib.parse import urlparse, urlunparse
 
 import requests
+from decouple import config
 from fastapi import HTTPException, status
+from requests.adapters import HTTPAdapter
 
 import schemas
 from chalicelib.utils import pg_client, helper
@@ -170,16 +175,77 @@ def trigger_batch(data_list):
         if webhooks_map[w["destination"]] is None:
             logging.error(f"!!Error webhook not found: webhook_id={w['destination']}")
         else:
-            __trigger(hook=webhooks_map[w["destination"]], data=w["data"])
+            try:
+                __trigger(hook=webhooks_map[w["destination"]], data=w["data"])
+            except Exception:
+                logging.exception(f"!!Error while triggering webhook_id={w['destination']}")
+
+
+def __get_allowed_hosts():
+    return {h.strip().lower() for h in config("WEBHOOK_ALLOWED_HOSTS", default="").split(",") if h.strip()}
+
+
+def __resolve_public_ip(endpoint):
+    """Validates that the endpoint resolves to public IPs only and returns one of them,
+    so the request can be pinned to it (protects against DNS-rebinding between check and request).
+    Returns None (no validation, no pinning) for hosts listed in WEBHOOK_ALLOWED_HOSTS."""
+    parsed = urlparse(endpoint)
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError(f"webhook endpoint has no valid hostname: {endpoint}")
+    if hostname.lower() in __get_allowed_hosts():
+        return None
+    try:
+        resolved = socket.getaddrinfo(hostname, parsed.port or (443 if parsed.scheme == "https" else 80),
+                                      proto=socket.IPPROTO_TCP)
+    except socket.gaierror as e:
+        raise ValueError(f"webhook endpoint hostname could not be resolved: {hostname}") from e
+    ips = []
+    for family, _, _, _, sockaddr in resolved:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if not ip.is_global:
+            raise ValueError(f"webhook endpoint resolves to a non-public IP address: {hostname} -> {ip}")
+        ips.append(ip)
+    return str(ips[0])
+
+
+class _PinnedHostHTTPSAdapter(HTTPAdapter):
+    """Keeps TLS SNI and certificate validation bound to the original hostname
+    while the connection itself targets a pre-resolved IP."""
+
+    def __init__(self, hostname, **kwargs):
+        self._hostname = hostname
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs["server_hostname"] = self._hostname
+        kwargs["assert_hostname"] = self._hostname
+        super().init_poolmanager(*args, **kwargs)
+
+
+def __post(endpoint, pinned_ip, json_data, headers):
+    if pinned_ip is None:
+        return requests.post(url=endpoint, json=json_data, headers=headers, allow_redirects=False)
+    parsed = urlparse(endpoint)
+    hostname = parsed.hostname
+    ip_host = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
+    netloc = ip_host if parsed.port is None else f"{ip_host}:{parsed.port}"
+    pinned_url = urlunparse(parsed._replace(netloc=netloc))
+    headers = {**headers, "Host": hostname if parsed.port is None else f"{hostname}:{parsed.port}"}
+    with requests.Session() as s:
+        if parsed.scheme == "https":
+            s.mount("https://", _PinnedHostHTTPSAdapter(hostname))
+        return s.post(url=pinned_url, json=json_data, headers=headers, allow_redirects=False)
 
 
 def __trigger(hook, data):
     if hook is not None and hook["type"] == 'webhook':
+        pinned_ip = __resolve_public_ip(hook["endpoint"])
         headers = {}
         if hook["authHeader"] is not None and len(hook["authHeader"]) > 0:
             headers = {"Authorization": hook["authHeader"]}
 
-        r = requests.post(url=hook["endpoint"], json=data, headers=headers)
+        r = __post(endpoint=hook["endpoint"], pinned_ip=pinned_ip, json_data=data, headers=headers)
         if r.status_code != 200:
             logging.error("=======> webhook: something went wrong for:")
             logging.error(hook)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened webhook delivery to prevent SSRF. We validate endpoints resolve to public IPs, pin the request to the resolved IP with SNI/Host preserved, block redirects, and add a `WEBHOOK_ALLOWED_HOSTS` allowlist.

- **Refactors**
  - Validate hostnames resolve only to public IPs; reject private/local addresses.
  - Add `WEBHOOK_ALLOWED_HOSTS` (via `decouple`) to bypass IP validation for trusted hosts.
  - Pin POSTs to the resolved IP and set the `Host` header; use a custom `_PinnedHostHTTPSAdapter` (`requests.adapters.HTTPAdapter`) to keep TLS SNI and cert checks bound to the original hostname.
  - Send webhook requests with `allow_redirects=False`.
  - Wrap batch triggers in try/except with error logging.

<sup>Written for commit 625a489987ad5c2035c09d6ca4361dde841f6c60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

