### PR TITLE
New assets management

### DIFF
--- a/backend/cmd/assets/main.go
+++ b/backend/cmd/assets/main.go
@@ -11,6 +11,7 @@ import (
 
 	"openreplay/backend/internal/assets"
 	"openreplay/backend/internal/assets/cacher"
+	"openreplay/backend/internal/assets/resolver"
 	config "openreplay/backend/internal/config/assets"
 	"openreplay/backend/internal/sink/assetscache"
 	"openreplay/backend/pkg/health"
@@ -42,7 +43,24 @@ func main() {
 		return producer.Ping(ctx)
 	})
 
-	rewriter, err := urlAssets.NewRewriter(cfg.AssetsOrigin)
+	var urlResolver *resolver.Resolver
+	var rewriterResolver urlAssets.Resolver
+	if cfg.KeyScheme == urlAssets.KeySchemeHash {
+		var err error
+		urlResolver, err = resolver.New(log, cfg.ConnectionURL, assetMetrics.RecordAssetResolve)
+		if err != nil {
+			log.Fatal(ctx, "can't init assets resolver: %s", err)
+		}
+		defer urlResolver.Close()
+		rewriterResolver = urlResolver
+		if cfg.ConnectionURL != "" {
+			h.Register("resolver", func(ctx context.Context) error {
+				return urlResolver.Ping(ctx)
+			})
+		}
+	}
+
+	rewriter, err := urlAssets.NewRewriterWithScheme(cfg.AssetsOrigin, cfg.KeyScheme, rewriterResolver)
 	if err != nil {
 		log.Fatal(ctx, "can't init rewriter: %s", err)
 	}
@@ -53,7 +71,7 @@ func main() {
 	if err != nil {
 		log.Fatal(ctx, "can't init object storage: %s", err)
 	}
-	cacher, err := cacher.NewCacher(log, cfg, objStore, assetMetrics)
+	cacher, err := cacher.NewCacher(log, cfg, objStore, assetMetrics, urlResolver)
 	if err != nil {
 		log.Fatal(ctx, "can't init cacher: %s", err)
 	}

--- a/backend/cmd/assets/main.go
+++ b/backend/cmd/assets/main.go
@@ -140,7 +140,6 @@ func main() {
 			}
 		case *messages.AssetCache:
 			cacher.CacheURL(m.SessionID(), m.URL)
-			assetMetrics.IncreaseProcessesSessions()
 		case *messages.JSException:
 			sourceList, err := assets.ExtractJSExceptionSources(&m.Payload)
 			if err != nil {
@@ -198,7 +197,9 @@ func main() {
 		default:
 			if !cacher.CanCache() {
 				// TODO: replace with a signal from the pool when a slot frees up.
+				pauseStart := time.Now()
 				time.Sleep(time.Millisecond)
+				assetMetrics.IncreaseConsumePausedTime(time.Since(pauseStart).Seconds())
 				continue
 			}
 			if err := msgConsumer.ConsumeNext(); err != nil {

--- a/backend/cmd/ender/main.go
+++ b/backend/cmd/ender/main.go
@@ -55,7 +55,7 @@ func main() {
 	})
 
 	projManager := projects.New(log, pgConn, redisClient, dbMetric)
-	sessManager := sessions.New(log, pgConn, projManager, redisClient, dbMetric, sessions.DoNotIgnoreInactiveProjects)
+	sessManager := sessions.New(log, pgConn, projManager, redisClient, dbMetric, sessions.IgnoreInactiveProjects)
 
 	sessionEndGenerator, err := ender.New(log, enderMetric, ender.EVENTS_SESSION_END_TIMEOUT, cfg.PartitionsNumber)
 	if err != nil {

--- a/backend/cmd/sink/main.go
+++ b/backend/cmd/sink/main.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 	"time"
 
+	"openreplay/backend/internal/assets/resolver"
 	config "openreplay/backend/internal/config/sink"
 	"openreplay/backend/internal/sink/assetscache"
 	"openreplay/backend/internal/sink/sessionwriter"
@@ -43,7 +44,17 @@ func main() {
 		return producer.Ping(ctx)
 	})
 
-	rewriter, err := assets.NewRewriter(cfg.AssetsOrigin)
+	var rewriterResolver assets.Resolver
+	if cfg.KeyScheme == assets.KeySchemeHash {
+		urlResolver, err := resolver.New(log, cfg.ConnectionURL, nil)
+		if err != nil {
+			log.Fatal(ctx, "can't init assets resolver: %s", err)
+		}
+		defer urlResolver.Close()
+		rewriterResolver = urlResolver
+	}
+
+	rewriter, err := assets.NewRewriterWithScheme(cfg.AssetsOrigin, cfg.KeyScheme, rewriterResolver)
 	if err != nil {
 		log.Fatal(ctx, "can't init rewriter: %s", err)
 	}

--- a/backend/cmd/sink/main.go
+++ b/backend/cmd/sink/main.go
@@ -78,7 +78,7 @@ func main() {
 	})
 
 	projManager := projects.New(log, pgConn, redisClient, dbMetric)
-	sessManager := sessions.New(log, pgConn, projManager, redisClient, dbMetric, sessions.DoNotIgnoreInactiveProjects)
+	sessManager := sessions.New(log, pgConn, projManager, redisClient, dbMetric, sessions.IgnoreInactiveProjects)
 
 	filePool := sessionwriter.NewFilePool(log, int(cfg.FsUlimit), cfg.FileBuffer, cfg.MaxFileSize, cfg.SyncWorkers)
 	mobWriter := sessionwriter.NewMobWriter(log, sessManager, filePool, cfg.FsDir, cfg.FileSplitTime)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/btcsuite/btcutil v1.0.2
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/confluentinc/confluent-kafka-go/v2 v2.14.1
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/elastic/go-elasticsearch/v9 v9.3.2
@@ -37,6 +38,7 @@ require (
 	github.com/ua-parser/uap-go v0.0.0-20251207011819-db9adb27a0b8
 	go.uber.org/zap v1.27.1
 	golang.org/x/net v0.55.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -45,7 +47,6 @@ require (
 	github.com/DataDog/zstd v1.5.7 // indirect
 	github.com/andybalholm/brotli v1.2.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.11.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
@@ -89,5 +90,4 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -156,8 +156,6 @@ github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 h1:XBBHcIb256gUJ
 github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203/go.mod h1:E1jcSv8FaEny+OP/5k9UxZVw9YFWGj7eI4KR/iOBqCg=
 github.com/elastic/elastic-transport-go/v8 v8.11.0 h1:taYmqC2M6+fZt/+W+ENYh/W5L9+KrlJGOSbEJs8egWc=
 github.com/elastic/elastic-transport-go/v8 v8.11.0/go.mod h1:DZQ0szCNywc9F+C9l/Kkd4n69SvJVj0I3yK1Of7s3l8=
-github.com/elastic/go-elasticsearch/v9 v9.3.1 h1:v5A9uFw0nLFA0luD3xAqliBXbscfuhch409HIinfhKY=
-github.com/elastic/go-elasticsearch/v9 v9.3.1/go.mod h1:B5u4H2jo2/v0+PrgbmIUdEyHdenFyavWtjciAFl7TA0=
 github.com/elastic/go-elasticsearch/v9 v9.3.2 h1:nvtvfN/Gsp/rzUPz/9yILwDAsYJ3s5L0VmhR16zPKCA=
 github.com/elastic/go-elasticsearch/v9 v9.3.2/go.mod h1:ubKUMJCJbX5V/gW5MIn2NQZyaEZ61ubXwJmD5UMNrM8=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
@@ -620,8 +618,6 @@ golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.20.0/go.mod h1:Xwo95rrVNIoSMx9wa1JroENMToLWn3RNVrTBpLHgZPQ=
-golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
-golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 h1:hNQpMuAJe5CtcUqCXaWga3FHu+kQvCqcsoVaQgSV60o=
@@ -641,8 +637,6 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
-golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
-golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
@@ -671,8 +665,6 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -681,9 +673,8 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
 golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
-golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
-golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -693,8 +684,6 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
-golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
-golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"openreplay/backend/internal/assets/resolver"
 	config "openreplay/backend/internal/config/assets"
 	"openreplay/backend/pkg/logger"
 	metrics "openreplay/backend/pkg/metrics/assets"
@@ -47,13 +48,15 @@ type cacher struct {
 	workers        *WorkerPool
 	scheduler      *scheduler
 	hosts          *hostLimiter
+	hashKeys       bool
+	resolver       *resolver.Resolver
 }
 
 func (c *cacher) CanCache() bool {
 	return c.workers.CanAddTask()
 }
 
-func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.ObjectStorage, metrics metrics.Assets) (*cacher, error) {
+func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.ObjectStorage, metrics metrics.Assets, urlResolver *resolver.Resolver) (*cacher, error) {
 	switch {
 	case cfg == nil:
 		return nil, errors.New("config is nil")
@@ -61,7 +64,11 @@ func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.Object
 		return nil, errors.New("object storage is nil")
 	}
 
-	rewriter, err := assets.NewRewriter(cfg.AssetsOrigin)
+	var rewriterResolver assets.Resolver
+	if urlResolver != nil {
+		rewriterResolver = urlResolver
+	}
+	rewriter, err := assets.NewRewriterWithScheme(cfg.AssetsOrigin, cfg.KeyScheme, rewriterResolver)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't create rewriter")
 	}
@@ -125,6 +132,8 @@ func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.Object
 		requestHeaders: cfg.AssetsRequestHeaders,
 		metrics:        metrics,
 		hosts:          newHostLimiter(cfg.AssetsPerHostLimit),
+		hashKeys:       cfg.KeyScheme == assets.KeySchemeHash,
+		resolver:       urlResolver,
 	}
 	c.workers = NewPool(cfg.AssetsWorkerCount, cfg.AssetsQueueSize, c.CacheFile)
 	c.scheduler = newScheduler(cfg.AssetsRetryHeapLimit, c.workers.tryAddTask, func(n int) {
@@ -206,11 +215,28 @@ func (c *cacher) cacheURL(t *Task) {
 
 	// TODO: implement in streams
 	start = time.Now()
-	err = c.objStorage.Upload(strings.NewReader(strData), t.cachePath, contentType, contentEncoding, objectstorage.NoCompression)
-	if err != nil {
-		c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), true)
-		c.retry(ctx, t, 0, "upload", err)
-		return
+	if c.hashKeys && !t.isJS {
+		hash := assets.HashBody(data)
+		contentPath := assets.GetCachePathWithHash(t.requestURL, hash)
+		if err := c.objStorage.Upload(strings.NewReader(strData), contentPath, contentType, contentEncoding, objectstorage.NoCompression); err != nil {
+			c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), true)
+			c.retry(ctx, t, 0, "upload", err)
+			return
+		}
+		if err := c.objStorage.Upload(strings.NewReader(strData), t.cachePath, contentType, contentEncoding, objectstorage.NoCompression); err != nil {
+			c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), true)
+			c.retry(ctx, t, 0, "upload", err)
+			return
+		}
+		if c.resolver != nil {
+			c.resolver.Set(t.requestURL, hash)
+		}
+	} else {
+		if err := c.objStorage.Upload(strings.NewReader(strData), t.cachePath, contentType, contentEncoding, objectstorage.NoCompression); err != nil {
+			c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), true)
+			c.retry(ctx, t, 0, "upload", err)
+			return
+		}
 	}
 	c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), false)
 	c.metrics.IncreaseSavedSessions()
