### PR TITLE
ui: fix search refresh on custom events

### DIFF
--- a/frontend/app/mstore/searchStore.ts
+++ b/frontend/app/mstore/searchStore.ts
@@ -532,7 +532,12 @@ class SearchStore {
     this.instance = new Search(inst);
     this.currentPage = 1;
 
-    if (filter.value && filter.value[0] && filter.value[0] !== '') {
+    const hasValue = Boolean(
+      filter.value && filter.value[0] && filter.value[0] !== '',
+    );
+    const isCustomEvent = Boolean(filter.isEvent) && !filter.autoCaptured;
+
+    if (hasValue || isCustomEvent) {
       void this.fetchSessions();
     }
   };


### PR DESCRIPTION
fix for #4829

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes session search when selecting a custom event, fixing missed updates. Previously we only fetched on a non-empty filter value; now we also fetch when the filter is a custom event (non–auto-captured). Fixes #4829.

- Adjusts the fetch trigger in `SearchStore` on filter updates: fetch when has a value OR is a custom event.
- Auto-captured events are unchanged; expect one extra fetch when selecting a custom event with an empty value.

<sup>Written for commit ef4bd2854122e3e8d26c7b021f9fefb0f34715ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

