### PR TITLE
Updated patch build from main 25cac8af41e672a0c9a65f21e54debd50c90cc59

### DIFF
--- a/scripts/helmcharts/openreplay/charts/integrations/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/integrations/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.1"
+AppVersion: "v1.27.2"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the `integrations` Helm chart `AppVersion` to `v1.27.2` for the patch build from `main`.

<sup>Written for commit 33f5daa779bb74e5d33aa1b6d00cc0b310b23a0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