@@ -344,7 +370,7 @@ func (c *cacher) checkTask(newTask *Task, blocking bool) {
 	if newTask.isJS {
 		cachePath = assets.GetCachePathForJS(newTask.requestURL)
 	} else {
-		cachePath = assets.GetCachePathForAssets(newTask.sessionID, newTask.requestURL)
+		cachePath = c.rewriter.CachePathForAssets(newTask.sessionID, newTask.requestURL)
 	}
 	if !c.timeoutMap.claim(cachePath) {
 		return

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -1,6 +1,8 @@
 package cacher
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -50,6 +52,7 @@ type cacher struct {
 	hosts          *hostLimiter
 	hashKeys       bool
 	resolver       *resolver.Resolver
+	gzipAssets     bool
 }
 
 func (c *cacher) CanCache() bool {
@@ -134,6 +137,7 @@ func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.Object
 		hosts:          newHostLimiter(cfg.AssetsPerHostLimit),
 		hashKeys:       cfg.KeyScheme == assets.KeySchemeHash,
 		resolver:       urlResolver,
+		gzipAssets:     cfg.AssetsCompression == config.CompressionGzip,
 	}
 	c.workers = NewPool(cfg.AssetsWorkerCount, cfg.AssetsQueueSize, c.CacheFile)
 	c.scheduler = newScheduler(cfg.AssetsRetryHeapLimit, c.workers.tryAddTask, func(n int) {
@@ -207,10 +211,22 @@ func (c *cacher) cacheURL(t *Task) {
 
 	isCSS := strings.HasPrefix(contentType, "text/css")
 
-	strData := string(data)
+	uploadBody := data
 	var cssURLs []string
 	if isCSS {
-		strData, cssURLs = c.rewriter.RewriteCSSAndExtract(t.sessionID, t.requestURL, strData)
+		var rewritten string
+		rewritten, cssURLs = c.rewriter.RewriteCSSAndExtract(t.sessionID, t.requestURL, string(data))
+		uploadBody = []byte(rewritten)
+	}
+
+	compression := objectstorage.NoCompression
+	if shouldCompress(c.gzipAssets, contentType, contentEncoding, t.isJS) {
+		if gzipped, err := gzipBytes(uploadBody); err == nil {
+			uploadBody = gzipped
+			compression = objectstorage.Gzip
+		} else {
+			c.log.Warn(ctx, "asset gzip failed, storing uncompressed: %s", err)
+		}
 	}
 
 	// TODO: implement in streams
@@ -218,12 +234,12 @@ func (c *cacher) cacheURL(t *Task) {
 	if c.hashKeys && !t.isJS {
 		hash := assets.HashBody(data)
 		contentPath := assets.GetCachePathWithHash(t.requestURL, hash)
-		if err := c.objStorage.Upload(strings.NewReader(strData), contentPath, contentType, contentEncoding, objectstorage.NoCompression); err != nil {
+		if err := c.objStorage.Upload(bytes.NewReader(uploadBody), contentPath, contentType, contentEncoding, compression); err != nil {
 			c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), true)
 			c.retry(ctx, t, 0, "upload", err)
 			return
 		}
-		if err := c.objStorage.Upload(strings.NewReader(strData), t.cachePath, contentType, contentEncoding, objectstorage.NoCompression); err != nil {
+		if err := c.objStorage.Upload(bytes.NewReader(uploadBody), t.cachePath, contentType, contentEncoding, compression); err != nil {
 			c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), true)
 			c.retry(ctx, t, 0, "upload", err)
 			return
@@ -232,7 +248,7 @@ func (c *cacher) cacheURL(t *Task) {
 			c.resolver.Set(t.requestURL, hash)
 		}
 	} else {
-		if err := c.objStorage.Upload(strings.NewReader(strData), t.cachePath, contentType, contentEncoding, objectstorage.NoCompression); err != nil {
+		if err := c.objStorage.Upload(bytes.NewReader(uploadBody), t.cachePath, contentType, contentEncoding, compression); err != nil {
 			c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), true)
 			c.retry(ctx, t, 0, "upload", err)
 			return
@@ -351,6 +367,29 @@ func parseRetryAfter(h string) (time.Duration, bool) {
 		return 0, true
 	}
 	return 0, false
+}
+
+func shouldCompress(gzipEnabled bool, contentType, contentEncoding string, isJS bool) bool {
+	return gzipEnabled && !isJS && contentEncoding == "" && isCompressibleType(contentType)
+}
+
+func isCompressibleType(contentType string) bool {
+	return strings.HasPrefix(contentType, "text/") ||
+		strings.HasPrefix(contentType, "application/javascript") ||
+		strings.HasPrefix(contentType, "application/json") ||
+		strings.HasPrefix(contentType, "image/svg")
+}
+
+func gzipBytes(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(data); err != nil {
+		return nil, err
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func hostOf(rawURL string) string {

--- a/backend/internal/assets/cacher/cacher.go
+++ b/backend/internal/assets/cacher/cacher.go
@@ -53,6 +53,7 @@ type cacher struct {
 	hashKeys       bool
 	resolver       *resolver.Resolver
 	gzipAssets     bool
+	samplerDone    chan struct{}
 }
 
 func (c *cacher) CanCache() bool {
@@ -143,7 +144,22 @@ func NewCacher(log logger.Logger, cfg *config.Config, store objectstorage.Object
 	c.scheduler = newScheduler(cfg.AssetsRetryHeapLimit, c.workers.tryAddTask, func(n int) {
 		c.metrics.RecordRetryQueueSize(float64(n))
 	})
+	c.samplerDone = make(chan struct{})
+	go c.samplePoolQueue()
 	return c, nil
+}
+
+func (c *cacher) samplePoolQueue() {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.samplerDone:
+			return
+		case <-ticker.C:
+			c.metrics.RecordPoolQueueSize(float64(c.workers.QueueLen()))
+		}
+	}
 }
 
 func (c *cacher) CacheFile(task *Task) {
@@ -162,6 +178,8 @@ func (c *cacher) cacheURL(t *Task) {
 
 	crTime := c.objStorage.GetCreationTime(t.cachePath)
 	if crTime != nil && crTime.After(time.Now().Add(-MAX_STORAGE_TIME)) {
+		c.metrics.IncreaseTasks(metrics.TaskFreshSkip)
+		c.timeoutMap.addFor(t.cachePath, time.Until(crTime.Add(MAX_STORAGE_TIME)))
 		return
 	}
 	start := time.Now()
@@ -192,6 +210,7 @@ func (c *cacher) cacheURL(t *Task) {
 		c.retry(ctx, t, 0, "read_body", err)
 		return
 	}
+	c.metrics.RecordDownloadBytes(float64(len(data)))
 	if len(data) > c.sizeLimit {
 		c.permanent(ctx, t, "size_exceeded", errors.New("maximum size exceeded"))
 		return
@@ -220,27 +239,28 @@ func (c *cacher) cacheURL(t *Task) {
 	}
 
 	compression := objectstorage.NoCompression
+	encoding := "identity"
 	if shouldCompress(c.gzipAssets, contentType, contentEncoding, t.isJS) {
 		if gzipped, err := gzipBytes(uploadBody); err == nil {
 			uploadBody = gzipped
 			compression = objectstorage.Gzip
+			encoding = "gzip"
 		} else {
 			c.log.Warn(ctx, "asset gzip failed, storing uncompressed: %s", err)
 		}
 	}
 
-	// TODO: implement in streams
 	start = time.Now()
+	puts := 1
 	if c.hashKeys && !t.isJS {
+		puts = 2
 		hash := assets.HashBody(data)
 		contentPath := assets.GetCachePathWithHash(t.requestURL, hash)
 		if err := c.objStorage.Upload(bytes.NewReader(uploadBody), contentPath, contentType, contentEncoding, compression); err != nil {
-			c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), true)
 			c.retry(ctx, t, 0, "upload", err)
 			return
 		}
 		if err := c.objStorage.Upload(bytes.NewReader(uploadBody), t.cachePath, contentType, contentEncoding, compression); err != nil {
-			c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), true)
 			c.retry(ctx, t, 0, "upload", err)
 			return
 		}
@@ -249,13 +269,13 @@ func (c *cacher) cacheURL(t *Task) {
 		}
 	} else {
 		if err := c.objStorage.Upload(bytes.NewReader(uploadBody), t.cachePath, contentType, contentEncoding, compression); err != nil {
-			c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), true)
 			c.retry(ctx, t, 0, "upload", err)
 			return
 		}
 	}
-	c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()), false)
-	c.metrics.IncreaseSavedSessions()
+	c.metrics.RecordUploadDuration(float64(time.Now().Sub(start).Milliseconds()))
+	c.metrics.RecordStoredBytes(float64(len(uploadBody)*puts), encoding)
+	c.metrics.IncreaseTasks(metrics.TaskUploaded)
 
 	if isCSS {
 		if t.depth > 0 {
@@ -285,6 +305,7 @@ func (c *cacher) retry(ctx context.Context, t *Task, explicitDelay time.Duration
 		// final try: drop, record, and evict the dedup entry so a future asset can re-trigger the download.
 		c.timeoutMap.addFor(t.cachePath, c.failureTTL)
 		c.metrics.IncreaseTerminalFailures(reason)
+		c.metrics.IncreaseTasks(metrics.TaskTerminal)
 		c.log.Error(ctx, "Error while caching (terminal, attempts=%d, reason=%s): %s", t.attempt, reason, errors.Wrap(cause, t.urlContext))
 		return
 	}
@@ -293,23 +314,28 @@ func (c *cacher) retry(ctx context.Context, t *Task, explicitDelay time.Duration
 		delay = c.backoff(t.attempt)
 	}
 	if c.scheduler.schedule(t, time.Now().Add(delay)) {
-		c.metrics.IncreaseRetries()
+		c.metrics.IncreaseRetries(reason)
 	} else {
 		// retry heap is full: shed load (the entry stays deduped for now)
 		c.metrics.IncreaseTerminalFailures("retry_queue_full")
+		c.metrics.IncreaseTasks(metrics.TaskDropped)
 		c.log.Warn(ctx, "retry queue full, dropping asset: %s", errors.Wrap(cause, t.urlContext))
 	}
 }
 
 func (c *cacher) permanent(ctx context.Context, t *Task, reason string, cause error) {
 	c.metrics.IncreaseTerminalFailures(reason)
+	c.metrics.IncreaseTasks(metrics.TaskTerminal)
 	c.log.Error(ctx, "Error while caching (permanent, reason=%s): %s", reason, errors.Wrap(cause, t.urlContext))
 }
 
 func (c *cacher) scheduleThrottle(ctx context.Context, t *Task) {
 	delay := hostDeferDelay + time.Duration(rand.Int63n(int64(hostDeferDelay)))
-	if !c.scheduler.schedule(t, time.Now().Add(delay)) {
+	if c.scheduler.schedule(t, time.Now().Add(delay)) {
+		c.metrics.IncreaseThrottled()
+	} else {
 		c.metrics.IncreaseTerminalFailures("throttle_queue_full")
+		c.metrics.IncreaseTasks(metrics.TaskDropped)
 		c.log.Warn(ctx, "retry queue full, dropping throttled asset: %s", t.urlContext)
 	}
 }
@@ -412,6 +438,7 @@ func (c *cacher) checkTask(newTask *Task, blocking bool) {
 		cachePath = c.rewriter.CachePathForAssets(newTask.sessionID, newTask.requestURL)
 	}
 	if !c.timeoutMap.claim(cachePath) {
+		c.metrics.IncreaseTasks(metrics.TaskDedupSkip)
 		return
 	}
 	newTask.cachePath = cachePath
@@ -422,6 +449,7 @@ func (c *cacher) checkTask(newTask *Task, blocking bool) {
 	}
 	if !c.workers.tryAddTask(newTask) {
 		c.timeoutMap.delete(cachePath)
+		c.metrics.IncreaseTasks(metrics.TaskDropped)
 		ctx := context.WithValue(context.Background(), "sessionID", newTask.sessionID)
 		c.log.Warn(ctx, "cacher queue full, dropping asset task: %s", newTask.requestURL)
 	}
@@ -452,6 +480,7 @@ func (c *cacher) UpdateTimeouts() {
 }
 
 func (c *cacher) Stop() {
+	close(c.samplerDone)
 	c.scheduler.stop()
 	c.workers.Stop()
 }

--- a/backend/internal/assets/cacher/pool.go
+++ b/backend/internal/assets/cacher/pool.go
@@ -31,6 +31,10 @@ func (p *WorkerPool) CanAddTask() bool {
 	return false
 }
 
+func (p *WorkerPool) QueueLen() int {
+	return len(p.tasks)
+}
+
 type Job func(task *Task)
 
 func NewPool(size, queueSize int, job Job) *WorkerPool {

--- a/backend/internal/assets/resolver/resolver.go
+++ b/backend/internal/assets/resolver/resolver.go
@@ -1,0 +1,138 @@
+package resolver
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"openreplay/backend/pkg/logger"
+)
+
+const (
+	redisKeyPrefix  = "assets:v1:"
+	redisTTL        = 7 * 24 * time.Hour
+	opTimeout       = 100 * time.Millisecond
+	positiveTTL     = 2 * time.Minute
+	localOnlyTTL    = 26 * time.Hour
+	negativeTTL     = 30 * time.Second
+	maxLocalEntries = 200_000
+)
+
+type entry struct {
+	hash string
+	ok   bool
+	exp  time.Time
+}
+
+type Resolver struct {
+	log      logger.Logger
+	rdb      *redis.Client // nil -> local-only mode
+	onLookup func(hit bool)
+	mu       sync.RWMutex
+	m        map[string]entry
+}
+
+func New(log logger.Logger, connectionURL string, onLookup func(hit bool)) (*Resolver, error) {
+	r := &Resolver{
+		log:      log,
+		onLookup: onLookup,
+		m:        make(map[string]entry),
+	}
+	if connectionURL != "" {
+		options, err := redis.ParseURL(connectionURL)
+		if err != nil {
+			return nil, err
+		}
+		r.rdb = redis.NewClient(options)
+	}
+	return r, nil
+}
+
+func (r *Resolver) positiveTTL() time.Duration {
+	if r.rdb == nil {
+		return localOnlyTTL
+	}
+	return positiveTTL
+}
+
+func (r *Resolver) Lookup(fullURL string) (string, bool) {
+	hash, ok := r.lookup(fullURL)
+	if r.onLookup != nil {
+		r.onLookup(ok)
+	}
+	return hash, ok
+}
+
+func (r *Resolver) lookup(fullURL string) (string, bool) {
+	now := time.Now()
+	r.mu.RLock()
+	e, found := r.m[fullURL]
+	r.mu.RUnlock()
+	if found && now.Before(e.exp) {
+		return e.hash, e.ok
+	}
+	if r.rdb == nil {
+		return "", false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+	defer cancel()
+	hash, err := r.rdb.Get(ctx, redisKeyPrefix+fullURL).Result()
+	switch {
+	case err == nil:
+		r.store(fullURL, entry{hash: hash, ok: true, exp: now.Add(positiveTTL)})
+		return hash, true
+	case err == redis.Nil:
+		r.store(fullURL, entry{exp: now.Add(negativeTTL)})
+		return "", false
+	default:
+		r.store(fullURL, entry{exp: now.Add(negativeTTL)})
+		r.log.Warn(context.Background(), "assets resolver lookup failed: %s", err)
+		return "", false
+	}
+}
+
+func (r *Resolver) Set(fullURL string, hash string) {
+	r.store(fullURL, entry{hash: hash, ok: true, exp: time.Now().Add(r.positiveTTL())})
+	if r.rdb == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+	defer cancel()
+	if err := r.rdb.Set(ctx, redisKeyPrefix+fullURL, hash, redisTTL).Err(); err != nil {
+		r.log.Warn(context.Background(), "assets resolver set failed: %s", err)
+	}
+}
+
+func (r *Resolver) store(fullURL string, e entry) {
+	now := time.Now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.m) >= maxLocalEntries {
+		for k, old := range r.m {
+			if now.After(old.exp) {
+				delete(r.m, k)
+			}
+		}
+		if len(r.m) >= maxLocalEntries { // everything is still live: shed the cache
+			r.m = make(map[string]entry)
+		}
+	}
+	r.m[fullURL] = e
+}
+
+func (r *Resolver) Ping(ctx context.Context) error {
+	if r.rdb == nil {
+		return nil
+	}
+	return r.rdb.Ping(ctx).Err()
+}
+
+func (r *Resolver) Close() error {
+	if r.rdb == nil {
+		return nil
+	}
+	return r.rdb.Close()
+}

--- a/backend/internal/assets/resolver/resolver.go
+++ b/backend/internal/assets/resolver/resolver.go
@@ -26,15 +26,21 @@ type entry struct {
 	exp  time.Time
 }
 
+const (
+	ResolveHit   = "hit"
+	ResolveMiss  = "miss"
+	ResolveError = "error"
+)
+
 type Resolver struct {
 	log      logger.Logger
 	rdb      *redis.Client // nil -> local-only mode
-	onLookup func(hit bool)
+	onLookup func(result string)
 	mu       sync.RWMutex
 	m        map[string]entry
 }
 
-func New(log logger.Logger, connectionURL string, onLookup func(hit bool)) (*Resolver, error) {
+func New(log logger.Logger, connectionURL string, onLookup func(result string)) (*Resolver, error) {
 	r := &Resolver{
 		log:      log,
 		onLookup: onLookup,
@@ -58,23 +64,26 @@ func (r *Resolver) positiveTTL() time.Duration {
 }
 
 func (r *Resolver) Lookup(fullURL string) (string, bool) {
-	hash, ok := r.lookup(fullURL)
+	hash, result := r.lookup(fullURL)
 	if r.onLookup != nil {
-		r.onLookup(ok)
+		r.onLookup(result)
 	}
-	return hash, ok
+	return hash, result == ResolveHit
 }
 
-func (r *Resolver) lookup(fullURL string) (string, bool) {
+func (r *Resolver) lookup(fullURL string) (string, string) {
 	now := time.Now()
 	r.mu.RLock()
 	e, found := r.m[fullURL]
 	r.mu.RUnlock()
 	if found && now.Before(e.exp) {
-		return e.hash, e.ok
+		if e.ok {
+			return e.hash, ResolveHit
+		}
+		return "", ResolveMiss
 	}
 	if r.rdb == nil {
-		return "", false
+		return "", ResolveMiss
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
@@ -83,14 +92,14 @@ func (r *Resolver) lookup(fullURL string) (string, bool) {
 	switch {
 	case err == nil:
 		r.store(fullURL, entry{hash: hash, ok: true, exp: now.Add(positiveTTL)})
-		return hash, true
+		return hash, ResolveHit
 	case err == redis.Nil:
 		r.store(fullURL, entry{exp: now.Add(negativeTTL)})
-		return "", false
+		return "", ResolveMiss
 	default:
 		r.store(fullURL, entry{exp: now.Add(negativeTTL)})
 		r.log.Warn(context.Background(), "assets resolver lookup failed: %s", err)
-		return "", false
+		return "", ResolveError
 	}
 }
 

--- a/backend/internal/config/assets/config.go
+++ b/backend/internal/config/assets/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	AssetsOrigin         string            `env:"ASSETS_ORIGIN,required"`
 	AssetsSizeLimit      int               `env:"ASSETS_SIZE_LIMIT,required"`
 	AssetsRequestHeaders map[string]string `env:"ASSETS_REQUEST_HEADERS"`
+	AssetsCompression    string            `env:"ASSETS_COMPRESSION,default=none"` // none|gzip
 	AssetsRetries        int               `env:"ASSETS_RETRIES,default=5"`
 	AssetsRetryBaseMs    int               `env:"ASSETS_RETRY_BASE_MS,default=2000"`
 	AssetsRetryMaxMs     int               `env:"ASSETS_RETRY_MAX_MS,default=60000"`
@@ -49,10 +50,19 @@ type Config struct {
 	ClientCertFilePath   string            `env:"CLIENT_CERT_FILE_PATH"`
 }
 
+const (
+	CompressionNone = "none"
+	CompressionGzip = "gzip"
+)
+
 func New(log logger.Logger) *Config {
 	cfg := &Config{}
 	configurator.Process(log, cfg)
 	cfg.Cache.Validate(log)
+	if cfg.AssetsCompression != CompressionNone && cfg.AssetsCompression != CompressionGzip {
+		log.Fatal(context.Background(), "invalid ASSETS_COMPRESSION %q (expected %q or %q)",
+			cfg.AssetsCompression, CompressionNone, CompressionGzip)
+	}
 	return cfg
 }
 

--- a/backend/internal/config/assets/config.go
+++ b/backend/internal/config/assets/config.go
@@ -1,10 +1,14 @@
 package assets
 
 import (
+	"context"
+
 	"openreplay/backend/internal/config/common"
 	"openreplay/backend/internal/config/configurator"
 	"openreplay/backend/internal/config/objectstorage"
+	"openreplay/backend/internal/config/redis"
 	"openreplay/backend/pkg/logger"
+	urlassets "openreplay/backend/pkg/url/assets"
 )
 
 type Cache struct {
@@ -13,12 +17,14 @@ type Cache struct {
 	CacheThreshold  int64  `env:"CACHE_THRESHOLD,default=5"`
 	CacheExpiration int64  `env:"CACHE_EXPIRATION,default=120"`
 	CacheBlackList  string `env:"CACHE_BLACK_LIST,default="`
+	KeyScheme       string `env:"ASSETS_KEY_SCHEME,default=daily"` // "hash" for a .<hash> suffix
 }
 
 type Config struct {
 	common.Config
 	objectstorage.ObjectsConfig
 	Cache
+	redis.Redis
 	GroupCache           string            `env:"GROUP_CACHE,required"`
 	TopicRawAssets       string            `env:"TOPIC_RAW_ASSETS,required"`
 	TopicRawWeb          string            `env:"TOPIC_RAW_WEB,required"`
@@ -46,5 +52,13 @@ type Config struct {
 func New(log logger.Logger) *Config {
 	cfg := &Config{}
 	configurator.Process(log, cfg)
+	cfg.Cache.Validate(log)
 	return cfg
+}
+
+func (c *Cache) Validate(log logger.Logger) {
+	if !urlassets.ValidKeyScheme(c.KeyScheme) {
+		log.Fatal(context.Background(), "invalid ASSETS_KEY_SCHEME %q (expected %q or %q)",
+			c.KeyScheme, urlassets.KeySchemeDaily, urlassets.KeySchemeHash)
+	}
 }

--- a/backend/internal/config/sink/config.go
+++ b/backend/internal/config/sink/config.go
@@ -34,5 +34,6 @@ type Config struct {
 func New(log logger.Logger) *Config {
 	cfg := &Config{}
 	configurator.Process(log, cfg)
+	cfg.Cache.Validate(log)
 	return cfg
 }

--- a/backend/pkg/metrics/assets/metrics.go
+++ b/backend/pkg/metrics/assets/metrics.go
@@ -12,6 +12,7 @@ type Assets interface {
 	IncreaseRetries()
 	IncreaseTerminalFailures(reason string)
 	RecordRetryQueueSize(size float64)
+	RecordAssetResolve(hit bool)
 	List() []prometheus.Collector
 }
 
@@ -27,3 +28,4 @@ func (a *assetsImpl) RecordUploadDuration(durMillis float64, isFailed bool) {}
 func (a *assetsImpl) IncreaseRetries()                                      {}
 func (a *assetsImpl) IncreaseTerminalFailures(reason string)                {}
 func (a *assetsImpl) RecordRetryQueueSize(size float64)                     {}
+func (a *assetsImpl) RecordAssetResolve(hit bool)                           {}

--- a/backend/pkg/metrics/assets/metrics.go
+++ b/backend/pkg/metrics/assets/metrics.go
@@ -4,15 +4,33 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	TaskUploaded  = "uploaded"           // downloaded and stored
+	TaskDedupSkip = "dedup_skip"         // suppressed by the in-process timeoutMap
+	TaskFreshSkip = "fresh_skip"         // stored object is younger than MAX_STORAGE_TIME
+	TaskDropped   = "dropped_queue_full" // shed on a full worker pool / retry heap
+	TaskTerminal  = "terminal"           // download failed permanently (see terminal_failures_total{reason})
+)
+
+const (
+	ResolveHit   = "hit"
+	ResolveMiss  = "miss"
+	ResolveError = "error"
+)
+
 type Assets interface {
-	IncreaseProcessesSessions()
-	IncreaseSavedSessions()
-	RecordDownloadDuration(durMillis float64, code int)
-	RecordUploadDuration(durMillis float64, isFailed bool)
-	IncreaseRetries()
+	IncreaseTasks(outcome string)
+	IncreaseThrottled()
+	IncreaseRetries(reason string)
 	IncreaseTerminalFailures(reason string)
 	RecordRetryQueueSize(size float64)
-	RecordAssetResolve(hit bool)
+	RecordPoolQueueSize(size float64)
+	IncreaseConsumePausedTime(seconds float64)
+	RecordDownloadDuration(durMillis float64, code int)
+	RecordDownloadBytes(size float64)
+	RecordUploadDuration(durMillis float64)
+	RecordStoredBytes(size float64, encoding string)
+	RecordAssetResolve(result string)
 	List() []prometheus.Collector
 }
 
@@ -20,12 +38,16 @@ type assetsImpl struct{}
 
 func New(serviceName string) Assets { return &assetsImpl{} }
 
-func (a *assetsImpl) List() []prometheus.Collector                          { return []prometheus.Collector{} }
-func (a *assetsImpl) IncreaseProcessesSessions()                            {}
-func (a *assetsImpl) IncreaseSavedSessions()                                {}
-func (a *assetsImpl) RecordDownloadDuration(durMillis float64, code int)    {}
-func (a *assetsImpl) RecordUploadDuration(durMillis float64, isFailed bool) {}
-func (a *assetsImpl) IncreaseRetries()                                      {}
-func (a *assetsImpl) IncreaseTerminalFailures(reason string)                {}
-func (a *assetsImpl) RecordRetryQueueSize(size float64)                     {}
-func (a *assetsImpl) RecordAssetResolve(hit bool)                           {}
+func (a *assetsImpl) List() []prometheus.Collector                       { return []prometheus.Collector{} }
+func (a *assetsImpl) IncreaseTasks(outcome string)                       {}
+func (a *assetsImpl) IncreaseThrottled()                                 {}
+func (a *assetsImpl) IncreaseRetries(reason string)                      {}
+func (a *assetsImpl) IncreaseTerminalFailures(reason string)             {}
+func (a *assetsImpl) RecordRetryQueueSize(size float64)                  {}
+func (a *assetsImpl) RecordPoolQueueSize(size float64)                   {}
+func (a *assetsImpl) IncreaseConsumePausedTime(seconds float64)          {}
+func (a *assetsImpl) RecordDownloadDuration(durMillis float64, code int) {}
+func (a *assetsImpl) RecordDownloadBytes(size float64)                   {}
+func (a *assetsImpl) RecordUploadDuration(durMillis float64)             {}
+func (a *assetsImpl) RecordStoredBytes(size float64, encoding string)    {}
+func (a *assetsImpl) RecordAssetResolve(result string)                   {}

--- a/backend/pkg/url/assets/rewriter.go
+++ b/backend/pkg/url/assets/rewriter.go
@@ -1,20 +1,36 @@
 package assets
 
 import (
+	"fmt"
 	"net/url"
 )
 
-type Rewriter struct {
-	assetsURL *url.URL
+type Resolver interface {
+	Lookup(fullURL string) (hash string, ok bool)
 }
 
+type Rewriter struct {
+	assetsURL *url.URL
+	scheme    string
+	resolver  Resolver
+}
+
+// NewRewriter keeps the legacy behavior: daily key scheme.
 func NewRewriter(baseOrigin string) (*Rewriter, error) {
+	return NewRewriterWithScheme(baseOrigin, KeySchemeDaily, nil)
+}
+
+func NewRewriterWithScheme(baseOrigin string, scheme string, resolver Resolver) (*Rewriter, error) {
+	if !ValidKeyScheme(scheme) {
+		return nil, fmt.Errorf("unknown assets key scheme: %q", scheme)
+	}
 	assetsURL, err := url.Parse(baseOrigin)
 	if err != nil {
 		return nil, err
 	}
 	return &Rewriter{
 		assetsURL: assetsURL,
+		scheme:    scheme,
+		resolver:  resolver,
 	}, nil
-
 }

--- a/backend/pkg/url/assets/url.go
+++ b/backend/pkg/url/assets/url.go
@@ -7,8 +7,21 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
+
 	"openreplay/backend/pkg/flakeid"
 )
+
+const (
+	// KeySchemeDaily — legacy: key = <escaped-url>.<day-of-month>
+	KeySchemeDaily = "daily"
+	// KeySchemeHash — key = <escaped-url>.<xxhash64(origin body)>
+	KeySchemeHash = "hash"
+)
+
+func ValidKeyScheme(scheme string) bool {
+	return scheme == KeySchemeDaily || scheme == KeySchemeHash
+}
 
 func getSessionKey(sessionID uint64) string {
 	return strconv.FormatUint(
@@ -80,8 +93,31 @@ func GetCachePathForJS(rawurl string) string {
 	return getCachePath(rawurl)
 }
 
-func GetCachePathForAssets(sessionID uint64, rawurl string) string {
+func HashBody(body []byte) string {
+	return strconv.FormatUint(xxhash.Sum64(body), 16)
+}
+
+func GetCachePathWithHash(rawurl string, hash string) string {
+	return getCachePath(rawurl) + "." + hash
+}
+
+func (r *Rewriter) CachePathForAssets(sessionID uint64, rawurl string) string {
+	if r.scheme == KeySchemeHash {
+		return getCachePath(rawurl)
+	}
 	return getCachePathWithKey(sessionID, rawurl)
+}
+
+func (r *Rewriter) rewritePath(sessionID uint64, fullURL string) string {
+	if r.scheme == KeySchemeHash {
+		if r.resolver != nil {
+			if hash, ok := r.resolver.Lookup(fullURL); ok {
+				return GetCachePathWithHash(fullURL, hash)
+			}
+		}
+		return getCachePath(fullURL) // mapping cold: fall back to the current-version pointer
+	}
+	return getCachePathWithKey(sessionID, fullURL)
 }
 
 func (r *Rewriter) RewriteURL(sessionID uint64, baseURL string, relativeURL string) string {
@@ -91,7 +127,7 @@ func (r *Rewriter) RewriteURL(sessionID uint64, baseURL string, relativeURL stri
 	}
 
 	u := url.URL{
-		Path:   r.assetsURL.Path + getCachePathWithKey(sessionID, fullURL),
+		Path:   r.assetsURL.Path + r.rewritePath(sessionID, fullURL),
 		Host:   r.assetsURL.Host,
 		Scheme: r.assetsURL.Scheme,
 	}

--- a/ee/backend/pkg/metrics/assets/metrics.go
+++ b/ee/backend/pkg/metrics/assets/metrics.go
@@ -16,6 +16,7 @@ type Assets interface {
 	IncreaseRetries()
 	IncreaseTerminalFailures(reason string)
 	RecordRetryQueueSize(size float64)
+	RecordAssetResolve(hit bool)
 	List() []prometheus.Collector
 }
 
@@ -27,6 +28,7 @@ type assetsImpl struct {
 	assetsRetries           prometheus.Counter
 	assetsTerminalFailures  *prometheus.CounterVec
 	assetsRetryQueueSize    prometheus.Gauge
+	assetsResolves          *prometheus.CounterVec
 }
 
 func New(serviceName string) Assets {
@@ -38,6 +40,7 @@ func New(serviceName string) Assets {
 		assetsRetries:           newRetries(serviceName),
 		assetsTerminalFailures:  newTerminalFailures(serviceName),
 		assetsRetryQueueSize:    newRetryQueueSize(serviceName),
+		assetsResolves:          newResolves(serviceName),
 	}
 }
 
@@ -50,6 +53,7 @@ func (a *assetsImpl) List() []prometheus.Collector {
 		a.assetsRetries,
 		a.assetsTerminalFailures,
 		a.assetsRetryQueueSize,
+		a.assetsResolves,
 	}
 }
 
@@ -158,4 +162,23 @@ func newRetryQueueSize(serviceName string) prometheus.Gauge {
 
 func (a *assetsImpl) RecordRetryQueueSize(size float64) {
 	a.assetsRetryQueueSize.Set(size)
+}
+
+func newResolves(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "resolver_lookups_total",
+			Help:      "A counter displaying url→content-hash resolver lookups under the hash key scheme, by result.",
+		},
+		[]string{"result"},
+	)
+}
+
+func (a *assetsImpl) RecordAssetResolve(hit bool) {
+	result := "miss"
+	if hit {
+		result = "hit"
+	}
+	a.assetsResolves.WithLabelValues(result).Inc()
 }

--- a/ee/backend/pkg/metrics/assets/metrics.go
+++ b/ee/backend/pkg/metrics/assets/metrics.go
@@ -8,177 +8,213 @@ import (
 	"openreplay/backend/pkg/metrics/common"
 )
 
+const (
+	TaskUploaded  = "uploaded"           // downloaded and stored
+	TaskDedupSkip = "dedup_skip"         // suppressed by the in-process timeoutMap
+	TaskFreshSkip = "fresh_skip"         // stored object is younger than MAX_STORAGE_TIME
+	TaskDropped   = "dropped_queue_full" // shed on a full worker pool / retry heap
+	TaskTerminal  = "terminal"           // download failed permanently (see terminal_failures_total{reason})
+)
+
+const (
+	ResolveHit   = "hit"
+	ResolveMiss  = "miss"
+	ResolveError = "error"
+)
+
 type Assets interface {
-	IncreaseProcessesSessions()
-	IncreaseSavedSessions()
-	RecordDownloadDuration(durMillis float64, code int)
-	RecordUploadDuration(durMillis float64, isFailed bool)
-	IncreaseRetries()
+	IncreaseTasks(outcome string)
+	IncreaseThrottled()
+	IncreaseRetries(reason string)
 	IncreaseTerminalFailures(reason string)
 	RecordRetryQueueSize(size float64)
-	RecordAssetResolve(hit bool)
+	RecordPoolQueueSize(size float64)
+	IncreaseConsumePausedTime(seconds float64)
+	RecordDownloadDuration(durMillis float64, code int)
+	RecordDownloadBytes(size float64)
+	RecordUploadDuration(durMillis float64)
+	RecordStoredBytes(size float64, encoding string)
+	RecordAssetResolve(result string)
 	List() []prometheus.Collector
 }
 
 type assetsImpl struct {
-	assetsProcessedSessions prometheus.Counter
-	assetsSavedSessions     prometheus.Counter
-	assetsDownloadDuration  *prometheus.HistogramVec
-	assetsUploadDuration    *prometheus.HistogramVec
-	assetsRetries           prometheus.Counter
-	assetsTerminalFailures  *prometheus.CounterVec
-	assetsRetryQueueSize    prometheus.Gauge
-	assetsResolves          *prometheus.CounterVec
+	tasks                *prometheus.CounterVec
+	throttled            prometheus.Counter
+	retries              *prometheus.CounterVec
+	terminalFailures     *prometheus.CounterVec
+	retryQueueSize       prometheus.Gauge
+	poolQueueSize        prometheus.Gauge
+	consumePausedSeconds prometheus.Counter
+	downloadDuration     *prometheus.HistogramVec
+	downloadBytes        prometheus.Counter
+	uploadDuration       prometheus.Histogram
+	storedBytes          *prometheus.CounterVec
+	resolves             *prometheus.CounterVec
 }
 
 func New(serviceName string) Assets {
 	return &assetsImpl{
-		assetsProcessedSessions: newProcessedSessions(serviceName),
-		assetsSavedSessions:     newSavedSessions(serviceName),
-		assetsDownloadDuration:  newDownloadDuration(serviceName),
-		assetsUploadDuration:    newUploadDuration(serviceName),
-		assetsRetries:           newRetries(serviceName),
-		assetsTerminalFailures:  newTerminalFailures(serviceName),
-		assetsRetryQueueSize:    newRetryQueueSize(serviceName),
-		assetsResolves:          newResolves(serviceName),
+		tasks: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: serviceName,
+				Name:      "tasks_total",
+				Help:      "A counter displaying terminal outcomes of asset cache tasks (the task funnel).",
+			},
+			[]string{"outcome"},
+		),
+		throttled: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: serviceName,
+				Name:      "throttled_total",
+				Help:      "A counter displaying per-host throttle deferrals (task re-scheduled, not a retry).",
+			},
+		),
+		retries: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: serviceName,
+				Name:      "retries_total",
+				Help:      "A counter displaying scheduled asset download retries, by reason.",
+			},
+			[]string{"reason"},
+		),
+		terminalFailures: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: serviceName,
+				Name:      "terminal_failures_total",
+				Help:      "A counter displaying assets that permanently failed to cache, by reason.",
+			},
+			[]string{"reason"},
+		),
+		retryQueueSize: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: serviceName,
+				Name:      "retry_queue_size",
+				Help:      "A gauge displaying the current number of pending asset download retries.",
+			},
+		),
+		poolQueueSize: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: serviceName,
+				Name:      "pool_queue_size",
+				Help:      "A gauge displaying the current depth of the download worker pool queue.",
+			},
+		),
+		consumePausedSeconds: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: serviceName,
+				Name:      "consume_paused_seconds_total",
+				Help:      "A counter displaying total time message consumption was paused because the worker pool was full.",
+			},
+		),
+		downloadDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: serviceName,
+				Name:      "download_duration_seconds",
+				Help:      "A histogram displaying the duration of downloading for each asset in seconds, by status class.",
+				Buckets:   common.DefaultDurationBuckets,
+			},
+			[]string{"code_class"},
+		),
+		downloadBytes: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Namespace: serviceName,
+				Name:      "download_bytes_total",
+				Help:      "A counter displaying total bytes downloaded from origins.",
+			},
+		),
+		uploadDuration: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: serviceName,
+				Name:      "upload_s3_duration_seconds",
+				Help:      "A histogram displaying the duration of successful asset uploads to object storage in seconds.",
+				Buckets:   common.DefaultDurationBuckets,
+			},
+		),
+		storedBytes: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: serviceName,
+				Name:      "stored_bytes_total",
+				Help:      "A counter displaying total bytes written to object storage, by encoding.",
+			},
+			[]string{"encoding"},
+		),
+		resolves: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: serviceName,
+				Name:      "resolver_lookups_total",
+				Help:      "A counter displaying url→content-hash resolver lookups under the hash key scheme, by result.",
+			},
+			[]string{"result"},
+		),
 	}
 }
 
 func (a *assetsImpl) List() []prometheus.Collector {
 	return []prometheus.Collector{
-		a.assetsProcessedSessions,
-		a.assetsSavedSessions,
-		a.assetsDownloadDuration,
-		a.assetsUploadDuration,
-		a.assetsRetries,
-		a.assetsTerminalFailures,
-		a.assetsRetryQueueSize,
-		a.assetsResolves,
+		a.tasks,
+		a.throttled,
+		a.retries,
+		a.terminalFailures,
+		a.retryQueueSize,
+		a.poolQueueSize,
+		a.consumePausedSeconds,
+		a.downloadDuration,
+		a.downloadBytes,
+		a.uploadDuration,
+		a.storedBytes,
+		a.resolves,
 	}
 }
 
