### PR TITLE
Added a safe http client and extra URL check

### DIFF
--- a/backend/pkg/integrations/clients/datadog.go
+++ b/backend/pkg/integrations/clients/datadog.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 )
+
+var validDatadogSite = regexp.MustCompile(`^[a-zA-Z0-9.-]+$`)
 
 type dataDogClient struct{}
 
@@ -55,12 +58,16 @@ func (d *dataDogClient) FetchSessionData(credentials interface{}, sessionID uint
 		body.Filter.Query = datadog.PtrString(fmt.Sprintf("openReplaySession.id=%d", sessionID))
 		body.Page.Limit = datadog.PtrInt32(1000)
 	}
+	if !validDatadogSite.MatchString(cfg.Site) {
+		return nil, fmt.Errorf("invalid datadog site")
+	}
 	ctx := context.WithValue(context.Background(), datadog.ContextServerVariables, map[string]string{"site": cfg.Site})
 	ctx = context.WithValue(ctx, datadog.ContextAPIKeys, map[string]datadog.APIKey{
 		"apiKeyAuth": {Key: cfg.ApiKey},
 		"appKeyAuth": {Key: cfg.AppKey},
 	})
 	configuration := datadog.NewConfiguration()
+	configuration.HTTPClient = SafeHTTPClient
 	apiClient := datadog.NewAPIClient(configuration)
 	api := datadogV2.NewLogsApi(apiClient)
 	resp, r, err := api.ListLogs(ctx, *datadogV2.NewListLogsOptionalParameters().WithBody(body))

--- a/backend/pkg/integrations/clients/dynatrace.go
+++ b/backend/pkg/integrations/clients/dynatrace.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 )
 
 type dynatraceClient struct{}
@@ -74,8 +75,7 @@ func (d *dynatraceClient) requestOAuthToken(clientID, clientSecret, resource str
 	}
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	client := &http.Client{}
-	response, err := client.Do(request)
+	response, err := SafeHTTPClient.Do(request)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,12 @@ func requestParams(sessionID uint64) url.Values {
 	return params
 }
 
