### PR TITLE
fix(analytics): escape event names in user journey queries

### DIFF
--- a/backend/pkg/analytics/charts/metric_user_journey.go
+++ b/backend/pkg/analytics/charts/metric_user_journey.go
@@ -220,7 +220,7 @@ func (h *UserJourneyQueryBuilder) buildQuery(p *Payload) ([]string, error) {
 	} else {
 		var b []string = make([]string, 0)
 		for i := 0; i < len(subEvents)-1; i++ {
-			b = append(b, fmt.Sprintf("`$event_name`='%s',%s", subEvents[i].EventName, subEvents[i].Column))
+			b = append(b, fmt.Sprintf("`$event_name`='%s',%s", sqlStringReplacer.Replace(subEvents[i].EventName), subEvents[i].Column))
 		}
 		mainColumn = fmt.Sprintf("multiIf(%s,%s)", strings.Join(b, ","), subEvents[len(subEvents)-1].Column)
 	}
@@ -256,7 +256,7 @@ func (h *UserJourneyQueryBuilder) buildQuery(p *Payload) ([]string, error) {
 				return nil, fmt.Errorf("unknown operator: %s", ef.Operator)
 			}
 			op = reverseSqlOperator(op)
-			exclusions[ef.Name] = []string{fmt.Sprintf("`$event_name` %s '%s'", op, ef.Name)}
+			exclusions[ef.Name] = []string{fmt.Sprintf("`$event_name` %s '%s'", op, sqlStringReplacer.Replace(ef.Name))}
 		}
 	}
 	_, _, sessionsConditions := BuildEventConditions(p.Series[0].Filter.Filters, BuildConditionsOptions{DefinedColumns: mainSessionsColumns, MainTableAlias: "sessions"})
@@ -271,7 +271,7 @@ func (h *UserJourneyQueryBuilder) buildQuery(p *Payload) ([]string, error) {
 		if _, ok := PredefinedJourneys[s]; ok {
 			selectedEventTypeSubQuery = append(selectedEventTypeSubQuery, fmt.Sprintf("events.`$event_name` = '%s'", PredefinedJourneys[s].EventName))
 		} else {
-			selectedEventTypeSubQuery = append(selectedEventTypeSubQuery, fmt.Sprintf("events.`$event_name` = '%s'", s))
+			selectedEventTypeSubQuery = append(selectedEventTypeSubQuery, fmt.Sprintf("events.`$event_name` = '%s'", sqlStringReplacer.Replace(s)))
 		}
 		if _, ok := exclusions[s]; ok {
 			selectedEventTypeSubQuery[len(selectedEventTypeSubQuery)-1] += fmt.Sprintf(" AND (%s)", strings.Join(exclusions[s], " AND "))

--- a/backend/pkg/analytics/charts/query_sqli_test.go
+++ b/backend/pkg/analytics/charts/query_sqli_test.go
@@ -166,8 +166,8 @@ func TestUserJourneyMetricValueNotInjectable(t *testing.T) {
 		StartTimestamp: 1704067200000,
 		EndTimestamp:   1704153600000,
 		Density:        2,
-		MetricValue:    []string{"x' OR 1=1 OR '"},
-		Series:         []model.Series{{Name: "s1", Filter: model.FilterGroup{}}},
+		MetricValue: []string{"x' OR 1=1 OR '", "CLICK"},
+		Series:      []model.Series{{Name: "s1", Filter: model.FilterGroup{}}},
 	}
 	p := &Payload{MetricPayload: payload, ProjectId: 1, UserId: 1}
 
@@ -176,6 +176,9 @@ func TestUserJourneyMetricValueNotInjectable(t *testing.T) {
 		t.Fatalf("buildQuery error: %v", err)
 	}
 	joined := strings.Join(queries, "\n")
+	if !strings.Contains(joined, "multiIf(") {
+		t.Fatalf("expected multiIf branch to be exercised:\n%s", joined)
+	}
 	// The malicious event name may only appear inside a quoted literal (escaped).
 	// Nothing from the payload may reach unquoted SQL expression position.
 	bare := stripSQLLiterals(joined)

--- a/backend/pkg/analytics/charts/query_sqli_test.go
+++ b/backend/pkg/analytics/charts/query_sqli_test.go
@@ -159,3 +159,50 @@ func TestIsMetadataColumn(t *testing.T) {
 		}
 	}
 }
+
+func TestUserJourneyMetricValueNotInjectable(t *testing.T) {
+	h := &UserJourneyQueryBuilder{}
+	payload := &model.MetricPayload{
+		StartTimestamp: 1704067200000,
+		EndTimestamp:   1704153600000,
+		Density:        2,
+		MetricValue:    []string{"x' OR 1=1 OR '"},
+		Series:         []model.Series{{Name: "s1", Filter: model.FilterGroup{}}},
+	}
+	p := &Payload{MetricPayload: payload, ProjectId: 1, UserId: 1}
+
+	queries, err := h.buildQuery(p)
+	if err != nil {
+		t.Fatalf("buildQuery error: %v", err)
+	}
+	joined := strings.Join(queries, "\n")
+	// The malicious event name may only appear inside a quoted literal (escaped).
+	// Nothing from the payload may reach unquoted SQL expression position.
+	bare := stripSQLLiterals(joined)
+	if strings.Contains(bare, "OR 1=1") {
+		t.Errorf("user-journey MetricValue injection survived:\n%s", joined)
+	}
+}
+
+func TestUserJourneyExcludeNameNotInjectable(t *testing.T) {
+	h := &UserJourneyQueryBuilder{}
+	mal := "y' OR 1=1 OR '"
+	payload := &model.MetricPayload{
+		StartTimestamp: 1704067200000,
+		EndTimestamp:   1704153600000,
+		Density:        2,
+		MetricValue:    []string{mal},
+		Exclude:        []model.Filter{{Name: mal, Operator: "is", Value: []string{"v"}}},
+		Series:         []model.Series{{Name: "s1", Filter: model.FilterGroup{}}},
+	}
+	p := &Payload{MetricPayload: payload, ProjectId: 1, UserId: 1}
+
+	queries, err := h.buildQuery(p)
+	if err != nil {
+		t.Fatalf("buildQuery error: %v", err)
+	}
+	bare := stripSQLLiterals(strings.Join(queries, "\n"))
+	if strings.Contains(bare, "OR 1=1") {
+		t.Errorf("user-journey Exclude.Name injection survived:\n%s", strings.Join(queries, "\n"))
+	}
+}


### PR DESCRIPTION
Event names supplied via MetricValue and Exclude filters were interpolated into ClickHouse string literals verbatim. Route them through sqlStringReplacer like the other string literals in the package, and add regression tests over buildQuery.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a SQL injection vulnerability in user journey queries where event names from `MetricValue` and `Exclude` filters were interpolated into ClickHouse literals verbatim. They now go through `sqlStringReplacer` like other string literals.

- Adds regression tests covering injection attempts via `buildQuery`, including the `multiIf` branch and the exclusion path.

<sup>Written for commit dbedbac684f426426a300e2ba8c5e7fdc60068b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

