### PR TITLE
Updated patch build from main 815257343151ba918e858c2e7723d728b8c488d4

### DIFF
--- a/scripts/helmcharts/openreplay/charts/api/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/api/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.8"
+AppVersion: "v1.27.9"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the API Helm chart AppVersion from v1.27.8 to v1.27.9 so deployments pick up the latest patch build. Previously installs used v1.27.8; now Helm installs/upgrades will use the v1.27.9 image.

**Rollout**
- Merge to trigger the tag update job automatically.
- If deployments are manual, run helm upgrade to pull v1.27.9; no values or chart schema changes.

<sup>Written for commit 17971a836bbce24a3b9fa254e6b6b3e20cfda614. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

