### PR TITLE
fix(integrations): added IPv6 support to the prev fix

### DIFF
--- a/backend/pkg/integrations/clients/httpclient.go
+++ b/backend/pkg/integrations/clients/httpclient.go
@@ -21,7 +21,47 @@ func isBlockedIP(ip net.IP) bool {
 	if ip.Equal(net.IPv4(169, 254, 169, 254)) {
 		return true
 	}
+	if ip4 := ip.To4(); ip4 != nil && ip4[0] == 100 && ip4[1] >= 64 && ip4[1] <= 127 {
+		return true
+	}
+	if ip.To4() == nil {
+		if ip16 := ip.To16(); ip16 != nil && ip16[0] == 0xfe && ip16[1]&0xc0 == 0xc0 {
+			return true
+		}
+	}
+	if embedded := embeddedIPv4(ip); embedded != nil {
+		return isBlockedIP(embedded)
+	}
 	return false
+}
+
+func embeddedIPv4(ip net.IP) net.IP {
+	ip16 := ip.To16()
+	if ip16 == nil || ip.To4() != nil {
+		return nil
+	}
+	switch {
+	case ip16[0] == 0x20 && ip16[1] == 0x02: // 6to4, 2002::/16
+		return net.IPv4(ip16[2], ip16[3], ip16[4], ip16[5])
+	case ip16[0] == 0x00 && ip16[1] == 0x64 && ip16[2] == 0xff && ip16[3] == 0x9b: // NAT64, 64:ff9b::/96
+		if allZero(ip16[4:12]) {
+			return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+		}
+	case ip16[0] == 0x20 && ip16[1] == 0x01 && ip16[2] == 0x00 && ip16[3] == 0x00: // Teredo, 2001:0000::/32
+		return net.IPv4(ip16[12]^0xff, ip16[13]^0xff, ip16[14]^0xff, ip16[15]^0xff)
+	case allZero(ip16[0:12]): // IPv4-compatible, ::/96 (deprecated)
+		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+	}
+	return nil
+}
+
+func allZero(b []byte) bool {
+	for _, x := range b {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func safeDialControl(network, address string, _ syscall.RawConn) error {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the SSRF protection so IPv6 addresses can no longer bypass the IPv4 blocklist. The fix unwraps IPv4 addresses embedded in 6to4, NAT64, Teredo, and IPv4-compatible IPv6 forms and rechecks them, and also blocks the IPv4 shared address space (100.64.0.0/10) and IPv6 unique local addresses (fc00::/7).

<sup>Written for commit fe0bdd1e63ec790e1f626eeb38d7c87bb3b8b86c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

