### PR TITLE
fix(ui): crash in getInitials on names with empty or non-latin parts

### DIFF
--- a/frontend/app/components/shared/NameAvatar.tsx
+++ b/frontend/app/components/shared/NameAvatar.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { getInitials } from 'App/utils';
 
 function NameAvatar({ name, size }: { name?: string; size?: number }) {
-  const safeName = name ?? '';
-  const stripped = safeName.replace(/[^\p{L}\s]/gu, '').trim();
-  const onlyLetterName = stripped || safeName;
+  const onlyLetterName = (name ?? '')
+    .replace(/[^\p{L}\p{N}\s]/gu, '')
+    .trim();
   const fontSize = size ? Math.floor((size / 32) * 14) : 14;
   return (
     <div

--- a/frontend/app/components/shared/NameAvatar.tsx
+++ b/frontend/app/components/shared/NameAvatar.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { getInitials } from 'App/utils';
 
-function NameAvatar({ name, size }: { name: string; size?: number }) {
-  const onlyLetterName = name.replace(/[^a-zA-Z\s]/g, '');
+function NameAvatar({ name, size }: { name?: string; size?: number }) {
+  const safeName = name ?? '';
+  const stripped = safeName.replace(/[^\p{L}\s]/gu, '').trim();
+  const onlyLetterName = stripped || safeName;
   const fontSize = size ? Math.floor((size / 32) * 14) : 14;
   return (
     <div

--- a/frontend/app/utils/index.ts
+++ b/frontend/app/utils/index.ts
@@ -406,12 +406,12 @@ export const compareJsonObjects = (obj1: any, obj2: any) =>
   JSON.stringify(obj1) === JSON.stringify(obj2);
 
 export const getInitials = (name = '') => {
-  const names = name.split(' ');
-  if (names.every((n) => !n)) return '';
+  const names = (name ?? '').split(' ').filter(Boolean);
+  if (!names.length) return '';
 
   return names
     .slice(0, 2)
-    .map((n: any) => n[0].toUpperCase())
+    .map((n: string) => [...n][0].toUpperCase())
     .join('');
 };
 export function getTimelinePosition(value: any, scale: any) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents a crash when rendering avatar initials for names with empty parts or non‑Latin scripts. Previously we stripped non‑ASCII letters and indexed empty tokens; now we keep Unicode letters and digits, ignore empty parts, and handle an absent name.

- getInitials: filters empty tokens, returns '' when none, and uppercases the first Unicode code point of up to two parts.
- NameAvatar: makes `name` optional; removes punctuation/symbols while keeping Unicode letters/digits/spaces, then trims so non‑Latin names render initials instead of crashing.

<sup>Written for commit 1cfffaaede7cf059ccc54387530b0e0e2cefa6d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