-func newProcessedSessions(serviceName string) prometheus.Counter {
-	return prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: serviceName,
-			Name:      "processed_total",
-			Help:      "A counter displaying the total count of processed assets.",
-		},
-	)
+func (a *assetsImpl) IncreaseTasks(outcome string) {
+	a.tasks.WithLabelValues(outcome).Inc()
 }
 
-func (a *assetsImpl) IncreaseProcessesSessions() {
-	a.assetsProcessedSessions.Inc()
+func (a *assetsImpl) IncreaseThrottled() {
+	a.throttled.Inc()
 }
 
-func newSavedSessions(serviceName string) prometheus.Counter {
-	return prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: serviceName,
-			Name:      "saved_total",
-			Help:      "A counter displaying the total number of cached assets.",
-		},
-	)
-}
-
-func (a *assetsImpl) IncreaseSavedSessions() {
-	a.assetsSavedSessions.Inc()
-}
-
-func newDownloadDuration(serviceName string) *prometheus.HistogramVec {
-	return prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: serviceName,
-			Name:      "download_duration_seconds",
-			Help:      "A histogram displaying the duration of downloading for each asset in seconds.",
-			Buckets:   common.DefaultDurationBuckets,
-		},
-		[]string{"response_code"},
-	)
-}
-
-func (a *assetsImpl) RecordDownloadDuration(durMillis float64, code int) {
-	a.assetsDownloadDuration.WithLabelValues(strconv.Itoa(code)).Observe(durMillis / 1000.0)
-}
-
-func newUploadDuration(serviceName string) *prometheus.HistogramVec {
-	return prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: serviceName,
-			Name:      "upload_s3_duration_seconds",
-			Help:      "A histogram displaying the duration of uploading to s3 for each asset in seconds.",
-			Buckets:   common.DefaultDurationBuckets,
-		},
-		[]string{"failed"},
-	)
-}
-
-func (a *assetsImpl) RecordUploadDuration(durMillis float64, isFailed bool) {
-	failed := "false"
-	if isFailed {
-		failed = "true"
-	}
-	a.assetsUploadDuration.WithLabelValues(failed).Observe(durMillis / 1000.0)
-}
-
-func newRetries(serviceName string) prometheus.Counter {
-	return prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: serviceName,
-			Name:      "retries_total",
-			Help:      "A counter displaying the total number of scheduled asset download retries.",
-		},
-	)
-}
-
-func (a *assetsImpl) IncreaseRetries() {
-	a.assetsRetries.Inc()
-}
-
-func newTerminalFailures(serviceName string) *prometheus.CounterVec {
-	return prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: serviceName,
-			Name:      "terminal_failures_total",
-			Help:      "A counter displaying the total number of assets that permanently failed to cache, by reason.",
-		},
-		[]string{"reason"},
-	)
+func (a *assetsImpl) IncreaseRetries(reason string) {
+	a.retries.WithLabelValues(reason).Inc()
 }
 
 func (a *assetsImpl) IncreaseTerminalFailures(reason string) {
-	a.assetsTerminalFailures.WithLabelValues(reason).Inc()
-}
-
-func newRetryQueueSize(serviceName string) prometheus.Gauge {
-	return prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: serviceName,
-			Name:      "retry_queue_size",
-			Help:      "A gauge displaying the current number of pending asset download retries.",
-		},
-	)
+	a.terminalFailures.WithLabelValues(reason).Inc()
 }
 
 func (a *assetsImpl) RecordRetryQueueSize(size float64) {
-	a.assetsRetryQueueSize.Set(size)
+	a.retryQueueSize.Set(size)
 }
 
