### PR TITLE
fix(api): enforce note ownership on delete, fix nil deref and ILIKE es…

### DIFF
--- a/backend/pkg/db/postgres/ilike.go
+++ b/backend/pkg/db/postgres/ilike.go
@@ -1,0 +1,10 @@
+package postgres
+
+import "strings"
+
+var ilikeReplacer = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+
+// EscapeILIKE escapes LIKE/ILIKE pattern metacharacters; use with ESCAPE '\' in the query.
+func EscapeILIKE(s string) string {
+	return ilikeReplacer.Replace(s)
+}

--- a/backend/pkg/notes/api/handlers.go
+++ b/backend/pkg/notes/api/handlers.go
@@ -227,8 +227,17 @@ func (h *handlersImpl) deleteNote(w http.ResponseWriter, r *http.Request) {
 		h.responser.ResponseWithError(h.log, r.Context(), w, http.StatusBadRequest, err, startTime, r.URL.Path, bodySize)
 		return
 	}
+	currUser := api.GetUser(r)
+	if currUser == nil {
+		h.responser.ResponseWithError(h.log, r.Context(), w, http.StatusUnauthorized, errors.New("unauthorized"), startTime, r.URL.Path, bodySize)
+		return
+	}
 
-	if err := h.notes.Delete(uint64(projID), noteID); err != nil {
+	if err := h.notes.Delete(uint64(projID), currUser.ID, noteID); err != nil {
+		if errors.Is(err, notes.ErrNoteNotFound) {
+			h.responser.ResponseWithError(h.log, r.Context(), w, http.StatusNotFound, err, startTime, r.URL.Path, bodySize)
+			return
+		}
 		h.responser.ResponseWithError(h.log, r.Context(), w, http.StatusBadRequest, err, startTime, r.URL.Path, bodySize)
 		return
 	}

--- a/backend/pkg/notes/notes.go
+++ b/backend/pkg/notes/notes.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v4"
+
+	"openreplay/backend/pkg/db/postgres"
 	"openreplay/backend/pkg/db/postgres/pool"
 	"openreplay/backend/pkg/logger"
 )
@@ -30,8 +33,10 @@ type Notes interface {
 	GetByID(projectID, userID, noteID uint64) (*Note, error)
 	GetAll(projectID, userID uint64, opts *GetOpts) (interface{}, error)
 	Update(projectID, userID, noteID uint64, note *NoteUpdate) (*Note, error)
-	Delete(projectID, noteID uint64) error
+	Delete(projectID, userID, noteID uint64) error
 }
