### PR TITLE
refactor(chalice): prevent SSRF

### DIFF
--- a/api/chalicelib/core/collaborations/collaboration_msteams.py
+++ b/api/chalicelib/core/collaborations/collaboration_msteams.py
@@ -1,12 +1,12 @@
 import logging
 
-import requests
 from decouple import config
 from fastapi import HTTPException, status
 
 import schemas
 from chalicelib.core import webhook
 from chalicelib.core.collaborations.collaboration_base import BaseCollaboration
+from chalicelib.utils import ssrf
 from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
@@ -18,7 +18,11 @@ class MSTeams(BaseCollaboration):
         if webhook.exists_by_name(tenant_id=tenant_id, name=data.name, exclude_id=None,
                                   webhook_type=schemas.WebhookType.MSTEAMS):
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"name already exists.")
-        if cls.say_hello(data.url):
+        try:
+            hello = cls.say_hello(data.url)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        if hello:
             return webhook.add(tenant_id=tenant_id,
                                endpoint=data.url.unicode_string(),
                                webhook_type=schemas.WebhookType.MSTEAMS,
@@ -28,9 +32,9 @@ class MSTeams(BaseCollaboration):
     @classmethod
     def say_hello(cls, url):
         try:
-            r = requests.post(
-                url=url,
-                json={
+            r = ssrf.post_json(
+                endpoint=url,
+                json_data={
                     "@type": "MessageCard",
                     "@context": "https://schema.org/extensions",
                     "summary": "Welcome to OpenReplay",
@@ -41,6 +45,8 @@ class MSTeams(BaseCollaboration):
                 logger.warning("MSTeams integration failed")
                 logger.warning(sanitize(r.text))
                 return False
+        except ValueError:
+            raise
         except Exception as e:
             logger.warning("!!! MSTeams integration failed")
             logger.exception(e)
@@ -53,9 +59,9 @@ class MSTeams(BaseCollaboration):
         if integration is None:
             return {"errors": ["msteams integration not found"]}
         try:
-            r = requests.post(
-                url=integration["endpoint"],
-                json=body,
+            r = ssrf.post_json(
+                endpoint=integration["endpoint"],
+                json_data=body,
                 timeout=5)
             if r.status_code != 200:
                 logger.warning(f"!! issue sending msteams raw; webhookId:{webhook_id} code:{r.status_code}")
@@ -81,13 +87,13 @@ class MSTeams(BaseCollaboration):
             for j in range(1, len(part), 2):
                 part.insert(j, {"text": "***"})
 
-            r = requests.post(url=integration["endpoint"],
-                              json={
-                                  "@type": "MessageCard",
-                                  "@context": "http://schema.org/extensions",
-                                  "summary": part[0]["activityTitle"],
-                                  "sections": part
-                              })
+            r = ssrf.post_json(endpoint=integration["endpoint"],
+                               json_data={
+                                   "@type": "MessageCard",
+                                   "@context": "http://schema.org/extensions",
+                                   "summary": part[0]["activityTitle"],
+                                   "sections": part
+                               })
             if r.status_code != 200:
                 logger.warning("!!!! something went wrong")
                 logger.warning(sanitize(r.text))
@@ -99,9 +105,9 @@ class MSTeams(BaseCollaboration):
         integration = cls.get_integration(tenant_id=tenant_id, integration_id=integration_id)
         if integration is None:
             return {"errors": ["Microsoft Teams integration not found"]}
-        r = requests.post(
-            url=integration["endpoint"],
-            json={
+        r = ssrf.post_json(
+            endpoint=integration["endpoint"],
+            json_data={
                 "@type": "MessageCard",
                 "@context": "http://schema.org/extensions",
                 "sections": [attachement],

--- a/api/chalicelib/core/collaborations/collaboration_slack.py
+++ b/api/chalicelib/core/collaborations/collaboration_slack.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-import requests
 from decouple import config
 from fastapi import HTTPException, status
 
@@ -9,6 +8,7 @@ from chalicelib.core import webhook
 from chalicelib.core.collaborations.collaboration_base import BaseCollaboration
 import logging
 
+from chalicelib.utils import ssrf
 from chalicelib.utils.log import sanitize
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,11 @@ class Slack(BaseCollaboration):
         if webhook.exists_by_name(tenant_id=tenant_id, name=data.name, exclude_id=None,
                                   webhook_type=schemas.WebhookType.SLACK):
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"name already exists.")
-        if cls.say_hello(data.url):
+        try:
+            hello = cls.say_hello(data.url)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        if hello:
             return webhook.add(tenant_id=tenant_id,
                                endpoint=data.url.unicode_string(),
                                webhook_type=schemas.WebhookType.SLACK,
@@ -28,9 +32,9 @@ class Slack(BaseCollaboration):
 
     @classmethod
     def say_hello(cls, url):
-        r = requests.post(
-            url=url,
-            json={
+        r = ssrf.post_json(
+            endpoint=url,
+            json_data={
                 "attachments": [
                     {
                         "text": "Welcome to OpenReplay",
@@ -50,9 +54,9 @@ class Slack(BaseCollaboration):
         if integration is None:
             return {"errors": ["slack integration not found"]}
         try:
-            r = requests.post(
-                url=integration["endpoint"],
-                json=body,
+            r = ssrf.post_json(
+                endpoint=integration["endpoint"],
+                json_data=body,
                 timeout=5)
             if r.status_code != 200:
                 logger.warning(f"!! issue sending slack raw; webhookId:{webhook_id} code:{r.status_code}")
@@ -74,9 +78,9 @@ class Slack(BaseCollaboration):
             return {"errors": ["slack integration not found"]}
         logger.debug(f"====> sending slack batch notification: {len(attachments)}")
         for i in range(0, len(attachments), 100):
-            r = requests.post(
-                url=integration["endpoint"],
-                json={"attachments": attachments[i:i + 100]})
+            r = ssrf.post_json(
+                endpoint=integration["endpoint"],
+                json_data={"attachments": attachments[i:i + 100]})
             if r.status_code != 200:
                 logger.warning(f"!!!! something went wrong while sending slack batch; webhookId:{webhook_id} code:{r.status_code}")
                 logger.warning(sanitize(r.text))
@@ -89,7 +93,7 @@ class Slack(BaseCollaboration):
         if integration is None:
             return {"errors": ["slack integration not found"]}
         attachement["ts"] = datetime.now().timestamp()
-        r = requests.post(url=integration["endpoint"], json={"attachments": [attachement], **extra})
+        r = ssrf.post_json(endpoint=integration["endpoint"], json_data={"attachments": [attachement], **extra})
         return r.text
 
     @classmethod

--- a/api/chalicelib/core/webhook.py
+++ b/api/chalicelib/core/webhook.py
@@ -1,14 +1,8 @@
-import ipaddress
 import logging
-import socket
 from typing import Optional
-from urllib.parse import urlparse, urlunparse
 
-import requests
-from decouple import config
-from requests.adapters import HTTPAdapter
 import schemas
-from chalicelib.utils import pg_client, helper
+from chalicelib.utils import pg_client, helper, ssrf
 from chalicelib.utils.TimeUTC import TimeUTC
 from chalicelib.utils.log import sanitize
 from fastapi import HTTPException, status
@@ -174,71 +168,13 @@ def trigger_batch(data_list):
                 logger.exception(f"!!Error while triggering webhook_id={w['destination']}")
 
 
-def __get_allowed_hosts():
-    return {h.strip().lower() for h in config("WEBHOOK_ALLOWED_HOSTS", default="").split(",") if h.strip()}
-
-
-def __resolve_public_ip(endpoint):
-    """Validates that the endpoint resolves to public IPs only and returns one of them,
-    so the request can be pinned to it (protects against DNS-rebinding between check and request).
-    Returns None (no validation, no pinning) for hosts listed in WEBHOOK_ALLOWED_HOSTS."""
-    parsed = urlparse(endpoint)
-    hostname = parsed.hostname
-    if not hostname:
-        raise ValueError(f"webhook endpoint has no valid hostname: {endpoint}")
-    if hostname.lower() in __get_allowed_hosts():
-        return None
-    try:
-        resolved = socket.getaddrinfo(hostname, parsed.port or (443 if parsed.scheme == "https" else 80),
-                                      proto=socket.IPPROTO_TCP)
-    except socket.gaierror as e:
-        raise ValueError(f"webhook endpoint hostname could not be resolved: {hostname}") from e
-    ips = []
-    for family, _, _, _, sockaddr in resolved:
-        ip = ipaddress.ip_address(sockaddr[0])
-        if not ip.is_global:
-            raise ValueError(f"webhook endpoint resolves to a non-public IP address: {hostname} -> {ip}")
-        ips.append(ip)
-    return str(ips[0])
-
-
-class _PinnedHostHTTPSAdapter(HTTPAdapter):
-    """Keeps TLS SNI and certificate validation bound to the original hostname
-    while the connection itself targets a pre-resolved IP."""
-
-    def __init__(self, hostname, **kwargs):
-        self._hostname = hostname
-        super().__init__(**kwargs)
-
-    def init_poolmanager(self, *args, **kwargs):
-        kwargs["server_hostname"] = self._hostname
-        kwargs["assert_hostname"] = self._hostname
-        super().init_poolmanager(*args, **kwargs)
-
-
-def __post(endpoint, pinned_ip, json_data, headers):
-    if pinned_ip is None:
-        return requests.post(url=endpoint, json=json_data, headers=headers, allow_redirects=False)
-    parsed = urlparse(endpoint)
-    hostname = parsed.hostname
-    ip_host = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
-    netloc = ip_host if parsed.port is None else f"{ip_host}:{parsed.port}"
-    pinned_url = urlunparse(parsed._replace(netloc=netloc))
-    headers = {**headers, "Host": hostname if parsed.port is None else f"{hostname}:{parsed.port}"}
-    with requests.Session() as s:
-        if parsed.scheme == "https":
-            s.mount("https://", _PinnedHostHTTPSAdapter(hostname))
-        return s.post(url=pinned_url, json=json_data, headers=headers, allow_redirects=False)
-
-
 def __trigger(hook, data):
     if hook is not None and hook["type"] == 'webhook':
-        pinned_ip = __resolve_public_ip(hook["endpoint"])
         headers = {}
         if hook["authHeader"] is not None and len(hook["authHeader"]) > 0:
             headers = {"Authorization": hook["authHeader"]}
 
-        r = __post(endpoint=hook["endpoint"], pinned_ip=pinned_ip, json_data=data, headers=headers)
+        r = ssrf.post_json(endpoint=hook["endpoint"], json_data=data, headers=headers)
         if r.status_code != 200:
             logger.error("=======> webhook: something went wrong for:")
             logger.error(hook)

--- a/api/chalicelib/utils/ssrf.py
+++ b/api/chalicelib/utils/ssrf.py
@@ -1,0 +1,72 @@
+import ipaddress
+import socket
+from urllib.parse import urlparse, urlunparse
+
+import requests
+from decouple import config
+from requests.adapters import HTTPAdapter
+
+
+def get_allowed_hosts():
+    return {h.strip().lower() for h in config("WEBHOOK_ALLOWED_HOSTS", default="").split(",") if h.strip()}
+
+
+def resolve_public_ip(endpoint):
+    """Validates that the endpoint resolves to public IPs only and returns one of them,
+    so the request can be pinned to it (protects against DNS-rebinding between check and request).
+    Returns None (no validation, no pinning) for hosts listed in WEBHOOK_ALLOWED_HOSTS."""
+    parsed = urlparse(endpoint)
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError(f"endpoint has no valid hostname: {endpoint}")
+    if hostname.lower() in get_allowed_hosts():
+        return None
+    try:
+        resolved = socket.getaddrinfo(hostname, parsed.port or (443 if parsed.scheme == "https" else 80),
+                                      proto=socket.IPPROTO_TCP)
+    except socket.gaierror as e:
+        raise ValueError(f"endpoint hostname could not be resolved: {hostname}") from e
+    ips = []
+    for family, _, _, _, sockaddr in resolved:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if not ip.is_global:
+            raise ValueError(f"endpoint resolves to a non-public IP address: {hostname} -> {ip}")
+        ips.append(ip)
+    return str(ips[0])
+
+
+class PinnedHostHTTPSAdapter(HTTPAdapter):
+    """Keeps TLS SNI and certificate validation bound to the original hostname
+    while the connection itself targets a pre-resolved IP."""
+
+    def __init__(self, hostname, **kwargs):
+        self._hostname = hostname
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs["server_hostname"] = self._hostname
+        kwargs["assert_hostname"] = self._hostname
+        super().init_poolmanager(*args, **kwargs)
+
+
+def post_json(endpoint, json_data, headers=None, timeout=None):
+    """POSTs JSON to an endpoint after validating that it targets a public IP (SSRF guard).
+    The connection is pinned to the validated IP and redirects are not followed.
+    Raises ValueError if the endpoint is non-public and not in WEBHOOK_ALLOWED_HOSTS."""
+    endpoint = str(endpoint)
+    headers = headers or {}
+    pinned_ip = resolve_public_ip(endpoint)
+    if pinned_ip is None:
+        return requests.post(url=endpoint, json=json_data, headers=headers, timeout=timeout,
+                             allow_redirects=False)
+    parsed = urlparse(endpoint)
+    hostname = parsed.hostname
+    ip_host = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
+    netloc = ip_host if parsed.port is None else f"{ip_host}:{parsed.port}"
+    pinned_url = urlunparse(parsed._replace(netloc=netloc))
+    headers = {**headers, "Host": hostname if parsed.port is None else f"{hostname}:{parsed.port}"}
+    with requests.Session() as s:
+        if parsed.scheme == "https":
+            s.mount("https://", PinnedHostHTTPSAdapter(hostname))
+        return s.post(url=pinned_url, json=json_data, headers=headers, timeout=timeout,
+                      allow_redirects=False)

--- a/ee/api/chalicelib/core/webhook.py
+++ b/ee/api/chalicelib/core/webhook.py
@@ -1,16 +1,10 @@
-import ipaddress
 import logging
-import socket
 from typing import Optional
-from urllib.parse import urlparse, urlunparse
 
-import requests
-from decouple import config
 from fastapi import HTTPException, status
-from requests.adapters import HTTPAdapter
 
 import schemas
-from chalicelib.utils import pg_client, helper
+from chalicelib.utils import pg_client, helper, ssrf
 from chalicelib.utils.TimeUTC import TimeUTC
 from chalicelib.utils.log import sanitize
 
@@ -181,71 +175,13 @@ def trigger_batch(data_list):
                 logging.exception(f"!!Error while triggering webhook_id={w['destination']}")
 
 
-def __get_allowed_hosts():
-    return {h.strip().lower() for h in config("WEBHOOK_ALLOWED_HOSTS", default="").split(",") if h.strip()}
-
-
-def __resolve_public_ip(endpoint):
-    """Validates that the endpoint resolves to public IPs only and returns one of them,
-    so the request can be pinned to it (protects against DNS-rebinding between check and request).
-    Returns None (no validation, no pinning) for hosts listed in WEBHOOK_ALLOWED_HOSTS."""
-    parsed = urlparse(endpoint)
-    hostname = parsed.hostname
-    if not hostname:
-        raise ValueError(f"webhook endpoint has no valid hostname: {endpoint}")
-    if hostname.lower() in __get_allowed_hosts():
-        return None
-    try:
-        resolved = socket.getaddrinfo(hostname, parsed.port or (443 if parsed.scheme == "https" else 80),
-                                      proto=socket.IPPROTO_TCP)
-    except socket.gaierror as e:
-        raise ValueError(f"webhook endpoint hostname could not be resolved: {hostname}") from e
-    ips = []
-    for family, _, _, _, sockaddr in resolved:
-        ip = ipaddress.ip_address(sockaddr[0])
-        if not ip.is_global:
-            raise ValueError(f"webhook endpoint resolves to a non-public IP address: {hostname} -> {ip}")
-        ips.append(ip)
-    return str(ips[0])
-
-
-class _PinnedHostHTTPSAdapter(HTTPAdapter):
-    """Keeps TLS SNI and certificate validation bound to the original hostname
-    while the connection itself targets a pre-resolved IP."""
-
-    def __init__(self, hostname, **kwargs):
-        self._hostname = hostname
-        super().__init__(**kwargs)
-
-    def init_poolmanager(self, *args, **kwargs):
-        kwargs["server_hostname"] = self._hostname
-        kwargs["assert_hostname"] = self._hostname
-        super().init_poolmanager(*args, **kwargs)
-
-
-def __post(endpoint, pinned_ip, json_data, headers):
-    if pinned_ip is None:
-        return requests.post(url=endpoint, json=json_data, headers=headers, allow_redirects=False)
-    parsed = urlparse(endpoint)
-    hostname = parsed.hostname
-    ip_host = f"[{pinned_ip}]" if ":" in pinned_ip else pinned_ip
-    netloc = ip_host if parsed.port is None else f"{ip_host}:{parsed.port}"
-    pinned_url = urlunparse(parsed._replace(netloc=netloc))
-    headers = {**headers, "Host": hostname if parsed.port is None else f"{hostname}:{parsed.port}"}
-    with requests.Session() as s:
-        if parsed.scheme == "https":
-            s.mount("https://", _PinnedHostHTTPSAdapter(hostname))
-        return s.post(url=pinned_url, json=json_data, headers=headers, allow_redirects=False)
-
-
 def __trigger(hook, data):
     if hook is not None and hook["type"] == 'webhook':
-        pinned_ip = __resolve_public_ip(hook["endpoint"])
         headers = {}
         if hook["authHeader"] is not None and len(hook["authHeader"]) > 0:
             headers = {"Authorization": hook["authHeader"]}
 
-        r = __post(endpoint=hook["endpoint"], pinned_ip=pinned_ip, json_data=data, headers=headers)
+        r = ssrf.post_json(endpoint=hook["endpoint"], json_data=data, headers=headers)
         if r.status_code != 200:
             logging.error("=======> webhook: something went wrong for:")
             logging.error(hook)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened outgoing webhooks against SSRF by validating targets, pinning requests to resolved public IPs, and blocking redirects. Slack and Microsoft Teams setup now fails fast with a clear 400 if the URL is unsafe.

- **Refactors**
  - Added `chalicelib.utils.ssrf` with `post_json` (public-IP validation, DNS pinning, TLS SNI preservation, `Host` header, no redirects).
  - Replaced direct `requests.post` calls in Slack/MSTeams collaborations and CE/EE webhook triggers with `ssrf.post_json`.
  - Centralized SSRF logic; removed duplicated helpers from `core/webhook.py`.
  - Setup flows now surface validation errors as HTTP 400 with a helpful message.

- **Migration**
  - No action required. If you need non-public targets, add hostnames to `WEBHOOK_ALLOWED_HOSTS`.

<sup>Written for commit 1e4b5d67b551ebe0e615935861c604a214f3e3fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

