### PR TITLE
refactor(chalice): refactored property name validation

### DIFF
--- a/api/schemas/schemas.py
+++ b/api/schemas/schemas.py
@@ -19,6 +19,7 @@ from .transformers_validators import (
     NAME_PATTERN,
     check_account_name,
     check_alphanumeric,
+    check_property_name,
     check_regex,
     force_is_event,
     int_to_string,
@@ -654,6 +655,9 @@ class PropertyFilterSchema(BaseModel):
     def transform_name(self):
         if isinstance(self.name, Enum):
             self.name = self.name.value
+        # name is interpolated into ClickHouse SQL as a column identifier,
+        # so restrict it to a safe character set to prevent SQL injection.
+        check_property_name(self.name)
         return self
 
     @model_validator(mode="after")

--- a/api/schemas/transformers_validators.py
+++ b/api/schemas/transformers_validators.py
@@ -7,6 +7,11 @@ from .overrides import Enum
 
 NAME_PATTERN = r"^[a-z,A-Z,0-9,\-,é,è,à,ç, ,|,&,\/,\\,_,.,#,']*$"
 
+# Property/column names are interpolated into ClickHouse SQL as identifiers, so
+# they must be restricted to a safe character set (no back-ticks, quotes, parens,
+# etc.) to prevent SQL injection.
+PROPERTY_NAME_PATTERN = r"^[\w$.\- ]+$"
+
 
 def transform_email(email: str) -> str:
     return email.lower().strip() if isinstance(email, str) else email
@@ -65,6 +70,16 @@ def check_account_name(v: str, info: ValidationInfo) -> str:
         is_valid = re.match(pattern, v, re.UNICODE)
         assert is_valid, (
             f"{info.field_name} contains invalid characters. Only letters, numbers, spaces, hyphens, apostrophes, and periods are allowed"
+        )
+    return v
+
+
+def check_property_name(v: str, info: ValidationInfo = None) -> str:
+    if isinstance(v, str):
+        field_name = getattr(info, "field_name", None) or "name"
+        assert re.match(PROPERTY_NAME_PATTERN, v, re.UNICODE), (
+            f"{field_name} contains invalid characters. Only letters, numbers, "
+            "spaces, and the characters $ . - _ are allowed"
         )
     return v
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds strict validation for property/column names used in ClickHouse queries. This blocks unsafe characters and prevents SQL injection via column identifiers.

- **Bug Fixes**
  - Added `check_property_name` using `PROPERTY_NAME_PATTERN` to allow only letters, numbers, spaces, and `$ . - _`.
  - Enforced validation in `transform_name()` after enum normalization.

<sup>Written for commit 154a63a3eebf829e59e8210f39d270fa7889b697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