-func newResolves(serviceName string) *prometheus.CounterVec {
-	return prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: serviceName,
-			Name:      "resolver_lookups_total",
-			Help:      "A counter displaying url→content-hash resolver lookups under the hash key scheme, by result.",
-		},
-		[]string{"result"},
-	)
+func (a *assetsImpl) RecordPoolQueueSize(size float64) {
+	a.poolQueueSize.Set(size)
 }
 
-func (a *assetsImpl) RecordAssetResolve(hit bool) {
-	result := "miss"
-	if hit {
-		result = "hit"
+func (a *assetsImpl) IncreaseConsumePausedTime(seconds float64) {
+	a.consumePausedSeconds.Add(seconds)
+}
+
+func (a *assetsImpl) RecordDownloadDuration(durMillis float64, code int) {
+	class := "unknown"
+	if code >= 100 && code < 600 {
+		class = strconv.Itoa(code/100) + "xx"
 	}
-	a.assetsResolves.WithLabelValues(result).Inc()
+	a.downloadDuration.WithLabelValues(class).Observe(durMillis / 1000.0)
+}
+
+func (a *assetsImpl) RecordDownloadBytes(size float64) {
+	a.downloadBytes.Add(size)
+}
+
+func (a *assetsImpl) RecordUploadDuration(durMillis float64) {
+	a.uploadDuration.Observe(durMillis / 1000.0)
+}
+
+func (a *assetsImpl) RecordStoredBytes(size float64, encoding string) {
+	a.storedBytes.WithLabelValues(encoding).Add(size)
+}
+
+func (a *assetsImpl) RecordAssetResolve(result string) {
+	a.resolves.WithLabelValues(result).Inc()
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds hash-based asset keys with a Redis-backed resolver and optional gzip compression to improve cache stability and storage efficiency. Also overhauls asset metrics and continues processing sessions for inactive projects.

- **New Features**
  - Hash key scheme via `ASSETS_KEY_SCHEME=hash`; URLs resolved through a Redis resolver (`assets/resolver`) and stored under both hash and pointer keys.
  - Optional gzip storage via `ASSETS_COMPRESSION=gzip` for compressible, non-JS assets; records encoding and byte counts.
  - URL rewriting supports schemes through `NewRewriterWithScheme`; resolver lookups drive hash-suffixed paths on hits.
  - Cacher dedup/fresh skips, backoff, host throttling, and worker pool queue sampling; tracks dropped tasks when queues are full.
  - Assets service can use Redis (`REDIS_...` envs) for resolver; config validates `ASSETS_KEY_SCHEME` and compression mode.
  - `ender` and `sink` now use `sessions.IgnoreInactiveProjects` to process data from inactive projects.

- **Metrics**
  - New counters and gauges: `tasks_total{outcome}`, `throttled_total`, `retries_total{reason}`, `terminal_failures_total{reason}`, `retry_queue_size`, `pool_queue_size`, `consume_paused_seconds_total`.
  - I/O metrics: `download_duration_seconds{code_class}`, `download_bytes_total`, `upload_s3_duration_seconds` (success only), `stored_bytes_total{encoding}`.
  - Resolver: `resolver_lookups_total{result}` (hit/miss/error).

<sup>Written for commit 9386a86bd4937b6286975d72ddb9bb2962d2706e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

