### PR TITLE
fix(analytics): validate metadata column names

### DIFF
--- a/backend/pkg/analytics/charts/metric_funnel.go
+++ b/backend/pkg/analytics/charts/metric_funnel.go
@@ -170,7 +170,7 @@ func (f *FunnelQueryBuilder) buildQuery(p *Payload) (string, map[string]any, err
 		}
 		if !filter.IsEvent {
 			if _, ok := SessionColumns[filterName]; ok ||
-				filter.AutoCaptured && strings.HasPrefix(filterName, "metadata_") {
+				filter.AutoCaptured && IsMetadataColumn(filterName) {
 				sessionFilters = append(sessionFilters, filter)
 			} else {
 				namelessEventFilters = append(namelessEventFilters, filter)

--- a/backend/pkg/analytics/charts/metric_table.go
+++ b/backend/pkg/analytics/charts/metric_table.go
@@ -676,7 +676,7 @@ func (t *TableQueryBuilder) buildSessionConditions(r *Payload, metricFormat stri
 			var subCondition []string
 			if column, ok := sessionProperties[f.Name]; ok {
 				subCondition = append(subCondition, buildCond(column, f.Value, f.Operator, false, "singleColumn"))
-			} else if strings.HasPrefix(f.Name, "metadata_") {
+			} else if IsMetadataColumn(f.Name) {
 				subCondition = append(subCondition, buildCond(f.Name, f.Value, f.Operator, false, "singleColumn"))
 			}
 			if len(subCondition) > 0 {

--- a/backend/pkg/analytics/charts/metric_timeseries.go
+++ b/backend/pkg/analytics/charts/metric_timeseries.go
@@ -152,7 +152,7 @@ func (t *TimeSeriesQueryBuilder) buildSubQuery(p *Payload, s model.Series, metri
 		if filter.AutoCaptured && !filter.IsEvent {
 			filter.Name = CamelToSnake(filter.Name)
 		}
-		if _, exists := SessionColumns[filter.Name]; exists || strings.HasPrefix(filter.Name, "metadata_") {
+		if _, exists := SessionColumns[filter.Name]; exists || IsMetadataColumn(filter.Name) {
 			sessionFilters = append(sessionFilters, filter)
 		} else {
 			eventFilters = append(eventFilters, filter)

--- a/backend/pkg/analytics/charts/query.go
+++ b/backend/pkg/analytics/charts/query.go
@@ -28,7 +28,16 @@ var (
 	sqlStringReplacer      = strings.NewReplacer(`\`, `\\`, `'`, `''`, `@`, `' || char(64) || '`)
 	sqlLikePatternReplacer = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`, `'`, `''`, `@`, `' || char(64) || '`)
 	camelToSnakeRe         = regexp.MustCompile("([a-z0-9])([A-Z])")
+	metadataColumnRe       = regexp.MustCompile(`^metadata_(?:[1-9]|10)$`)
 )
+
+// IsMetadataColumn reports whether name is a valid metadata column
+// (metadata_1 .. metadata_10). The metadata filter path splices the column
+// name directly into the SQL expression position, so it must be validated
+// against this fixed allowlist before use to prevent SQL injection.
+func IsMetadataColumn(name string) bool {
+	return metadataColumnRe.MatchString(name)
+}
 
 type Payload struct {
 	*model.MetricPayload
@@ -209,7 +218,7 @@ func BuildEventConditions(filters []model.Filter, option BuildConditionsOptions)
 		}
 		isSessionProperty := false
 		_, isSessionProperty = sessionProperties[f.Name]
-		isSessionProperty = isSessionProperty || strings.HasPrefix(f.Name, "metadata_") && f.AutoCaptured
+		isSessionProperty = isSessionProperty || IsMetadataColumn(f.Name) && f.AutoCaptured
 		if f.IsEvent || !isSessionProperty {
 			if option.EventsOrder == "then" {
 				//for "then" order, we can have duplicate conditions
@@ -278,7 +287,7 @@ func addFilter(f model.Filter, opts BuildConditionsOptions, isEventProperty bool
 			}
 		}
 	}
-	if strings.HasPrefix(f.Name, "metadata_") {
+	if IsMetadataColumn(f.Name) {
 		cond := buildCond(f.Name, f.Value, f.Operator, false, "singleColumn")
 		if cond != "" {
 			return []string{cond}, ""
@@ -581,7 +590,7 @@ func BuildWhere(filters []model.Filter, eventsOrder string, eventsAlias, session
 				filterName = CamelToSnake(f.Name)
 			}
 
-			if _, ok := SessionColumns[filterName]; ok || f.AutoCaptured && strings.HasPrefix(filterName, "metadata_") {
+			if _, ok := SessionColumns[filterName]; ok || f.AutoCaptured && IsMetadataColumn(filterName) {
 				sessionFiltersList = append(sessionFiltersList, f)
 			} else {
 				isEvent = true

--- a/backend/pkg/analytics/charts/query_sqli_test.go
+++ b/backend/pkg/analytics/charts/query_sqli_test.go
@@ -1,6 +1,7 @@
 package charts
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -60,5 +61,101 @@ func TestStringValueStillEscaped(t *testing.T) {
 	}
 	if !strings.Contains(got, "'1 OR 1=1'") {
 		t.Errorf("expected quoted literal, got: %s", got)
+	}
+}
+
+func TestMetadataNameNotInjectable(t *testing.T) {
+	inject := []struct {
+		name string
+		f    model.Filter
+	}{
+		{"isAny-or", model.Filter{
+			Name:     "metadata_2) OR ((SELECT user_id FROM experimental.sessions LIMIT 1)='x'",
+			Operator: "isAny",
+		}},
+		{"isAny-break", model.Filter{
+			Name:     "metadata_1))) POC_SYNTAX_BREAK (((",
+			Operator: "isAny",
+		}},
+		{"is-value-expr", model.Filter{
+			Name:     "metadata_2) OR 1=1 --",
+			Operator: "is",
+			Value:    []string{"x"},
+		}},
+		{"contains-expr", model.Filter{
+			Name:     "metadata_1) OR 1=1 --",
+			Operator: "contains",
+			Value:    []string{"x"},
+		}},
+		{"trailing-index", model.Filter{
+			Name:     "metadata_11 OR 1=1",
+			Operator: "isAny",
+		}},
+	}
+	for _, c := range inject {
+		got := buildOne(t, c.f)
+		// Payloads that don't match the metadata allowlist must never reach the
+		// SQL expression position. They may only appear (inert) inside quoted
+		// string literals, so strip those before checking for injected tokens.
+		bare := stripSQLLiterals(got)
+		if strings.Contains(bare, "OR ") || strings.Contains(bare, "SELECT") ||
+			strings.Contains(bare, "((") || strings.Contains(bare, "--") {
+			t.Errorf("%s: metadata name injection survived: %s", c.name, got)
+		}
+	}
+}
+
+// stripSQLLiterals removes single-quoted string literals so tests can assert
+// that attacker-controlled text never lands in unquoted expression position.
+func stripSQLLiterals(s string) string {
+	var b strings.Builder
+	inLit := false
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\'' {
+			// collapse doubled '' escapes inside a literal
+			if inLit && i+1 < len(s) && s[i+1] == '\'' {
+				i++
+				continue
+			}
+			inLit = !inLit
+			continue
+		}
+		if !inLit {
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
+}
+
+func TestLegitimateMetadataPreserved(t *testing.T) {
+	for i := 1; i <= 10; i++ {
+		name := fmt.Sprintf("metadata_%d", i)
+		got := buildOne(t, model.Filter{Name: name, Operator: "isAny"})
+		if !strings.Contains(got, fmt.Sprintf("isNotNull(%s)", name)) {
+			t.Errorf("%s: valid metadata column wrongly dropped: %s", name, got)
+		}
+	}
+	got := buildOne(t, model.Filter{Name: "metadata_3", Operator: "is", Value: []string{"prod"}})
+	if !strings.Contains(got, "metadata_3 = 'prod'") {
+		t.Errorf("valid metadata equals not built: %s", got)
+	}
+}
+
+func TestIsMetadataColumn(t *testing.T) {
+	valid := []string{"metadata_1", "metadata_9", "metadata_10"}
+	for _, n := range valid {
+		if !IsMetadataColumn(n) {
+			t.Errorf("expected %q to be a valid metadata column", n)
+		}
+	}
+	invalid := []string{
+		"metadata_0", "metadata_11", "metadata_", "metadata_1a",
+		"metadata_2) OR 1=1", "metadata_1 ", " metadata_1", "Metadata_1",
+		"metadata_01", "metadata_1;drop",
+	}
+	for _, n := range invalid {
+		if IsMetadataColumn(n) {
+			t.Errorf("expected %q to be rejected", n)
+		}
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validates analytics metadata column names to prevent SQL injection, replacing a permissive prefix check with a strict allowlist.

- Previously any column starting with `metadata_` was accepted; now only `metadata_1` through `metadata_10` are valid.
- Columns outside that range are no longer treated as metadata columns, so they fall back to other handling.
- Adds regression tests for injection payloads and valid column names.

<sup>Written for commit 4eebe408051dd0b4a5cf91f131a5cc58d313e83f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