+
+var ErrNoteNotFound = errors.New("note not found")
 
 func New(log logger.Logger, db pool.Pool) (Notes, error) {
 	return &notesImpl{
@@ -50,7 +55,7 @@ func (n *notesImpl) Create(projectID, userID uint64, note *Note) (*Note, error) 
 		return nil, errors.New("note is required")
 	}
 
-	if len(*note.Message) > MaxMessageLength {
+	if note.Message != nil && len(*note.Message) > MaxMessageLength {
 		*note.Message = (*note.Message)[0:MaxMessageLength]
 	}
 	if note.Tag != nil && len(*note.Tag) > MaxTagLength {
@@ -206,8 +211,8 @@ func (n *notesImpl) GetAll(projectID, userID uint64, opts *GetOpts) (interface{}
 	}
 
 	if opts.Search != "" {
-		where = append(where, fmt.Sprintf("sessions_notes.message ILIKE $%d", argPos))
-		args = append(args, "%"+opts.Search+"%")
+		where = append(where, fmt.Sprintf(`sessions_notes.message ILIKE $%d ESCAPE '\'`, argPos))
+		args = append(args, "%"+postgres.EscapeILIKE(opts.Search)+"%")
 		argPos++
 	}
 
@@ -336,18 +341,24 @@ func (n *notesImpl) Update(projectID, userID, noteID uint64, note *NoteUpdate) (
 	return &updatedNote, nil
 }
 
-func (n *notesImpl) Delete(projectID, noteID uint64) error {
+func (n *notesImpl) Delete(projectID, userID, noteID uint64) error {
 	switch {
 	case projectID == 0:
 		return errors.New("projectID is required")
+	case userID == 0:
+		return errors.New("userID is required")
 	case noteID == 0:
 		return errors.New("noteID is required")
 	}
 	sql := `UPDATE sessions_notes
 			SET deleted_at = timezone('utc'::text, now())
-			WHERE note_id = $1 AND project_id = $2 AND deleted_at ISNULL;`
-	err := n.db.Exec(sql, noteID, projectID)
-	if err != nil {
+			WHERE note_id = $1 AND project_id = $2 AND user_id = $3 AND deleted_at ISNULL
+			RETURNING note_id;`
+	var deletedID uint64
+	if err := n.db.QueryRow(sql, noteID, projectID, userID).Scan(&deletedID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNoteNotFound
+		}
 		return fmt.Errorf("failed to delete note: %v", err)
 	}
 	return nil

--- a/backend/pkg/projects/storage.go
+++ b/backend/pkg/projects/storage.go
@@ -2,7 +2,8 @@ package projects
 
 import (
 	"fmt"
-	"strings"
+
+	"openreplay/backend/pkg/db/postgres"
 )
 
 func (c *projectsImpl) getProjectByKey(projectKey string) (*Project, error) {
@@ -69,7 +70,7 @@ func (c *projectsImpl) listProjects() ([]*Project, error) {
 }
 
 func (c *projectsImpl) existsByName(name string) (bool, error) {
-	escaped := escapeILIKE(name)
+	escaped := postgres.EscapeILIKE(name)
 	var exists bool
 	if err := c.db.QueryRow(`
 		SELECT EXISTS(
@@ -80,12 +81,6 @@ func (c *projectsImpl) existsByName(name string) (bool, error) {
 		return false, err
 	}
 	return exists, nil
-}
-
-var ilikeReplacer = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
-
-func escapeILIKE(s string) string {
-	return ilikeReplacer.Replace(s)
 }
 
 func (c *projectsImpl) createProject(name string, platform string) (*Project, error) {

--- a/ee/backend/pkg/projects/storage.go
+++ b/ee/backend/pkg/projects/storage.go
@@ -2,7 +2,8 @@ package projects
 
 import (
 	"fmt"
-	"strings"
+
+	"openreplay/backend/pkg/db/postgres"
 )
 
 func (c *projectsImpl) getProjectByKey(projectKey string) (*Project, error) {
@@ -69,7 +70,7 @@ func (c *projectsImpl) listProjectsByTenantID(tenantID int) ([]*Project, error) 
 }
 
 func (c *projectsImpl) existsByName(name string) (bool, error) {
-	escaped := escapeILIKE(name)
+	escaped := postgres.EscapeILIKE(name)
 	var exists bool
 	if err := c.db.QueryRow(`
 		SELECT EXISTS(
@@ -83,7 +84,7 @@ func (c *projectsImpl) existsByName(name string) (bool, error) {
 }
 
 func (c *projectsImpl) existsByNameForTenant(name string, tenantID int) (bool, error) {
-	escaped := escapeILIKE(name)
+	escaped := postgres.EscapeILIKE(name)
 	var exists bool
 	if err := c.db.QueryRow(`
 		SELECT EXISTS(
@@ -94,12 +95,6 @@ func (c *projectsImpl) existsByNameForTenant(name string, tenantID int) (bool, e
 		return false, err
 	}
 	return exists, nil
-}
-
-var ilikeReplacer = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
-
-func escapeILIKE(s string) string {
-	return ilikeReplacer.Replace(s)
 }
 
 func (c *projectsImpl) createProject(tenantID int, name string, platform string) (*Project, error) {


### PR DESCRIPTION
…caping in notes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces note ownership when deleting notes and hardens search. Previously any project member could delete any note; now only the note’s owner can delete it. Also fixes a nil dereference in note creation and properly escapes ILIKE patterns to avoid wildcard injection.

**Key changes**
- API behavior: delete note now requires an authenticated user; returns 401 when unauthenticated and 404 when the note is missing or not owned by the user.
- Storage API: `notes.Delete` now takes `(projectID, userID, noteID)` and returns `ErrNoteNotFound` when no row matches. Update any internal callers to pass `userID`.
- Search hardening: added `postgres.EscapeILIKE` and use `ESCAPE '\'` in queries. Applied to notes search and project name existence checks (both OSS and EE), removing duplicate escaping helpers.
- Bug fix: guard against a nil `Message` in note creation to avoid a nil dereference.
- No schema or config changes.

<sup>Written for commit 1336489da398ef30b4346b8794368eae04a949a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