+var validEnvironmentID = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
+
 func (d *dynatraceClient) requestLogs(token, environmentID string, sessionID uint64) (interface{}, error) {
+	if !validEnvironmentID.MatchString(environmentID) {
+		return nil, fmt.Errorf("invalid dynatrace environment id")
+	}
 	requestURL := fmt.Sprintf("https://%s.live.dynatrace.com/api/v2/logs/search", environmentID)
 	if sessionID == 0 {
 		requestURL += "?" + testRequestParams().Encode()
@@ -129,8 +134,7 @@ func (d *dynatraceClient) requestLogs(token, environmentID string, sessionID uin
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
-	client := &http.Client{}
-	response, err := client.Do(request)
+	response, err := SafeHTTPClient.Do(request)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/integrations/clients/elastic.go
+++ b/backend/pkg/integrations/clients/elastic.go
@@ -44,11 +44,15 @@ func (e *elasticsearchClient) FetchSessionData(credentials interface{}, sessionI
 			cfg.Indexes = val
 		}
 	}
+	if err := validateExternalURL(cfg.URL); err != nil {
+		return nil, fmt.Errorf("invalid elasticsearch url: %w", err)
+	}
 	clientCfg := elasticsearch.Config{
 		Addresses: []string{
 			cfg.URL,
 		},
-		APIKey: base64.StdEncoding.EncodeToString([]byte(cfg.APIKeyId + ":" + cfg.APIKey)),
+		APIKey:    base64.StdEncoding.EncodeToString([]byte(cfg.APIKeyId + ":" + cfg.APIKey)),
+		Transport: SafeTransport,
 	}
 
 	// Create Elasticsearch client

--- a/backend/pkg/integrations/clients/httpclient.go
+++ b/backend/pkg/integrations/clients/httpclient.go
@@ -1,0 +1,93 @@
+package clients
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"syscall"
+	"time"
+)
+
+func isBlockedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() {
+		return true
+	}
+	if ip.Equal(net.IPv4(169, 254, 169, 254)) {
+		return true
+	}
+	return false
+}
+
+func safeDialControl(network, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("could not parse resolved address %q", address)
+	}
+	if isBlockedIP(ip) {
+		return fmt.Errorf("refusing to connect to non-public address %s", ip)
+	}
+	return nil
+}
+
+var SafeTransport = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	DialContext: (&net.Dialer{
+		Timeout:   5 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   safeDialControl,
+	}).DialContext,
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   5 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
+}
+
+var SafeHTTPClient = &http.Client{
+	Timeout:   10 * time.Second,
+	Transport: SafeTransport,
+	CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+func validateExternalURL(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("unsupported url scheme %q (only http/https allowed)", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("url has no host")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if isBlockedIP(ip) {
+			return fmt.Errorf("url points to a non-public address")
+		}
+		return nil
+	}
+	if ips, err := net.LookupIP(host); err == nil {
+		for _, ip := range ips {
+			if isBlockedIP(ip) {
+				return fmt.Errorf("url resolves to a non-public address")
+			}
+		}
+	}
+	return nil
+}

--- a/backend/pkg/integrations/clients/sentry.go
+++ b/backend/pkg/integrations/clients/sentry.go
@@ -86,6 +86,9 @@ func parseSentryConfig(credentials interface{}) (sentryConfig, error) {
 	if cfg.URL == "" {
 		cfg.URL = "https://sentry.io"
 	}
+	if err := validateExternalURL(cfg.URL); err != nil {
+		return cfg, fmt.Errorf("invalid sentry url: %w", err)
+	}
 	return cfg, nil
 }
 
@@ -115,8 +118,7 @@ func makeRequest(cfg sentryConfig, requestUrl string) ([]SentryEvent, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := SafeHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %v", err)
 	}

--- a/backend/pkg/integrations/service/service.go
+++ b/backend/pkg/integrations/service/service.go
@@ -49,16 +49,26 @@ func (s *serviceImpl) AddIntegration(projectID uint64, provider string, data int
 	case data == nil:
 		return errors.New("data is empty")
 	}
-	sql := `INSERT INTO public.integrations (project_id, provider, options) VALUES ($1, $2, $3)`
-	if err := s.conn.Exec(sql, projectID, provider, data); err != nil {
-		return fmt.Errorf("failed to add integration: %v", err)
-	}
-	// Check that provided credentials are valid
-	_, err := s.fetchSessionData(provider, data, 0)
-	if err != nil {
+	creds := normalizeCredentials(data)
+	if _, err := s.fetchSessionData(provider, creds, 0); err != nil {
 		return fmt.Errorf("failed to validate provider credentials: %v", err)
 	}
+	sql := `INSERT INTO public.integrations (project_id, provider, options) VALUES ($1, $2, $3)`
+	if err := s.conn.Exec(sql, projectID, provider, creds); err != nil {
+		return fmt.Errorf("failed to add integration: %v", err)
+	}
 	return nil
+}
+
+func normalizeCredentials(data interface{}) interface{} {
+	if m, ok := data.(map[string]string); ok {
+		out := make(map[string]interface{}, len(m))
+		for k, v := range m {
+			out[k] = v
+		}
+		return out
+	}
+	return data
 }
 
 func (s *serviceImpl) GetIntegration(projectID uint64, provider string) (interface{}, error) {
@@ -89,8 +99,12 @@ func (s *serviceImpl) UpdateIntegration(projectID uint64, provider string, data 
 	case data == nil:
 		return errors.New("data is empty")
 	}
+	creds := normalizeCredentials(data)
+	if _, err := s.fetchSessionData(provider, creds, 0); err != nil {
+		return fmt.Errorf("failed to validate provider credentials: %v", err)
+	}
 	sql := `UPDATE public.integrations SET options = $1 WHERE project_id = $2 AND provider = $3`
-	if err := s.conn.Exec(sql, data, projectID, provider); err != nil {
+	if err := s.conn.Exec(sql, creds, projectID, provider); err != nil {
 		return fmt.Errorf("failed to update integration: %v", err)
 	}
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds SSRF protection to integration clients by routing all outbound requests through a shared HTTP client that blocks non-public IPs and validates external URLs. Also reorders credential validation to happen before the integration is stored.

**SSRF hardening**
- The safe client rejects redirects, has a 10s timeout, and blocks loopback, private, link-local, and metadata addresses.
- `validateExternalURL` accepts only `http`/`https` and rejects hosts that resolve to non-public IPs.
- Datadog, Dynatrace, Elasticsearch, and Sentry now use this client and validate provider-specific URL fields.

<sup>Written for commit 956eed2a47027e25e23f08151acf0dc80c52575f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

