### PR TITLE
Reworked all the backend metrics

### DIFF
--- a/assist/utils/metrics.js
+++ b/assist/utils/metrics.js
@@ -43,20 +43,6 @@ const IncreaseTotalWSConnections = function (type) {
     websocketTotalConnections.inc({type: type});
 }
 
-const websocketOnlineConnections = new client.Gauge({
-    name: 'ws_connections_online',
-    help: 'A gauge displaying the number of online (active) connections',
-    labelNames: ['type'], // tab, agent
-});
-
-const IncreaseOnlineConnections = function (type) {
-    websocketOnlineConnections.inc({type: type});
-}
-
-const DecreaseOnlineConnections = function (type) {
-    websocketOnlineConnections.dec({type: type});
-}
-
 const websocketTotalRooms = new client.Counter({
     name: 'ws_rooms_total',
     help: 'A counter displaying the number of all rooms',
@@ -66,34 +52,16 @@ const IncreaseTotalRooms = function () {
     websocketTotalRooms.inc();
 }
 
-const websocketOnlineRooms = new client.Gauge({
-    name: 'ws_rooms_online',
-    help: 'A gauge displaying the number of online (active) rooms',
-});
-
-const IncreaseOnlineRooms = function () {
-    websocketOnlineRooms.inc();
-}
-
-const DecreaseOnlineRooms = function () {
-    websocketOnlineRooms.dec();
-}
 
 register.registerMetric(httpRequestDuration);
 register.registerMetric(httpTotalRequests);
 register.registerMetric(websocketTotalConnections);
-register.registerMetric(websocketOnlineConnections);
 register.registerMetric(websocketTotalRooms);
-register.registerMetric(websocketOnlineRooms);
 
 module.exports = {
     register,
     RecordRequestDuration,
     IncreaseTotalRequests,
     IncreaseTotalWSConnections,
-    IncreaseOnlineConnections,
-    DecreaseOnlineConnections,
     IncreaseTotalRooms,
-    IncreaseOnlineRooms,
-    DecreaseOnlineRooms,
 }

--- a/assist/utils/socketHandlers.js
+++ b/assist/utils/socketHandlers.js
@@ -17,11 +17,7 @@ const {
 } = require('../utils/wsServer');
 const {
     IncreaseTotalWSConnections,
-    IncreaseOnlineConnections,
-    DecreaseOnlineConnections,
     IncreaseTotalRooms,
-    IncreaseOnlineRooms,
-    DecreaseOnlineRooms,
 } = require('../utils/metrics');
 const {logger} = require('./logger');
 const deepMerge = require('@fastify/deepmerge')({all: true});
@@ -81,7 +77,6 @@ async function onConnect(socket) {
     logger.debug(`WS started:${socket.id}, Query:${JSON.stringify(socket.handshake.query)}`);
     processNewSocket(socket);
     IncreaseTotalWSConnections(socket.handshake.query.identity);
-    IncreaseOnlineConnections(socket.handshake.query.identity);
 
     const io = getServer();
     const {tabsCount, agentsCount, tabIDs, agentInfos, agentIDs, config} = await getRoomData(io, socket.handshake.query.roomId);
@@ -101,7 +96,6 @@ async function onConnect(socket) {
         if (tabsCount < 0) {
             // New session creates new room
             IncreaseTotalRooms();
-            IncreaseOnlineRooms();
         }
         // Inform all connected agents about reconnected session
         if (agentsCount > 0) {
@@ -149,7 +143,6 @@ async function onConnect(socket) {
 }
 
 async function onDisconnect(socket) {
-    DecreaseOnlineConnections(socket.handshake.query.identity);
     logger.debug(`${socket.id} disconnected from ${socket.handshake.query.roomId}`);
 
     if (socket.handshake.query.identity === IDENTITIES.agent) {
@@ -162,7 +155,6 @@ async function onDisconnect(socket) {
     let {tabsCount, agentsCount, tabIDs, agentIDs} = await getRoomData(io, socket.handshake.query.roomId);
 
     if (tabsCount === -1 && agentsCount === -1) {
-        DecreaseOnlineRooms();
         logger.debug(`room not found: ${socket.handshake.query.roomId}`);
         return;
     }

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -12,6 +12,7 @@ import (
 	"openreplay/backend/pkg/health"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/metrics"
+	assistMetrics "openreplay/backend/pkg/metrics/assist"
 	"openreplay/backend/pkg/metrics/database"
 	"openreplay/backend/pkg/metrics/web"
 	"openreplay/backend/pkg/objectstorage/store"
@@ -31,7 +32,8 @@ func main() {
 
 	webMetrics := web.New("api")
 	dbMetric := database.New("api")
-	metrics.New(log, append(webMetrics.List(), dbMetric.List()...))
+	assistMetric := assistMetrics.New("assist")
+	metrics.New(log, append(append(webMetrics.List(), dbMetric.List()...), assistMetric.List()...))
 
 	pgPool, err := pool.New(dbMetric, cfg.Postgres.String())
 	if err != nil {
@@ -81,7 +83,7 @@ func main() {
 		log.Fatal(ctx, "can't init project service: %s", err)
 	}
 
-	services, err := apiService.NewServiceBuilder(log, cfg, webMetrics, pgPool, redisClient, chConnection, chSessionFactory, objStore, projects, canvases)
+	services, err := apiService.NewServiceBuilder(log, cfg, webMetrics, assistMetric, pgPool, redisClient, chConnection, chSessionFactory, objStore, projects, canvases)
 	if err != nil {
 		log.Fatal(ctx, "can't init services and handlers: %s", err)
 	}

--- a/backend/cmd/db/main.go
+++ b/backend/cmd/db/main.go
@@ -86,7 +86,7 @@ func main() {
 		log.Fatal(ctx, "can't init users: %s", err)
 	}
 
-	saver := datasaver.New(log, cfg, chConnector, sessManager, issuesManager, tagsManager, canvases, users)
+	saver := datasaver.New(log, cfg, chConnector, sessManager, issuesManager, tagsManager, canvases, users, dbMetric)
 
 	msgFilter := []int{
 		// Web messages

--- a/backend/cmd/ender/main.go
+++ b/backend/cmd/ender/main.go
@@ -131,6 +131,7 @@ func main() {
 				return processEndedBatch(ctx, candidates, sessManager, producer, cfg, log, details, cleanupRegistry)
 			})
 			details.Log(log, ctx)
+			details.Record(enderMetric)
 			producer.Flush(cfg.ProducerTimeout)
 			if err := consumer.CommitBack(ender.EVENTS_BACK_COMMIT_GAP); err != nil {
 				log.Error(ctx, "can't commit messages with offset: %s", err)
@@ -162,6 +163,7 @@ func processEndedBatch(
 	}
 	loaded, err := sessManager.GetManySessions(ids)
 	if err != nil {
+		details.LoadErrors += len(ids)
 		log.Error(ctx, "can't get sessions from database: %s", err)
 		return map[uint64]bool{}
 	}

--- a/backend/cmd/sink/main.go
+++ b/backend/cmd/sink/main.go
@@ -106,6 +106,8 @@ func main() {
 			stats := mobWriter.Sync()
 			sinkMetrics.RecordOpenFiles(float64(stats.OpenFiles), float64(stats.FilesLimit))
 			sinkMetrics.IncreaseFileEvictions(float64(stats.Evicted))
+			sinkMetrics.RecordSyncDuration(float64(stats.Duration.Milliseconds()))
+			sinkMetrics.IncreaseSyncedBytes(float64(stats.BytesSynced))
 			log.Info(ctx, "manual sync finished, fds=%d/%d, synced=%d, evicted=%d, size=%.2fMB, dur=%dms",
 				stats.OpenFiles, stats.FilesLimit, stats.FilesSynced, stats.Evicted,
 				float64(stats.BytesSynced)/(1024*1024), stats.Duration.Milliseconds())
@@ -141,10 +143,12 @@ func main() {
 			stats := mobWriter.Sync()
 			sinkMetrics.RecordOpenFiles(float64(stats.OpenFiles), float64(stats.FilesLimit))
 			sinkMetrics.IncreaseFileEvictions(float64(stats.Evicted))
+			sinkMetrics.RecordSyncDuration(float64(stats.Duration.Milliseconds()))
+			sinkMetrics.IncreaseSyncedBytes(float64(stats.BytesSynced))
 			log.Info(ctx, "sync: fds=%d/%d, synced=%d, evicted=%d, size=%.2fMB, dur=%dms",
 				stats.OpenFiles, stats.FilesLimit, stats.FilesSynced, stats.Evicted,
 				float64(stats.BytesSynced)/(1024*1024), stats.Duration.Milliseconds())
-			mobWriter.EvictStale(cfg.SessionTTL)
+			sinkMetrics.IncreaseStaleSessionsEvicted(float64(mobWriter.EvictStale(cfg.SessionTTL)))
 			if err := consumer.Commit(); err != nil {
 				log.Error(ctx, "can't commit messages: %s", err)
 			}

--- a/backend/cmd/storage/main.go
+++ b/backend/cmd/storage/main.go
@@ -102,7 +102,9 @@ func main() {
 		case <-counterTick:
 			log.Info(ctx, "count: %d", counter)
 			counter = 0
+			drainStart := time.Now()
 			srv.Wait()
+			storageMetric.RecordDrainDuration(float64(time.Since(drainStart).Milliseconds()))
 			if err := consumer.Commit(); err != nil {
 				log.Error(ctx, "can't commit messages: %s", err)
 			}

--- a/backend/internal/db/datasaver/saver.go
+++ b/backend/internal/db/datasaver/saver.go
@@ -13,6 +13,7 @@ import (
 	"openreplay/backend/pkg/issues"
 	"openreplay/backend/pkg/logger"
 	. "openreplay/backend/pkg/messages"
+	"openreplay/backend/pkg/metrics/database"
 	queue "openreplay/backend/pkg/queue/types"
 	"openreplay/backend/pkg/sessions"
 	"openreplay/backend/pkg/tags"
@@ -35,9 +36,10 @@ type saverImpl struct {
 	canvases canvas.Canvases
 	users    service.Users
 	builders *builders
+	metrics  database.Database
 }
 
-func New(log logger.Logger, cfg *db.Config, ch clickhouse.Connector, session sessions.Sessions, issues issues.Issues, tags tags.Tags, canvases canvas.Canvases, users service.Users) Saver {
+func New(log logger.Logger, cfg *db.Config, ch clickhouse.Connector, session sessions.Sessions, issues issues.Issues, tags tags.Tags, canvases canvas.Canvases, users service.Users, metrics database.Database) Saver {
 	if ch == nil {
 		log.Fatal(context.Background(), "ch pool is empty")
 	}
@@ -50,9 +52,17 @@ func New(log logger.Logger, cfg *db.Config, ch clickhouse.Connector, session ses
 		tags:     tags,
 		canvases: canvases,
 		users:    users,
+		metrics:  metrics,
 	}
 	s.builders = newBuilders(log, s.Handle)
 	return s
+}
+
+func platformOf(msg Message) string {
+	if IsMobileType(msg.TypeID()) {
+		return "mobile"
+	}
+	return "web"
 }
 
 func (s *saverImpl) Handle(msg Message) {
@@ -64,6 +74,7 @@ func (s *saverImpl) Handle(msg Message) {
 		err     error
 	)
 	if msg.TypeID() == MsgSessionEnd || msg.TypeID() == MsgMobileSessionEnd {
+		s.log.Info(sessCtx, "SE_TRACE stage=db_received sessID=%d", msg.SessionID())
 		issueTypes, err := s.issues.Get(msg.SessionID())
 		if err != nil {
 			s.log.Warn(sessCtx, "issue types get error: %s", err)
@@ -73,6 +84,10 @@ func (s *saverImpl) Handle(msg Message) {
 		session, err = s.sessions.Get(msg.SessionID())
 	}
 	if err != nil || session == nil {
+		if msg.TypeID() == MsgSessionEnd || msg.TypeID() == MsgMobileSessionEnd {
+			s.log.Error(sessCtx, "SE_TRACE stage=db_dropped reason=no_session sessID=%d err=%v", msg.SessionID(), err)
+		}
+		s.metrics.IncreaseSaverMessages(platformOf(msg), database.MessageNoSession)
 		s.log.Error(sessCtx, "error on session retrieving from cache: %v, SessionID: %v, Message: %v", err, msg.SessionID(), msg)
 		return
 	}
@@ -94,18 +109,26 @@ func (s *saverImpl) Handle(msg Message) {
 
 	if IsMobileType(msg.TypeID()) {
 		if err := s.handleMobileMessage(session, msg); err != nil {
-			if !postgres.IsPkeyViolation(err) {
+			if postgres.IsPkeyViolation(err) {
+				s.metrics.IncreaseSaverMessages("mobile", database.MessageDuplicate)
+			} else {
+				s.metrics.IncreaseSaverMessages("mobile", database.MessageError)
 				s.log.Error(sessCtx, "mobile message insertion error, msg: %+v, err: %.200s", msg, err)
 			}
 			return
 		}
+		s.metrics.IncreaseSaverMessages("mobile", database.MessageSaved)
 	} else {
 		if err := s.handleWebMessage(session, msg); err != nil {
-			if !postgres.IsPkeyViolation(err) {
+			if postgres.IsPkeyViolation(err) {
+				s.metrics.IncreaseSaverMessages("web", database.MessageDuplicate)
+			} else {
+				s.metrics.IncreaseSaverMessages("web", database.MessageError)
 				s.log.Error(sessCtx, "web message insertion error, msg: %+v, err: %.200s", msg, err)
 			}
 			return
 		}
+		s.metrics.IncreaseSaverMessages("web", database.MessageSaved)
 	}
 	return
 }

--- a/backend/internal/ender/ender.go
+++ b/backend/internal/ender/ender.go
@@ -55,16 +55,14 @@ func (se *SessionEnder) ActivePartitions(parts []uint64) {
 		activeParts[p] = true
 	}
 	removedSessions := 0
-	activeSessions := 0
-	for sessID, _ := range se.sessions {
+	for sessID := range se.sessions {
 		if !activeParts[sessID%se.parts] {
 			delete(se.sessions, sessID)
 			se.metrics.DecreaseActiveSessions()
 			removedSessions++
-		} else {
-			activeSessions++
 		}
 	}
+	se.metrics.IncreaseRebalanceEvictions(float64(removedSessions))
 }
 
 // UpdateSession save timestamp for new sessions and update for existing sessions
@@ -147,7 +145,6 @@ func (se *SessionEnder) HandleEndedSessions(handler EndedSessionHandler) {
 		if completed {
 			delete(se.sessions, sessID)
 			se.metrics.DecreaseActiveSessions()
-			se.metrics.IncreaseClosedSessions()
 		}
 	}
 }

--- a/backend/internal/ender/logdetails.go
+++ b/backend/internal/ender/logdetails.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"openreplay/backend/pkg/logger"
+	"openreplay/backend/pkg/metrics/ender"
 )
 
 type SessionEndType int
@@ -19,14 +20,32 @@ const (
 )
 
 type LogDetails struct {
-	Failed     map[uint64]uint64
-	Duplicated map[uint64]uint64
-	Negative   map[uint64]uint64
-	Shorter    map[uint64]int64
-	NotFound   map[uint64]uint64
-	Diff       map[uint64]int64
-	Updated    int
-	New        int
+	Failed              map[uint64]uint64
+	Duplicated          map[uint64]uint64
+	Negative            map[uint64]uint64
+	Shorter             map[uint64]int64
+	NotFound            map[uint64]uint64
+	Diff                map[uint64]int64
+	Updated             int
+	New                 int
+	LoadErrors          int
+	UpdateErrors        int
+	ProduceErrors       int
+	ProduceCanvasErrors int
+}
+
+func (l *LogDetails) Record(m ender.Ender) {
+	m.IncreaseSessionEnds(ender.EndNew, float64(l.New))
+	m.IncreaseSessionEnds(ender.EndUpdated, float64(l.Updated))
+	m.IncreaseSessionEnds(ender.EndDuplicate, float64(len(l.Duplicated)))
+	m.IncreaseSessionEnds(ender.EndShorter, float64(len(l.Shorter)))
+	m.IncreaseSessionEnds(ender.EndNotFound, float64(len(l.NotFound)))
+	m.IncreaseSessionEnds(ender.EndFailed, float64(len(l.Failed)))
+	m.IncreaseSessionEnds(ender.EndNegative, float64(len(l.Negative)))
+	m.IncreaseEndErrors(ender.StageLoad, float64(l.LoadErrors))
+	m.IncreaseEndErrors(ender.StageUpdate, float64(l.UpdateErrors))
+	m.IncreaseEndErrors(ender.StageProduce, float64(l.ProduceErrors))
+	m.IncreaseEndErrors(ender.StageProduceCanvas, float64(l.ProduceCanvasErrors))
 }
 
 func NewLogDetails() *LogDetails {

--- a/backend/internal/ender/processor.go
+++ b/backend/internal/ender/processor.go
@@ -137,6 +137,7 @@ func ProcessEndedSession(
 			details.NotFound[sessionID] = timestamp
 			return true
 		}
+		details.UpdateErrors++
 		log.Error(ctx, "can't update session duration, err: %s", err)
 		return false
 	}
@@ -177,18 +178,22 @@ func emitSessionEnd(
 	if sess.Platform == "ios" || sess.Platform == "android" {
 		mobileMsg := &messages.MobileSessionEnd{Timestamp: timestamp}
 		if err := producer.Produce(cfg.TopicRawMobile, sessionID, mobileMsg.Encode()); err != nil {
+			details.ProduceErrors++
 			log.Error(ctx, "can't send MobileSessionEnd to mobile topic: %s", err)
 			return false
 		}
 		if err := producer.Produce(cfg.TopicRawImages, sessionID, mobileMsg.Encode()); err != nil {
+			details.ProduceCanvasErrors++
 			log.Error(ctx, "can't send MobileSessionEnd signal to canvas topic: %s", err)
 		}
 	} else {
 		if err := producer.Produce(cfg.TopicRawAssets, sessionID, msg.Encode()); err != nil {
+			details.ProduceErrors++
 			log.Error(ctx, "can't send sessionEnd to raw topic: %s", err)
 			return false
 		}
 		if err := producer.Produce(cfg.TopicCanvasImages, sessionID, msg.Encode()); err != nil {
+			details.ProduceCanvasErrors++
 			log.Error(ctx, "can't send sessionEnd signal to canvas topic: %s", err)
 		}
 	}

--- a/backend/internal/http/services/services.go
+++ b/backend/internal/http/services/services.go
@@ -55,10 +55,10 @@ func New(log logger.Logger, cfg *http.Config, webMetrics web.Web, dbMetrics data
 	responser := api.NewResponser(webMetrics)
 	cleanupReg := registry.New(log, redis)
 	builder := &serviceBuilder{}
-	if builder.webAPI, err = websessions.NewHandlers(cfg, log, responser, producer, projs, sessions, uaModule, geoModule, tokenizer, conditions, flaker, cleanupReg); err != nil {
+	if builder.webAPI, err = websessions.NewHandlers(cfg, log, responser, producer, projs, sessions, uaModule, geoModule, tokenizer, conditions, flaker, cleanupReg, webMetrics); err != nil {
 		return nil, err
 	}
-	if builder.mobileAPI, err = mobilesessions.NewHandlers(cfg, log, responser, producer, projs, sessions, uaModule, geoModule, tokenizer, conditions, flaker, cleanupReg); err != nil {
+	if builder.mobileAPI, err = mobilesessions.NewHandlers(cfg, log, responser, producer, projs, sessions, uaModule, geoModule, tokenizer, conditions, flaker, cleanupReg, webMetrics); err != nil {
 		return nil, err
 	}
 	if builder.conditionsAPI, err = conditionsAPI.NewHandlers(log, responser, tokenizer, conditions); err != nil {

--- a/backend/internal/sink/sessionwriter/mobwriter.go
+++ b/backend/internal/sink/sessionwriter/mobwriter.go
@@ -166,9 +166,9 @@ func (w *MobWriter) Sync() SyncStats {
 	return w.pool.Sync()
 }
 
-func (w *MobWriter) EvictStale(ttl time.Duration) {
+func (w *MobWriter) EvictStale(ttl time.Duration) int {
 	if ttl <= 0 {
-		return
+		return 0
 	}
 	now := time.Now().UnixNano()
 	cutoff := now - ttl.Nanoseconds()
@@ -199,6 +199,7 @@ func (w *MobWriter) EvictStale(ttl time.Duration) {
 			"evicted %d sessions by TTL (oldest: %s ago)",
 			evicted, time.Duration(oldest).Round(time.Second))
 	}
+	return evicted
 }
 
 func (w *MobWriter) Stop() {

--- a/backend/pkg/api/builder.go
+++ b/backend/pkg/api/builder.go
@@ -35,6 +35,7 @@ import (
 	favoriteAPI "openreplay/backend/pkg/favorite/api"
 	"openreplay/backend/pkg/jobs"
 	"openreplay/backend/pkg/logger"
+	assistMetrics "openreplay/backend/pkg/metrics/assist"
 	"openreplay/backend/pkg/metrics/web"
 	"openreplay/backend/pkg/notes"
 	noteAPI "openreplay/backend/pkg/notes/api"
@@ -74,7 +75,7 @@ func (b *serviceBuilder) Handlers() []api.Handlers {
 		b.chartsAPI, b.dashboardsAPI, b.cardsAPI, b.searchAPI, b.savedSearchesAPI, b.usersAPI, b.lexiconAPI, b.tagsAdminAPI}
 }
 
-func NewServiceBuilder(log logger.Logger, cfg *config.Config, webMetrics web.Web, pgconn pool.Pool, redisClient *redis.Client, chconn clickhouse.Conn, chSessionFactory chdb.SessionFactory, objStore objectstorage.ObjectStorage, projects projects.Projects, canvases canvas.Canvases) (api.ServiceBuilder, error) {
+func NewServiceBuilder(log logger.Logger, cfg *config.Config, webMetrics web.Web, assistMetric assistMetrics.Assist, pgconn pool.Pool, redisClient *redis.Client, chconn clickhouse.Conn, chSessionFactory chdb.SessionFactory, objStore objectstorage.ObjectStorage, projects projects.Projects, canvases canvas.Canvases) (api.ServiceBuilder, error) {
 	responser := api.NewResponser(webMetrics)
 
 	reqValidator := validator.New()
@@ -86,7 +87,7 @@ func NewServiceBuilder(log logger.Logger, cfg *config.Config, webMetrics web.Web
 		return nil, fmt.Errorf("failed to create view service: %s", err)
 	}
 
-	assistService, err := assist.NewAssist(log, cfg, pgconn, redisClient, projects)
+	assistService, err := assist.NewAssist(log, cfg, pgconn, redisClient, projects, assistMetric)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create assist service: %s", err)
 	}

--- a/backend/pkg/assist/factory.go
+++ b/backend/pkg/assist/factory.go
@@ -5,9 +5,10 @@ import (
 	"openreplay/backend/pkg/db/postgres/pool"
 	"openreplay/backend/pkg/db/redis"
 	"openreplay/backend/pkg/logger"
+	assistMetrics "openreplay/backend/pkg/metrics/assist"
 	"openreplay/backend/pkg/projects"
 )
 
-func NewAssist(log logger.Logger, cfg *config.Config, pgconn pool.Pool, redisClient *redis.Client, projects projects.Projects) (Assist, error) {
+func NewAssist(log logger.Logger, cfg *config.Config, pgconn pool.Pool, redisClient *redis.Client, projects projects.Projects, metrics assistMetrics.Assist) (Assist, error) {
 	return newProxy(log, cfg, projects)
 }

--- a/backend/pkg/canvases/service/canvas.go
+++ b/backend/pkg/canvases/service/canvas.go
@@ -100,6 +100,7 @@ func (v *ImageStorage) SaveCanvasToDisk(ctx context.Context, sessID uint64, data
 	}
 	var msg = &canvasData{}
 	if err := json.Unmarshal(data, msg); err != nil {
+		v.metrics.IncreaseFrames(canvas.FrameBadMessage)
 		return fmt.Errorf("can't parse canvas message, err: %s", err)
 	}
 	v.saverPool.Submit(&saveTask{ctx: ctx, sessionID: sessID, name: msg.Name, image: bytes.NewBuffer(msg.Data)})
@@ -142,7 +143,7 @@ func (v *ImageStorage) writeToDisk(payload interface{}) {
 	}
 
 	v.metrics.RecordCanvasImageSize(float64(task.image.Len()))
-	v.metrics.IncreaseTotalSavedImages()
+	v.metrics.IncreaseFrames(canvas.FrameSaved)
 
 	v.log.Debug(task.ctx, "canvas image saved, name: %s, size: %3.3f mb", task.name, float64(task.image.Len())/1024.0/1024.0)
 	return
@@ -172,6 +173,7 @@ func (v *ImageStorage) PrepareSessionCanvases(ctx context.Context, sessID uint64
 			Payload: dir,
 		}
 		if err := v.producer.Produce(v.cfg.TopicCanvasTrigger, sessID, msg.Encode()); err != nil {
+			v.metrics.IncreaseTriggerErrors()
 			v.log.Error(ctx, "can't send canvas trigger: %s", err)
 		}
 	}
@@ -199,9 +201,10 @@ func (v *ImageStorage) packCanvas(payload interface{}) {
 		if !strings.Contains(err.Error(), "no such file or directory") {
 			v.log.Fatal(task.ctx, "can't upload canvas, name: %s, err: %s", task.name, err)
 		}
+		v.metrics.IncreaseUploads(canvas.UploadMissing)
 		return
 	}
-	v.metrics.IncreaseTotalCreatedArchives()
+	v.metrics.IncreaseUploads(canvas.UploadOK)
 	v.metrics.RecordUploadingDuration(time.Since(start).Seconds())
 
 	v.log.Debug(task.ctx, "canvas packed and uploaded successfully in %.3fs, session: %d", time.Since(start).Seconds(), task.sessionID)

--- a/backend/pkg/db/clickhouse/connector.go
+++ b/backend/pkg/db/clickhouse/connector.go
@@ -224,6 +224,7 @@ func (c *connectorImpl) flush() {
 	c.mu.Unlock()
 	c.inflight <- struct{}{}
 	c.workerTask <- newTask
+	c.metrics.RecordCHQueueDepth(float64(len(c.workerTask)))
 }
 
 func copyOffsets(src qtypes.Offsets) qtypes.Offsets {
@@ -307,12 +308,14 @@ func (c *connectorImpl) sendBulk(b Batch) {
 			log.Fatalf("FATAL_CH_NO_SPACE: ClickHouse code 243, restarting to limit data loss: %s", err)
 		}
 		if isPermanentDataError(err) {
+			c.metrics.RecordBulkDroppedRows(float64(b.Len()), "ch", b.Table())
 			log.Printf("BROKEN_BATCH_DROPPED: table=%s rows=%d, unparseable data, dropping batch: %s", b.Table(), b.Len(), err)
 			return
 		}
 		if attempt >= maxSendAttempts {
 			log.Fatalf("FATAL_CH_SEND: table=%s giving up after %d attempts, restarting: %s", b.Table(), attempt, err)
 		}
+		c.metrics.IncreaseBulkSendRetries("ch", b.Table())
 		log.Printf("can't send batch (attempt %d): %s", attempt, err)
 		time.Sleep(backoff)
 		if backoff < sendRetryMax {

--- a/backend/pkg/images/service/image.go
+++ b/backend/pkg/images/service/image.go
@@ -90,6 +90,7 @@ type ImagesMessage struct {
 func (v *ImageStorage) Process(ctx context.Context, sessID uint64, data []byte) error {
 	var msg = &ImagesMessage{}
 	if err := json.Unmarshal(data, msg); err != nil {
+		v.metrics.IncreaseFrames(images.FrameBadMessage)
 		return fmt.Errorf("can't parse canvas message, err: %s", err)
 	}
 	v.saverPool.Submit(&saveTask{ctx: ctx, sessionID: sessID, name: msg.Name, data: msg.Data})
@@ -124,7 +125,7 @@ func (v *ImageStorage) writeToDisk(payload interface{}) {
 		v.log.Fatal(task.ctx, "can't write frame to disk, err: %s", err)
 	}
 
-	v.metrics.IncreaseTotalSavedImages()
+	v.metrics.IncreaseFrames(images.FrameSaved)
 	v.metrics.RecordSavingImageDuration(time.Since(start).Seconds())
 	return
 }
@@ -143,9 +144,10 @@ func (v *ImageStorage) sendToS3(payload interface{}) {
 		if !strings.Contains(err.Error(), "no such file or directory") {
 			v.log.Fatal(task.ctx, "can't upload image, name: %s, err: %s", task.name, err)
 		}
+		v.metrics.IncreaseUploads(images.UploadMissing)
 		return
 	}
-	v.metrics.IncreaseTotalCreatedArchives()
+	v.metrics.IncreaseUploads(images.UploadOK)
 	v.metrics.RecordUploadingDuration(time.Since(start).Seconds())
 }
 

--- a/backend/pkg/messages/iterator-sink.go
+++ b/backend/pkg/messages/iterator-sink.go
@@ -26,7 +26,6 @@ func (i *sinkIteratorImpl) handle(message Message) {
 
 func (i *sinkIteratorImpl) Iterate(batchData []byte, batchInfo *BatchInfo) {
 	i.metrics.RecordBatchSize(float64(len(batchData)))
-	i.metrics.IncreaseTotalBatches()
 	// Call core iterator
 	i.coreIterator.Iterate(batchData, batchInfo)
 	// Send batch end signal

--- a/backend/pkg/metrics/assist/metrics.go
+++ b/backend/pkg/metrics/assist/metrics.go
@@ -1,0 +1,32 @@
+package assist
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	DropParse        = "parse"
+	DropInsert       = "insert"
+	DropUpdate       = "update"
+	DropUnknownState = "unknown_state"
+)
+
+type Assist interface {
+	RecordOnlineSessions(count float64)
+	RecordNodes(count float64)
+	RecordStatsQueueDepth(count float64)
+	IncreaseStatsEvents(eventType, eventState string)
+	IncreaseStatsDropped(reason string)
+	List() []prometheus.Collector
+}
+
+type assistImpl struct{}
+
+func New(serviceName string) Assist { return &assistImpl{} }
+
+func (a *assistImpl) List() []prometheus.Collector                     { return []prometheus.Collector{} }
+func (a *assistImpl) RecordOnlineSessions(count float64)               {}
+func (a *assistImpl) RecordNodes(count float64)                        {}
+func (a *assistImpl) RecordStatsQueueDepth(count float64)              {}
+func (a *assistImpl) IncreaseStatsEvents(eventType, eventState string) {}
+func (a *assistImpl) IncreaseStatsDropped(reason string)               {}

--- a/backend/pkg/metrics/canvas/metrics.go
+++ b/backend/pkg/metrics/canvas/metrics.go
@@ -4,12 +4,20 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	FrameSaved      = "saved"
+	FrameBadMessage = "bad_message"
+	UploadOK        = "uploaded"
+	UploadMissing   = "missing"
+)
+
 type Canvas interface {
 	RecordCanvasImageSize(size float64)
-	IncreaseTotalSavedImages()
+	IncreaseFrames(outcome string)
 	RecordCanvasesPerSession(number float64)
 	RecordPreparingDuration(duration float64)
-	IncreaseTotalCreatedArchives()
+	IncreaseTriggerErrors()
+	IncreaseUploads(outcome string)
 	RecordUploadingDuration(duration float64)
 	List() []prometheus.Collector
 }
@@ -20,8 +28,9 @@ func New(serviceName string) Canvas { return &canvasImpl{} }
 
 func (c *canvasImpl) List() []prometheus.Collector             { return []prometheus.Collector{} }
 func (c *canvasImpl) RecordCanvasImageSize(size float64)       {}
-func (c *canvasImpl) IncreaseTotalSavedImages()                {}
+func (c *canvasImpl) IncreaseFrames(outcome string)            {}
 func (c *canvasImpl) RecordCanvasesPerSession(number float64)  {}
 func (c *canvasImpl) RecordPreparingDuration(duration float64) {}
-func (c *canvasImpl) IncreaseTotalCreatedArchives()            {}
+func (c *canvasImpl) IncreaseTriggerErrors()                   {}
+func (c *canvasImpl) IncreaseUploads(outcome string)           {}
 func (c *canvasImpl) RecordUploadingDuration(duration float64) {}

--- a/backend/pkg/metrics/database/metrics.go
+++ b/backend/pkg/metrics/database/metrics.go
@@ -4,6 +4,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	MessageSaved     = "saved"
+	MessageError     = "error"
+	MessageDuplicate = "duplicate"
+	MessageNoSession = "no_session"
+)
+
 type Database interface {
 	RecordBatchElements(number float64)
 	RecordBatchInsertDuration(durMillis float64)
@@ -13,6 +20,10 @@ type Database interface {
 	IncreaseTotalRequests(method, table string)
 	IncreaseRedisRequests(method, table string)
 	RecordRedisRequestDuration(durMillis float64, method, table string)
+	IncreaseSaverMessages(platform, outcome string)
+	RecordBulkDroppedRows(size float64, db, table string)
+	IncreaseBulkSendRetries(db, table string)
+	RecordCHQueueDepth(size float64)
 	List() []prometheus.Collector
 }
 
@@ -29,3 +40,7 @@ func (d *databaseImpl) RecordRequestDuration(durMillis float64, method, table st
 func (d *databaseImpl) IncreaseTotalRequests(method, table string)                         {}
 func (d *databaseImpl) IncreaseRedisRequests(method, table string)                         {}
 func (d *databaseImpl) RecordRedisRequestDuration(durMillis float64, method, table string) {}
+func (d *databaseImpl) IncreaseSaverMessages(platform, outcome string)                     {}
+func (d *databaseImpl) RecordBulkDroppedRows(size float64, db, table string)               {}
+func (d *databaseImpl) IncreaseBulkSendRetries(db, table string)                           {}
+func (d *databaseImpl) RecordCHQueueDepth(size float64)                                    {}

--- a/backend/pkg/metrics/ender/metrics.go
+++ b/backend/pkg/metrics/ender/metrics.go
@@ -2,11 +2,27 @@ package ender
 
 import "github.com/prometheus/client_golang/prometheus"
 
+const (
+	EndNew             = "new"
+	EndUpdated         = "updated"
+	EndDuplicate       = "duplicate"
+	EndShorter         = "shorter"
+	EndNotFound        = "not_found"
+	EndFailed          = "failed"
+	EndNegative        = "negative"
+	StageLoad          = "load"
+	StageUpdate        = "update"
+	StageProduce       = "produce"
+	StageProduceCanvas = "produce_canvas"
+)
+
 type Ender interface {
 	IncreaseActiveSessions()
 	DecreaseActiveSessions()
-	IncreaseClosedSessions()
 	IncreaseTotalSessions()
+	IncreaseSessionEnds(outcome string, count float64)
+	IncreaseEndErrors(stage string, count float64)
+	IncreaseRebalanceEvictions(count float64)
 	List() []prometheus.Collector
 }
 
@@ -14,8 +30,10 @@ type enderImpl struct{}
 
 func New(serviceName string) Ender { return &enderImpl{} }
 
-func (e *enderImpl) List() []prometheus.Collector { return []prometheus.Collector{} }
-func (e *enderImpl) IncreaseActiveSessions()      {}
-func (e *enderImpl) DecreaseActiveSessions()      {}
-func (e *enderImpl) IncreaseClosedSessions()      {}
-func (e *enderImpl) IncreaseTotalSessions()       {}
+func (e *enderImpl) List() []prometheus.Collector                      { return []prometheus.Collector{} }
+func (e *enderImpl) IncreaseActiveSessions()                           {}
+func (e *enderImpl) DecreaseActiveSessions()                           {}
+func (e *enderImpl) IncreaseTotalSessions()                            {}
+func (e *enderImpl) IncreaseSessionEnds(outcome string, count float64) {}
+func (e *enderImpl) IncreaseEndErrors(stage string, count float64)     {}
+func (e *enderImpl) IncreaseRebalanceEvictions(count float64)          {}

--- a/backend/pkg/metrics/images/metrics.go
+++ b/backend/pkg/metrics/images/metrics.go
@@ -4,10 +4,17 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	FrameSaved      = "saved"
+	FrameBadMessage = "bad_message"
+	UploadOK        = "uploaded"
+	UploadMissing   = "missing"
+)
+
 type Images interface {
 	RecordSavingImageDuration(duration float64)
-	IncreaseTotalSavedImages()
-	IncreaseTotalCreatedArchives()
+	IncreaseFrames(outcome string)
+	IncreaseUploads(outcome string)
 	RecordUploadingDuration(duration float64)
 	List() []prometheus.Collector
 }
@@ -18,6 +25,6 @@ func New(serviceName string) Images { return &imagesImpl{} }
 
 func (i *imagesImpl) List() []prometheus.Collector               { return []prometheus.Collector{} }
 func (i *imagesImpl) RecordSavingImageDuration(duration float64) {}
-func (i *imagesImpl) IncreaseTotalSavedImages()                  {}
-func (i *imagesImpl) IncreaseTotalCreatedArchives()              {}
+func (i *imagesImpl) IncreaseFrames(outcome string)              {}
+func (i *imagesImpl) IncreaseUploads(outcome string)             {}
 func (i *imagesImpl) RecordUploadingDuration(duration float64)   {}

--- a/backend/pkg/metrics/sink/metrics.go
+++ b/backend/pkg/metrics/sink/metrics.go
@@ -4,14 +4,17 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	MessageWritten  = "written"
+	MessageFiltered = "filtered"
+	MessageTrigger  = "trigger"
+	MessageError    = "error"
+)
+
 type Sink interface {
-	RecordMessageSize(size float64)
-	IncreaseWrittenMessages()
-	IncreaseTotalMessages()
+	IncreaseMessages(outcome string)
 	RecordBatchSize(size float64)
-	IncreaseTotalBatches()
 	RecordWrittenBytes(size float64, fileType string)
-	IncreaseTotalWrittenBytes(size float64, fileType string)
 	IncreaseCachedAssets()
 	DecreaseCachedAssets()
 	IncreaseSkippedAssets()
@@ -20,6 +23,10 @@ type Sink interface {
 	RecordProcessAssetDuration(durMillis float64)
 	RecordOpenFiles(count, limit float64)
 	IncreaseFileEvictions(count float64)
+	RecordSyncDuration(durMillis float64)
+	IncreaseSyncedBytes(size float64)
+	IncreaseStaleSessionsEvicted(count float64)
+	IncreaseTriggerErrors()
 	List() []prometheus.Collector
 }
 
@@ -27,19 +34,19 @@ type sinkImpl struct{}
 
 func New(serviceName string) Sink { return &sinkImpl{} }
 
-func (s *sinkImpl) List() []prometheus.Collector                            { return []prometheus.Collector{} }
-func (s *sinkImpl) RecordMessageSize(size float64)                          {}
-func (s *sinkImpl) IncreaseWrittenMessages()                                {}
-func (s *sinkImpl) IncreaseTotalMessages()                                  {}
-func (s *sinkImpl) RecordBatchSize(size float64)                            {}
-func (s *sinkImpl) IncreaseTotalBatches()                                   {}
-func (s *sinkImpl) RecordWrittenBytes(size float64, fileType string)        {}
-func (s *sinkImpl) IncreaseTotalWrittenBytes(size float64, fileType string) {}
-func (s *sinkImpl) IncreaseCachedAssets()                                   {}
-func (s *sinkImpl) DecreaseCachedAssets()                                   {}
-func (s *sinkImpl) IncreaseSkippedAssets()                                  {}
-func (s *sinkImpl) IncreaseTotalAssets()                                    {}
-func (s *sinkImpl) RecordAssetSize(size float64)                            {}
-func (s *sinkImpl) RecordProcessAssetDuration(durMillis float64)            {}
-func (s *sinkImpl) RecordOpenFiles(count, limit float64)                    {}
-func (s *sinkImpl) IncreaseFileEvictions(count float64)                     {}
+func (s *sinkImpl) List() []prometheus.Collector                     { return []prometheus.Collector{} }
+func (s *sinkImpl) IncreaseMessages(outcome string)                  {}
+func (s *sinkImpl) RecordBatchSize(size float64)                     {}
+func (s *sinkImpl) RecordWrittenBytes(size float64, fileType string) {}
+func (s *sinkImpl) IncreaseCachedAssets()                            {}
+func (s *sinkImpl) DecreaseCachedAssets()                            {}
+func (s *sinkImpl) IncreaseSkippedAssets()                           {}
+func (s *sinkImpl) IncreaseTotalAssets()                             {}
+func (s *sinkImpl) RecordAssetSize(size float64)                     {}
+func (s *sinkImpl) RecordProcessAssetDuration(durMillis float64)     {}
+func (s *sinkImpl) RecordOpenFiles(count, limit float64)             {}
+func (s *sinkImpl) IncreaseFileEvictions(count float64)              {}
+func (s *sinkImpl) RecordSyncDuration(durMillis float64)             {}
+func (s *sinkImpl) IncreaseSyncedBytes(size float64)                 {}
+func (s *sinkImpl) IncreaseStaleSessionsEvicted(count float64)       {}
+func (s *sinkImpl) IncreaseTriggerErrors()                           {}

--- a/backend/pkg/metrics/spot/spot.go
+++ b/backend/pkg/metrics/spot/spot.go
@@ -4,17 +4,24 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	SpotProcessed   = "processed"
+	SpotSkipped     = "skipped"
+	SpotFailed      = "failed"
+	StageDownload   = "download"
+	StageCrop       = "crop"
+	StageCropUpload = "crop_upload"
+	StageTranscode  = "transcode"
+	StageUpload     = "upload"
+	StagePlaylist   = "playlist"
+)
+
 type Spot interface {
+	IncreaseSpots(outcome string)
+	IncreaseTaskFailures(stage string)
+	RecordStageDuration(durMillis float64, stage string)
 	RecordOriginalVideoSize(size float64)
 	RecordCroppedVideoSize(size float64)
-	IncreaseVideosTotal()
-	IncreaseVideosCropped()
-	IncreaseVideosTranscoded()
-	RecordOriginalVideoDownloadDuration(durMillis float64)
-	RecordCroppingDuration(durMillis float64)
-	RecordCroppedVideoUploadDuration(durMillis float64)
-	RecordTranscodingDuration(durMillis float64)
-	RecordTranscodedVideoUploadDuration(durMillis float64)
 	List() []prometheus.Collector
 }
 
@@ -22,14 +29,9 @@ type spotImpl struct{}
 
 func New(serviceName string) Spot { return &spotImpl{} }
 
-func (s *spotImpl) List() []prometheus.Collector                          { return []prometheus.Collector{} }
-func (s *spotImpl) RecordOriginalVideoSize(size float64)                  {}
-func (s *spotImpl) RecordCroppedVideoSize(size float64)                   {}
-func (s *spotImpl) IncreaseVideosTotal()                                  {}
-func (s *spotImpl) IncreaseVideosCropped()                                {}
-func (s *spotImpl) IncreaseVideosTranscoded()                             {}
-func (s *spotImpl) RecordOriginalVideoDownloadDuration(durMillis float64) {}
-func (s *spotImpl) RecordCroppingDuration(durMillis float64)              {}
-func (s *spotImpl) RecordCroppedVideoUploadDuration(durMillis float64)    {}
-func (s *spotImpl) RecordTranscodingDuration(durMillis float64)           {}
-func (s *spotImpl) RecordTranscodedVideoUploadDuration(durMillis float64) {}
+func (s *spotImpl) List() []prometheus.Collector                        { return []prometheus.Collector{} }
+func (s *spotImpl) IncreaseSpots(outcome string)                        {}
+func (s *spotImpl) IncreaseTaskFailures(stage string)                   {}
+func (s *spotImpl) RecordStageDuration(durMillis float64, stage string) {}
+func (s *spotImpl) RecordOriginalVideoSize(size float64)                {}
+func (s *spotImpl) RecordCroppedVideoSize(size float64)                 {}

--- a/backend/pkg/metrics/storage/metrics.go
+++ b/backend/pkg/metrics/storage/metrics.go
@@ -4,10 +4,21 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	UploadOK      = "uploaded"
+	UploadMissing = "missing"
+	UploadFailed  = "failed"
+)
+
 type Storage interface {
 	RecordSessionSize(fileSize float64, fileType string)
-	IncreaseStorageTotalSessions(fileType string)
 	RecordSessionUploadDuration(durMillis float64, fileType, mode string)
+	IncreaseUploads(fileType, outcome string)
+	IncreaseUploadedBytes(size float64, fileType string)
+	IncreaseFailedSessions()
+	IncreaseSessionsNotFound()
+	IncreaseSessionsWithoutStart()
+	RecordDrainDuration(durMillis float64)
 	List() []prometheus.Collector
 }
 
@@ -17,5 +28,10 @@ func New(serviceName string) Storage { return &storageImpl{} }
 
 func (s *storageImpl) List() []prometheus.Collector                                         { return []prometheus.Collector{} }
 func (s *storageImpl) RecordSessionSize(fileSize float64, fileType string)                  {}
-func (s *storageImpl) IncreaseStorageTotalSessions(fileType string)                         {}
 func (s *storageImpl) RecordSessionUploadDuration(durMillis float64, fileType, mode string) {}
+func (s *storageImpl) IncreaseUploads(fileType, outcome string)                             {}
+func (s *storageImpl) IncreaseUploadedBytes(size float64, fileType string)                  {}
+func (s *storageImpl) IncreaseFailedSessions()                                              {}
+func (s *storageImpl) IncreaseSessionsNotFound()                                            {}
+func (s *storageImpl) IncreaseSessionsWithoutStart()                                        {}
+func (s *storageImpl) RecordDrainDuration(durMillis float64)                                {}

--- a/backend/pkg/metrics/web/metrics.go
+++ b/backend/pkg/metrics/web/metrics.go
@@ -4,10 +4,24 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	RejectEmptyBody           = "empty_body"
+	RejectTooLarge            = "too_large"
+	RejectBadJSON             = "bad_json"
+	RejectTrackerOutdated     = "tracker_outdated"
+	RejectNoProjectKey        = "no_project_key"
+	RejectProjectNotFound     = "project_not_found"
+	RejectProjectError        = "project_error"
+	RejectPlatformUnsupported = "platform_unsupported"
+	RejectBrowserUnrecognized = "browser_unrecognized"
+	RejectSampleRateMiss      = "sample_rate_miss"
+	RejectInternalError       = "internal_error"
+)
+
 type Web interface {
 	RecordRequestSize(size float64, url string, code int)
 	RecordRequestDuration(durMillis float64, url string, code int)
-	IncreaseTotalRequests()
+	IncreaseStartRejects(platform, reason string)
 	List() []prometheus.Collector
 }
 
@@ -18,4 +32,4 @@ func New(serviceName string) Web { return &webImpl{} }
 func (w *webImpl) List() []prometheus.Collector                                  { return []prometheus.Collector{} }
 func (w *webImpl) RecordRequestSize(size float64, url string, code int)          {}
 func (w *webImpl) RecordRequestDuration(durMillis float64, url string, code int) {}
-func (w *webImpl) IncreaseTotalRequests()                                        {}
+func (w *webImpl) IncreaseStartRejects(platform, reason string)                  {}

--- a/backend/pkg/server/api/responser.go
+++ b/backend/pkg/server/api/responser.go
@@ -64,6 +64,5 @@ func (r *responserImpl) recordMetrics(requestStart time.Time, url string, code, 
 	if bodySize > 0 {
 		r.metrics.RecordRequestSize(float64(bodySize), url, code)
 	}
-	r.metrics.IncreaseTotalRequests()
 	r.metrics.RecordRequestDuration(float64(time.Now().Sub(requestStart).Milliseconds()), url, code)
 }

--- a/backend/pkg/sessions/api/mobile/handlers.go
+++ b/backend/pkg/sessions/api/mobile/handlers.go
@@ -26,6 +26,7 @@ import (
 	"openreplay/backend/pkg/flakeid"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/messages"
+	webmetrics "openreplay/backend/pkg/metrics/web"
 	"openreplay/backend/pkg/projects"
 	"openreplay/backend/pkg/queue/types"
 	"openreplay/backend/pkg/server/api"
@@ -63,11 +64,12 @@ type handlersImpl struct {
 	conditions conditions.Conditions
 	flaker     *flakeid.Flaker
 	cleanupReg registry.Registry
+	metrics    webmetrics.Web
 }
 
 func NewHandlers(cfg *httpCfg.Config, log logger.Logger, responser api.Responser, producer types.Producer, projects projects.Projects,
 	sessions sessions.Sessions, uaParser *uaparser.UAParser, geoIP geoip.GeoParser, tokenizer *token.Tokenizer,
-	conditions conditions.Conditions, flaker *flakeid.Flaker, cleanupReg registry.Registry) (api.Handlers, error) {
+	conditions conditions.Conditions, flaker *flakeid.Flaker, cleanupReg registry.Registry, metrics webmetrics.Web) (api.Handlers, error) {
 	return &handlersImpl{
 		log:        log,
 		cfg:        cfg,
@@ -81,7 +83,13 @@ func NewHandlers(cfg *httpCfg.Config, log logger.Logger, responser api.Responser
 		conditions: conditions,
 		flaker:     flaker,
 		cleanupReg: cleanupReg,
+		metrics:    metrics,
 	}, nil
+}
+
+func (e *handlersImpl) rejectStart(w http.ResponseWriter, r *http.Request, code int, err error, startTime time.Time, reason string) {
+	e.metrics.IncreaseStartRejects("mobile", reason)
+	e.responser.ResponseWithError(e.log, r.Context(), w, code, err, startTime, r.URL.Path, 0)
 }
 
 func (e *handlersImpl) GetAll() []*api.Description {
@@ -96,7 +104,7 @@ func (e *handlersImpl) startMobileSessionHandler(w http.ResponseWriter, r *http.
 	startTime := time.Now()
 
 	if r.Body == nil {
-		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusBadRequest, errors.New("request body is empty"), startTime, r.URL.Path, 0)
+		e.rejectStart(w, r, http.StatusBadRequest, errors.New("request body is empty"), startTime, webmetrics.RejectEmptyBody)
 		return
 	}
 	body := http.MaxBytesReader(w, r.Body, e.cfg.JsonSizeLimit)
@@ -104,7 +112,7 @@ func (e *handlersImpl) startMobileSessionHandler(w http.ResponseWriter, r *http.
 
 	req := &StartMobileSessionRequest{}
 	if err := json.NewDecoder(body).Decode(req); err != nil {
-		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusBadRequest, err, startTime, r.URL.Path, 0)
+		e.rejectStart(w, r, http.StatusBadRequest, err, startTime, webmetrics.RejectBadJSON)
 		return
 	}
 
@@ -112,7 +120,7 @@ func (e *handlersImpl) startMobileSessionHandler(w http.ResponseWriter, r *http.
 	r = r.WithContext(context.WithValue(r.Context(), "tracker", req.TrackerVersion))
 
 	if req.ProjectKey == nil {
-		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusForbidden, errors.New("projectKey value required"), startTime, r.URL.Path, 0)
+		e.rejectStart(w, r, http.StatusForbidden, errors.New("projectKey value required"), startTime, webmetrics.RejectNoProjectKey)
 		return
 	}
 
@@ -120,10 +128,10 @@ func (e *handlersImpl) startMobileSessionHandler(w http.ResponseWriter, r *http.
 	if err != nil {
 		if postgres.IsNoRowsErr(err) {
 			logErr := fmt.Errorf("project doesn't exist or is not active, key: %s", *req.ProjectKey)
-			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusNotFound, logErr, startTime, r.URL.Path, 0)
+			e.rejectStart(w, r, http.StatusNotFound, logErr, startTime, webmetrics.RejectProjectNotFound)
 		} else {
 			e.log.Error(r.Context(), "failed to get project by key: %s, err: %s", *req.ProjectKey, err)
-			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusInternalServerError, errors.New("can't find a project"), startTime, r.URL.Path, 0)
+			e.rejectStart(w, r, http.StatusInternalServerError, errors.New("can't find a project"), startTime, webmetrics.RejectProjectError)
 		}
 		return
 	}
@@ -133,12 +141,12 @@ func (e *handlersImpl) startMobileSessionHandler(w http.ResponseWriter, r *http.
 
 	// Check if the project supports mobile sessions
 	if !p.IsMobile() {
-		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusForbidden, errors.New("project doesn't support mobile sessions"), startTime, r.URL.Path, 0)
+		e.rejectStart(w, r, http.StatusForbidden, errors.New("project doesn't support mobile sessions"), startTime, webmetrics.RejectPlatformUnsupported)
 		return
 	}
 
 	if !checkMobileTrackerVersion(req.TrackerVersion) {
-		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusUpgradeRequired, errors.New("tracker version not supported"), startTime, r.URL.Path, 0)
+		e.rejectStart(w, r, http.StatusUpgradeRequired, errors.New("tracker version not supported"), startTime, webmetrics.RejectTrackerOutdated)
 		return
 	}
 
@@ -157,18 +165,18 @@ func (e *handlersImpl) startMobileSessionHandler(w http.ResponseWriter, r *http.
 			}
 		}
 		if dice >= p.SampleRate {
-			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusForbidden, fmt.Errorf("capture rate miss, rate: %d", p.SampleRate), startTime, r.URL.Path, 0)
+			e.rejectStart(w, r, http.StatusForbidden, fmt.Errorf("capture rate miss, rate: %d", p.SampleRate), startTime, webmetrics.RejectSampleRateMiss)
 			return
 		}
 
 		ua := e.uaParser.ParseFromHTTPRequest(r)
 		if ua == nil {
-			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusForbidden, fmt.Errorf("browser not recognized, user-agent: %s", r.Header.Get("User-Agent")), startTime, r.URL.Path, 0)
+			e.rejectStart(w, r, http.StatusForbidden, fmt.Errorf("browser not recognized, user-agent: %s", r.Header.Get("User-Agent")), startTime, webmetrics.RejectBrowserUnrecognized)
 			return
 		}
 		sessionID, err := e.flaker.Compose(uint64(startTime.UnixMilli()))
 		if err != nil {
-			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusInternalServerError, err, startTime, r.URL.Path, 0)
+			e.rejectStart(w, r, http.StatusInternalServerError, err, startTime, webmetrics.RejectInternalError)
 			return
 		}
 

--- a/backend/pkg/sessions/api/web/handlers.go
+++ b/backend/pkg/sessions/api/web/handlers.go
@@ -23,6 +23,7 @@ import (
 	"openreplay/backend/pkg/flakeid"
 	"openreplay/backend/pkg/logger"
 	. "openreplay/backend/pkg/messages"
+	webmetrics "openreplay/backend/pkg/metrics/web"
 	"openreplay/backend/pkg/projects"
 	"openreplay/backend/pkg/queue/types"
 	"openreplay/backend/pkg/server/api"
@@ -45,11 +46,12 @@ type handlersImpl struct {
 	flaker          *flakeid.Flaker
 	beaconSizeCache *beacons.BeaconCache
 	cleanupReg      registry.Registry
+	metrics         webmetrics.Web
 }
 
 func NewHandlers(cfg *httpCfg.Config, log logger.Logger, responser api.Responser, producer types.Producer, projects projects.Projects,
 	sessions sessions.Sessions, uaParser *uaparser.UAParser, geoIP geoip.GeoParser, tokenizer *token.Tokenizer,
-	conditions conditions.Conditions, flaker *flakeid.Flaker, cleanupReg registry.Registry) (api.Handlers, error) {
+	conditions conditions.Conditions, flaker *flakeid.Flaker, cleanupReg registry.Registry, metrics webmetrics.Web) (api.Handlers, error) {
 	return &handlersImpl{
 		log:             log,
 		cfg:             cfg,
@@ -64,7 +66,13 @@ func NewHandlers(cfg *httpCfg.Config, log logger.Logger, responser api.Responser
 		flaker:          flaker,
 		beaconSizeCache: beacons.NewBeaconCache(cfg.BeaconSizeLimit),
 		cleanupReg:      cleanupReg,
+		metrics:         metrics,
 	}, nil
+}
+
+func (e *handlersImpl) rejectStart(w http.ResponseWriter, r *http.Request, code int, err error, startTime time.Time, bodySize int, reason string) {
+	e.metrics.IncreaseStartRejects("web", reason)
+	e.responser.ResponseWithError(e.log, r.Context(), w, code, err, startTime, r.URL.Path, bodySize)
 }
 
 func (e *handlersImpl) GetAll() []*api.Description {
@@ -110,13 +118,13 @@ func (e *handlersImpl) startSessionHandlerWeb(w http.ResponseWriter, r *http.Req
 
 	// Check request body
 	if r.Body == nil {
-		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusBadRequest, errors.New("request body is empty"), startTime, r.URL.Path, bodySize)
+		e.rejectStart(w, r, http.StatusBadRequest, errors.New("request body is empty"), startTime, bodySize, webmetrics.RejectEmptyBody)
 		return
 	}
 
 	bodyBytes, err := api.ReadCompressedBody(e.log, w, r, e.cfg.JsonSizeLimit)
 	if err != nil {
-		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusRequestEntityTooLarge, err, startTime, r.URL.Path, bodySize)
+		e.rejectStart(w, r, http.StatusRequestEntityTooLarge, err, startTime, bodySize, webmetrics.RejectTooLarge)
 		return
 	}
 	bodySize = len(bodyBytes)
@@ -124,7 +132,7 @@ func (e *handlersImpl) startSessionHandlerWeb(w http.ResponseWriter, r *http.Req
 	// Parse request body
 	req := &StartSessionRequest{}
 	if err := json.Unmarshal(bodyBytes, req); err != nil {
-		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusBadRequest, err, startTime, r.URL.Path, bodySize)
+		e.rejectStart(w, r, http.StatusBadRequest, err, startTime, bodySize, webmetrics.RejectBadJSON)
 		return
 	}
 
@@ -132,13 +140,13 @@ func (e *handlersImpl) startSessionHandlerWeb(w http.ResponseWriter, r *http.Req
 	r = r.WithContext(context.WithValue(r.Context(), "tracker", req.TrackerVersion))
 	if err := validateTrackerVersion(req.TrackerVersion); err != nil {
 		e.log.Error(r.Context(), "unsupported tracker version: %s, err: %s", req.TrackerVersion, err)
-		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusUpgradeRequired, errors.New("please upgrade the tracker version"), startTime, r.URL.Path, bodySize)
+		e.rejectStart(w, r, http.StatusUpgradeRequired, errors.New("please upgrade the tracker version"), startTime, bodySize, webmetrics.RejectTrackerOutdated)
 		return
 	}
 
 	// Handler's logic
 	if req.ProjectKey == nil {
-		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusForbidden, errors.New("ProjectKey value required"), startTime, r.URL.Path, bodySize)
+		e.rejectStart(w, r, http.StatusForbidden, errors.New("ProjectKey value required"), startTime, bodySize, webmetrics.RejectNoProjectKey)
 		return
 	}
 
@@ -146,10 +154,10 @@ func (e *handlersImpl) startSessionHandlerWeb(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		if postgres.IsNoRowsErr(err) {
 			logErr := fmt.Errorf("project doesn't exist or is not active, key: %s", *req.ProjectKey)
-			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusNotFound, logErr, startTime, r.URL.Path, bodySize)
+			e.rejectStart(w, r, http.StatusNotFound, logErr, startTime, bodySize, webmetrics.RejectProjectNotFound)
 		} else {
 			e.log.Error(r.Context(), "failed to get project by key: %s, err: %s", *req.ProjectKey, err)
-			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusInternalServerError, errors.New("can't find a project"), startTime, r.URL.Path, bodySize)
+			e.rejectStart(w, r, http.StatusInternalServerError, errors.New("can't find a project"), startTime, bodySize, webmetrics.RejectProjectError)
 		}
 		return
 	}
@@ -159,13 +167,13 @@ func (e *handlersImpl) startSessionHandlerWeb(w http.ResponseWriter, r *http.Req
 
 	// Check if the project supports mobile sessions
 	if !p.IsWeb() {
-		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusForbidden, errors.New("project doesn't support web sessions"), startTime, r.URL.Path, bodySize)
+		e.rejectStart(w, r, http.StatusForbidden, errors.New("project doesn't support web sessions"), startTime, bodySize, webmetrics.RejectPlatformUnsupported)
 		return
 	}
 
 	ua := e.uaParser.ParseFromHTTPRequest(r)
 	if ua == nil {
-		e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusForbidden, fmt.Errorf("browser not recognized, user-agent: %s", r.Header.Get("User-Agent")), startTime, r.URL.Path, bodySize)
+		e.rejectStart(w, r, http.StatusForbidden, fmt.Errorf("browser not recognized, user-agent: %s", r.Header.Get("User-Agent")), startTime, bodySize, webmetrics.RejectBrowserUnrecognized)
 		return
 	}
 
@@ -185,14 +193,14 @@ func (e *handlersImpl) startSessionHandlerWeb(w http.ResponseWriter, r *http.Req
 			}
 		}
 		if dice >= p.SampleRate {
-			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusForbidden, fmt.Errorf("capture rate miss, rate: %d", p.SampleRate), startTime, r.URL.Path, bodySize)
+			e.rejectStart(w, r, http.StatusForbidden, fmt.Errorf("capture rate miss, rate: %d", p.SampleRate), startTime, bodySize, webmetrics.RejectSampleRateMiss)
 			return
 		}
 
 		startTimeMili := startTime.UnixMilli()
 		sessionID, err := e.flaker.Compose(uint64(startTimeMili))
 		if err != nil {
-			e.responser.ResponseWithError(e.log, r.Context(), w, http.StatusInternalServerError, err, startTime, r.URL.Path, bodySize)
+			e.rejectStart(w, r, http.StatusInternalServerError, err, startTime, bodySize, webmetrics.RejectInternalError)
 			return
 		}
 

--- a/backend/pkg/sink/message-handler.go
+++ b/backend/pkg/sink/message-handler.go
@@ -70,17 +70,19 @@ func (h *handlerImpl) Handle(msg messages.Message) {
 		return
 	}
 
-	h.sinkMetrics.IncreaseTotalMessages()
 	sessCtx := context.WithValue(context.Background(), "sessionID", msg.SessionID())
 
 	// Send SessionEnd trigger to storage service
 	if msg.TypeID() == messages.MsgSessionEnd || msg.TypeID() == messages.MsgMobileSessionEnd {
+		h.sinkMetrics.IncreaseMessages(sink.MessageTrigger)
 		if err := h.producer.Produce(h.cfg.TopicTrigger, msg.SessionID(), msg.Encode()); err != nil {
+			h.sinkMetrics.IncreaseTriggerErrors()
 			h.log.Error(sessCtx, "can't send SessionEnd to trigger topic: %s", err)
 		}
 		// duplicate session end message to mobile trigger topic to build video replay for mobile sessions
 		if msg.TypeID() == messages.MsgMobileSessionEnd {
 			if err := h.producer.Produce(h.cfg.TopicMobileTrigger, msg.SessionID(), msg.Encode()); err != nil {
+				h.sinkMetrics.IncreaseTriggerErrors()
 				h.log.Error(sessCtx, "can't send MobileSessionEnd to mobile trigger topic: %s", err)
 			}
 		}
@@ -95,6 +97,7 @@ func (h *handlerImpl) Handle(msg messages.Message) {
 		msg.TypeID() == messages.MsgAdoptedSSInsertRuleURLBased {
 		m := msg.Decode()
 		if m == nil {
+			h.sinkMetrics.IncreaseMessages(sink.MessageError)
 			h.log.Error(sessCtx, "assets decode err, info: %s", msg.Meta().Batch().Info())
 			return
 		}
@@ -102,6 +105,7 @@ func (h *handlerImpl) Handle(msg messages.Message) {
 	}
 
 	if !messages.IsReplayerType(msg.TypeID()) {
+		h.sinkMetrics.IncreaseMessages(sink.MessageFiltered)
 		return
 	}
 
@@ -115,6 +119,7 @@ func (h *handlerImpl) Handle(msg messages.Message) {
 	// Try to encode message to avoid null data inserts
 	data := msg.Encode()
 	if data == nil {
+		h.sinkMetrics.IncreaseMessages(sink.MessageError)
 		return
 	}
 	binary.LittleEndian.PutUint64(h.messageIndex, msg.Meta().Index)
@@ -128,6 +133,5 @@ func (h *handlerImpl) Handle(msg messages.Message) {
 		h.devBuffer.Write(data)
 	}
 
-	h.sinkMetrics.IncreaseWrittenMessages()
-	h.sinkMetrics.RecordMessageSize(float64(len(data)))
+	h.sinkMetrics.IncreaseMessages(sink.MessageWritten)
 }

--- a/backend/pkg/spot/transcoder/transcoder.go
+++ b/backend/pkg/spot/transcoder/transcoder.go
@@ -62,9 +62,30 @@ func NewTranscoder(cfg *spot.Config, log logger.Logger, objStorage objectstorage
 	return tnsc
 }
 
+type stageError struct {
+	stage string
+	err   error
+}
+
+func (e *stageError) Error() string { return e.err.Error() }
+func (e *stageError) Unwrap() error { return e.err }
+
+func withStage(stage string, err error) error {
+	return &stageError{stage: stage, err: err}
+}
+
+func stageOf(err error, fallback string) string {
+	var se *stageError
+	if errors.As(err, &se) {
+		return se.stage
+	}
+	return fallback
+}
+
 func (t *transcoderImpl) Process(spot *service.Spot) error {
 	if spot.Crop == nil && spot.Duration < t.cfg.MinimumStreamDuration {
 		// Skip this spot and set processed status
+		t.metrics.IncreaseSpots(spotMetrics.SpotSkipped)
 		t.log.Info(context.Background(), "Spot video %+v is too short for transcoding and without crop values", spot)
 		if err := t.spots.SetStatus(spot.ID, "processed"); err != nil {
 			t.log.Error(context.Background(), "Error updating spot status: %v", err)
@@ -95,7 +116,9 @@ func (t *transcoderImpl) mainLoop() {
 	}
 }
 
-func (t *transcoderImpl) failedTask(task *Task, err error) {
+func (t *transcoderImpl) failedTask(task *Task, stage string, err error) {
+	t.metrics.IncreaseSpots(spotMetrics.SpotFailed)
+	t.metrics.IncreaseTaskFailures(stage)
 	t.log.Error(context.Background(), "Task failed: %v", err)
 	if err := t.tasks.Failed(task, err); err != nil {
 		t.log.Error(context.Background(), "Error marking task as failed: %v", err)
@@ -106,6 +129,7 @@ func (t *transcoderImpl) failedTask(task *Task, err error) {
 }
 
 func (t *transcoderImpl) doneTask(task *Task) {
+	t.metrics.IncreaseSpots(spotMetrics.SpotProcessed)
 	if err := t.spots.SetStatus(task.SpotID, "processed"); err != nil {
 		t.log.Error(context.Background(), "Error updating spot status: %v", err)
 	}
@@ -118,9 +142,7 @@ func (t *transcoderImpl) doneTask(task *Task) {
 }
 
 func (t *transcoderImpl) process(task *Task) {
-	t.metrics.IncreaseVideosTotal()
-	//spotID := task.SpotID
-	t.log.Info(context.Background(), "Processing spot %s", task.SpotID)
+	t.log.Info(context.Background(), "Processing spot %d", task.SpotID)
 
 	// Prepare path for spot video
 	path := t.cfg.FSDir + "/"
@@ -138,13 +160,13 @@ func (t *transcoderImpl) prepare(payload interface{}) {
 
 	// Download video from S3
 	if err := t.downloadSpotVideo(task.SpotID, task.Path); err != nil {
-		t.failedTask(task, fmt.Errorf("can't download video, spot: %d, err: %s", task.SpotID, err.Error()))
+		t.failedTask(task, spotMetrics.StageDownload, fmt.Errorf("can't download video, spot: %d, err: %s", task.SpotID, err.Error()))
 		return
 	}
 
 	if task.HasToTrim() {
 		if err := t.cropSpotVideo(task.SpotID, task.Crop, task.Path); err != nil {
-			t.failedTask(task, fmt.Errorf("can't crop video, spot: %d, err: %s", task.SpotID, err.Error()))
+			t.failedTask(task, stageOf(err, spotMetrics.StageCrop), fmt.Errorf("can't crop video, spot: %d, err: %s", task.SpotID, err.Error()))
 			return
 		}
 	}
@@ -164,13 +186,13 @@ func (t *transcoderImpl) transcode(payload interface{}) {
 	// Transcode spot video to HLS format
 	streamPlaylist, err := t.transcodeSpotVideo(task.SpotID, task.Path)
 	if err != nil {
-		t.failedTask(task, fmt.Errorf("can't transcode video, spot: %d, err: %s", task.SpotID, err.Error()))
+		t.failedTask(task, stageOf(err, spotMetrics.StageTranscode), fmt.Errorf("can't transcode video, spot: %d, err: %s", task.SpotID, err.Error()))
 		return
 	}
 
 	// Save stream playlist to DB
 	if err := t.streams.Add(task.SpotID, streamPlaylist); err != nil {
-		t.failedTask(task, fmt.Errorf("can't insert playlist to DB, spot: %d, err: %s", task.SpotID, err.Error()))
+		t.failedTask(task, spotMetrics.StagePlaylist, fmt.Errorf("can't insert playlist to DB, spot: %d, err: %s", task.SpotID, err.Error()))
 		return
 	}
 
@@ -208,7 +230,7 @@ func (t *transcoderImpl) downloadSpotVideo(spotID uint64, path string) error {
 	}
 	originVideo.Close()
 
-	t.metrics.RecordOriginalVideoDownloadDuration(time.Since(start).Seconds())
+	t.metrics.RecordStageDuration(float64(time.Since(start).Milliseconds()), spotMetrics.StageDownload)
 
 	t.log.Info(context.Background(), "Saved origin video to disk, spot: %d in %v sec", spotID, time.Since(start).Seconds())
 	return nil
@@ -229,10 +251,9 @@ func (t *transcoderImpl) cropSpotVideo(spotID uint64, crop []int, path string) e
 
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("failed to execute command: %v, stderr: %v", err, stderr.String())
+		return withStage(spotMetrics.StageCrop, fmt.Errorf("failed to execute command: %v, stderr: %v", err, stderr.String()))
 	}
-	t.metrics.IncreaseVideosCropped()
-	t.metrics.RecordCroppingDuration(time.Since(start).Seconds())
+	t.metrics.RecordStageDuration(float64(time.Since(start).Milliseconds()), spotMetrics.StageCrop)
 
 	t.log.Info(context.Background(), "Cropped spot %d in %v", spotID, time.Since(start).Seconds())
 
@@ -243,7 +264,7 @@ func (t *transcoderImpl) cropSpotVideo(spotID uint64, crop []int, path string) e
 	start = time.Now()
 	video, err := os.Open(path + "origin.webm")
 	if err != nil {
-		return fmt.Errorf("failed to open cropped video: %v", err)
+		return withStage(spotMetrics.StageCropUpload, fmt.Errorf("failed to open cropped video: %v", err))
 	}
 	defer video.Close()
 
@@ -255,10 +276,10 @@ func (t *transcoderImpl) cropSpotVideo(spotID uint64, crop []int, path string) e
 
 	err = t.objStorage.Upload(video, fmt.Sprintf("%d/video.webm", spotID), "video/webm", objectstorage.NoContentEncoding, objectstorage.NoCompression)
 	if err != nil {
-		return fmt.Errorf("failed to upload cropped video: %v", err)
+		return withStage(spotMetrics.StageCropUpload, fmt.Errorf("failed to upload cropped video: %v", err))
 	}
 
-	t.metrics.RecordCroppedVideoUploadDuration(time.Since(start).Seconds())
+	t.metrics.RecordStageDuration(float64(time.Since(start).Milliseconds()), spotMetrics.StageCropUpload)
 
 	t.log.Info(context.Background(), "Uploaded cropped spot %d in %v", spotID, time.Since(start).Seconds())
 	return nil
@@ -293,11 +314,10 @@ func (t *transcoderImpl) transcodeSpotVideo(spotID uint64, path string) (string,
 
 	if err := cmd.Run(); err != nil {
 		t.log.Error(context.Background(), "Failed to execute ffmpeg: %v, stderr: %v", err, stderr.String())
-		return "", err
+		return "", withStage(spotMetrics.StageTranscode, err)
 	}
 
-	t.metrics.IncreaseVideosTranscoded()
-	t.metrics.RecordTranscodingDuration(time.Since(start).Seconds())
+	t.metrics.RecordStageDuration(float64(time.Since(start).Milliseconds()), spotMetrics.StageTranscode)
 	t.log.Info(context.Background(), "Transcoded spot %d in %v", spotID, time.Since(start).Seconds())
 
 	uploadStart := time.Now()
@@ -306,7 +326,7 @@ func (t *transcoderImpl) transcodeSpotVideo(spotID uint64, path string) (string,
 	mpdBytes, err := os.ReadFile(manifestPath)
 	if err != nil {
 		t.log.Error(context.Background(), "Error reading manifest file: %v", err)
-		return "", err
+		return "", withStage(spotMetrics.StageUpload, err)
 	}
 
 	var chunks []string
@@ -328,14 +348,14 @@ func (t *transcoderImpl) transcodeSpotVideo(spotID uint64, path string) (string,
 	})
 	if err != nil {
 		t.log.Error(context.Background(), "Error walking output dir: %v", err)
-		return "", err
+		return "", withStage(spotMetrics.StageUpload, err)
 	}
 
 	for _, chunkPath := range chunks {
 		f, err := os.Open(chunkPath)
 		if err != nil {
 			t.log.Error(context.Background(), "Error opening file %s: %v", chunkPath, err)
-			return "", err
+			return "", withStage(spotMetrics.StageUpload, err)
 		}
 
 		name := filepath.Base(chunkPath)
@@ -344,12 +364,12 @@ func (t *transcoderImpl) transcodeSpotVideo(spotID uint64, path string) (string,
 		if err := t.objStorage.Upload(f, key, "video/iso.segment", objectstorage.NoContentEncoding, objectstorage.NoCompression); err != nil {
 			_ = f.Close()
 			t.log.Error(context.Background(), "Error uploading file %s (key=%s): %v", chunkPath, key, err)
-			return "", err
+			return "", withStage(spotMetrics.StageUpload, err)
 		}
 		_ = f.Close()
 	}
 
-	t.metrics.RecordTranscodedVideoUploadDuration(time.Since(uploadStart).Seconds())
+	t.metrics.RecordStageDuration(float64(time.Since(uploadStart).Milliseconds()), spotMetrics.StageUpload)
 	t.log.Info(context.Background(), "Uploaded %d DASH chunks for spot %d in %v", len(chunks), spotID, time.Since(uploadStart).Seconds())
 
 	return string(mpdBytes), nil
@@ -373,10 +393,9 @@ func (t *transcoderImpl) _transcodeSpotVideo(spotID uint64, path string) (string
 	err := cmd.Run()
 	if err != nil {
 		t.log.Error(context.Background(), "Failed to execute command: %v, stderr: %v", err, stderr.String())
-		return "", err
+		return "", withStage(spotMetrics.StageTranscode, err)
 	}
-	t.metrics.IncreaseVideosTranscoded()
-	t.metrics.RecordTranscodingDuration(time.Since(start).Seconds())
+	t.metrics.RecordStageDuration(float64(time.Since(start).Milliseconds()), spotMetrics.StageTranscode)
 	t.log.Info(context.Background(), "Transcoded spot %d in %v", spotID, time.Since(start).Seconds())
 
 	start = time.Now()
@@ -418,10 +437,10 @@ func (t *transcoderImpl) _transcodeSpotVideo(spotID uint64, path string) (string
 		err = t.objStorage.Upload(chunkFile, key, "video/mp2t", objectstorage.NoContentEncoding, objectstorage.NoCompression)
 		if err != nil {
 			fmt.Println("Error uploading file:", err)
-			return "", err
+			return "", withStage(spotMetrics.StageUpload, err)
 		}
 	}
-	t.metrics.RecordTranscodedVideoUploadDuration(time.Since(start).Seconds())
+	t.metrics.RecordStageDuration(float64(time.Since(start).Milliseconds()), spotMetrics.StageUpload)
 
 	t.log.Info(context.Background(), "Uploaded chunks for spot %d in %v", spotID, time.Since(start).Seconds())
 	return strings.Join(lines, "\n"), nil

--- a/backend/pkg/storage/encryptor.go
+++ b/backend/pkg/storage/encryptor.go
@@ -8,6 +8,6 @@ func GenerateEncryptionKey() []byte {
 	return nil
 }
 
-func (u *uploaderImpl) streamEncryptionToS3(name, key, srcPath string) error {
-	return errors.New("not implemented")
+func (u *uploaderImpl) streamEncryptionToS3(name, key, srcPath string) (int64, error) {
+	return 0, errors.New("not implemented")
 }

--- a/backend/pkg/storage/storage.go
+++ b/backend/pkg/storage/storage.go
@@ -67,9 +67,13 @@ func (u *uploaderImpl) Upload(ctx context.Context, sessionID uint64, encryptionK
 	saveMobeAsMobs := false
 	if err := checkMobFilePresence(filePath); err != nil {
 		if !errors.Is(err, ErrSessionWithoutFirstPart) {
+			if errors.Is(err, ErrSessionNotFound) {
+				u.metrics.IncreaseSessionsNotFound()
+			}
 			return err
 		}
 		saveMobeAsMobs = true
+		u.metrics.IncreaseSessionsWithoutStart()
 		u.log.Warn(ctx, "session without first part: %d", sessionID)
 	}
 	u.uploaderPool.Submit(&uploadTask{
@@ -121,17 +125,22 @@ func (u *uploaderImpl) uploadSession(payload interface{}) {
 		start := time.Now()
 		mode := "compress"
 		var err error
+		var uploadedBytes int64
 		if task.encryptionKey != "" {
 			mode = "encrypt"
-			err = u.streamEncryptionToS3(name, task.encryptionKey, srcPath)
+			uploadedBytes, err = u.streamEncryptionToS3(name, task.encryptionKey, srcPath)
 		} else {
-			err = u.streamZstdToS3(name, srcPath)
+			uploadedBytes, err = u.streamZstdToS3(name, srcPath)
 		}
 		u.metrics.RecordSessionUploadDuration(float64(time.Since(start).Milliseconds()), fileType, mode)
-		if err == nil {
-			u.metrics.IncreaseStorageTotalSessions(fileType)
-		}
-		if err != nil {
+		switch {
+		case err == nil:
+			u.metrics.IncreaseUploads(fileType, storageMetrics.UploadOK)
+			u.metrics.IncreaseUploadedBytes(float64(uploadedBytes), fileType)
+		case IsNotExist(err):
+			u.metrics.IncreaseUploads(fileType, storageMetrics.UploadMissing)
+		default:
+			u.metrics.IncreaseUploads(fileType, storageMetrics.UploadFailed)
 			var fatalErr *objectstorage.FatalUploadError
 			if errors.As(err, &fatalErr) {
 				log.Fatalf("fatal S3 upload error (HTTP %d), terminating: %v", fatalErr.StatusCode, fatalErr.Cause)
@@ -193,6 +202,7 @@ func (u *uploaderImpl) uploadSession(payload interface{}) {
 
 	wg.Wait()
 	if mobsFailed {
+		u.metrics.IncreaseFailedSessions()
 		errs := make([]string, 0, len(uploadErrors))
 		for _, e := range uploadErrors {
 			if e != "" {
@@ -234,7 +244,18 @@ func (u *uploaderImpl) Wait() {
 	u.uploaderPool.Pause()
 }
 
-func (u *uploaderImpl) streamZstdToS3(name, srcPath string) error {
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
+}
+
+func (u *uploaderImpl) streamZstdToS3(name, srcPath string) (int64, error) {
 	pr, pw := io.Pipe()
 	errCh := make(chan error, 1)
 
@@ -266,10 +287,11 @@ func (u *uploaderImpl) streamZstdToS3(name, srcPath string) error {
 		_, wErr = io.CopyBuffer(zw, f, make([]byte, 256*1024))
 	}()
 
-	if err := u.objStorage.Upload(pr, name, "application/octet-stream", objectstorage.NoContentEncoding, objectstorage.Zstd); err != nil {
+	cr := &countingReader{r: pr}
+	if err := u.objStorage.Upload(cr, name, "application/octet-stream", objectstorage.NoContentEncoding, objectstorage.Zstd); err != nil {
 		pr.CloseWithError(err)
 		<-errCh
-		return err
+		return cr.n, err
 	}
-	return <-errCh
+	return cr.n, <-errCh
 }

--- a/ee/backend/cmd/connector/main.go
+++ b/ee/backend/cmd/connector/main.go
@@ -15,6 +15,7 @@ import (
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/messages"
 	"openreplay/backend/pkg/metrics"
+	connectorMetrics "openreplay/backend/pkg/metrics/connector"
 	"openreplay/backend/pkg/metrics/database"
 	"openreplay/backend/pkg/objectstorage/store"
 	"openreplay/backend/pkg/projects"
@@ -29,7 +30,8 @@ func main() {
 	cfg := config.New(log)
 	// Observability
 	dbMetrics := database.New("connector")
-	metrics.New(log, dbMetrics.List())
+	connMetrics := connectorMetrics.New("connector")
+	metrics.New(log, append(connMetrics.List(), dbMetrics.List()...))
 
 	objStore, err := store.NewStore(&cfg.ObjectsConfig)
 	if err != nil {
@@ -84,7 +86,7 @@ func main() {
 
 	projManager := projects.New(log, pgConn, redisClient, dbMetrics)
 	sessManager := sessions.New(log, pgConn, projManager, redisClient, dbMetrics, sessions.DoNotIgnoreInactiveProjects)
-	dataSaver := saver.New(log, cfg, db, sessManager, projManager)
+	dataSaver := saver.New(log, cfg, db, sessManager, projManager, connMetrics)
 
 	// Message filter
 	msgFilter := []int{messages.MsgConsoleLog, messages.MsgCustomEvent, messages.MsgJSException,

--- a/ee/backend/pkg/assist/factory.go
+++ b/ee/backend/pkg/assist/factory.go
@@ -7,20 +7,21 @@ import (
 	"openreplay/backend/pkg/db/postgres/pool"
 	"openreplay/backend/pkg/db/redis"
 	"openreplay/backend/pkg/logger"
+	assistMetrics "openreplay/backend/pkg/metrics/assist"
 	"openreplay/backend/pkg/projects"
 	"openreplay/backend/pkg/sessionmanager"
 )
 
-func NewAssist(log logger.Logger, cfg *config.Config, pgconn pool.Pool, redisClient *redis.Client, projects projects.Projects) (Assist, error) {
+func NewAssist(log logger.Logger, cfg *config.Config, pgconn pool.Pool, redisClient *redis.Client, projects projects.Projects, metrics assistMetrics.Assist) (Assist, error) {
 	if redisClient == nil || redisClient.Redis == nil {
 		return nil, errors.New("redis connection is required for assist")
 	}
-	sessManager, err := sessionmanager.New(log, cfg.AssistCacheTTL, cfg.AssistBatchSize, cfg.AssistScanSize, redisClient.Redis)
+	sessManager, err := sessionmanager.New(log, cfg.AssistCacheTTL, cfg.AssistBatchSize, cfg.AssistScanSize, redisClient.Redis, metrics)
 	if err != nil {
 		return nil, err
 	}
 	sessManager.Start()
-	if _, err := NewAssistStats(log, pgconn, redisClient.Redis); err != nil {
+	if _, err := NewAssistStats(log, pgconn, redisClient.Redis, metrics); err != nil {
 		return nil, err
 	}
 	return newDirect(log, cfg, projects, sessManager), nil

--- a/ee/backend/pkg/assist/stats.go
+++ b/ee/backend/pkg/assist/stats.go
@@ -11,6 +11,7 @@ import (
 
 	"openreplay/backend/pkg/db/postgres/pool"
 	"openreplay/backend/pkg/logger"
+	assistMetrics "openreplay/backend/pkg/metrics/assist"
 )
 
 type FlexUint32 uint32
@@ -37,6 +38,7 @@ type assistStatsImpl struct {
 	log         logger.Logger
 	pgClient    pool.Pool
 	redisClient *redis.Client
+	metrics     assistMetrics.Assist
 	ticker      *time.Ticker
 	stopChan    chan struct{}
 }
@@ -45,7 +47,7 @@ type AssistStats interface {
 	Stop()
 }
 
-func NewAssistStats(log logger.Logger, pgClient pool.Pool, redisClient *redis.Client) (AssistStats, error) {
+func NewAssistStats(log logger.Logger, pgClient pool.Pool, redisClient *redis.Client, metrics assistMetrics.Assist) (AssistStats, error) {
 	switch {
 	case log == nil:
 		return nil, errors.New("logger is empty")
@@ -53,11 +55,14 @@ func NewAssistStats(log logger.Logger, pgClient pool.Pool, redisClient *redis.Cl
 		return nil, errors.New("pg client is empty")
 	case redisClient == nil:
 		return nil, errors.New("redis client is empty")
+	case metrics == nil:
+		return nil, errors.New("metrics is empty")
 	}
 	stats := &assistStatsImpl{
 		log:         log,
 		pgClient:    pgClient,
 		redisClient: redisClient,
+		metrics:     metrics,
 		ticker:      time.NewTicker(time.Minute),
 		stopChan:    make(chan struct{}),
 	}
@@ -94,6 +99,10 @@ type AssistStatsEvent struct {
 func (as *assistStatsImpl) loadData() {
 	ctx := context.Background()
 
+	if depth, err := as.redisClient.LLen(ctx, "assist:stats").Result(); err == nil {
+		as.metrics.RecordStatsQueueDepth(float64(depth))
+	}
+
 	events, err := as.redisClient.LPopCount(ctx, "assist:stats", 1000).Result()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
@@ -113,15 +122,22 @@ func (as *assistStatsImpl) loadData() {
 		e := &AssistStatsEvent{}
 		err := json.Unmarshal([]byte(event), &e)
 		if err != nil {
+			as.metrics.IncreaseStatsDropped(assistMetrics.DropParse)
 			as.log.Error(ctx, "Failed to unmarshal event: %v", err)
 			continue
 		}
+		as.metrics.IncreaseStatsEvents(e.EventType, e.EventState)
 		switch e.EventState {
 		case "start":
-			err = as.insertEvent(e)
+			if err = as.insertEvent(e); err != nil {
+				as.metrics.IncreaseStatsDropped(assistMetrics.DropInsert)
+			}
 		case "end":
-			err = as.updateEvent(e)
+			if err = as.updateEvent(e); err != nil {
+				as.metrics.IncreaseStatsDropped(assistMetrics.DropUpdate)
+			}
 		default:
+			as.metrics.IncreaseStatsDropped(assistMetrics.DropUnknownState)
 			as.log.Warn(ctx, "Unknown event type: %s", e.EventType)
 		}
 		if err != nil {

--- a/ee/backend/pkg/connector/saver.go
+++ b/ee/backend/pkg/connector/saver.go
@@ -10,6 +10,7 @@ import (
 	"openreplay/backend/internal/http/geoip"
 	"openreplay/backend/pkg/logger"
 	"openreplay/backend/pkg/messages"
+	connMetrics "openreplay/backend/pkg/metrics/connector"
 	"openreplay/backend/pkg/projects"
 	"openreplay/backend/pkg/sessions"
 )
@@ -21,6 +22,7 @@ type Saver struct {
 	db               Database
 	sessModule       sessions.Sessions
 	projModule       projects.Projects
+	metrics          connMetrics.Connector
 	sessions         map[uint64]map[string]string
 	updatedSessions  map[uint64]bool
 	lastUpdate       map[uint64]time.Time
@@ -29,7 +31,7 @@ type Saver struct {
 	projectIDs       map[uint32]bool
 }
 
-func New(log logger.Logger, cfg *config.Config, db Database, sessions sessions.Sessions, projects projects.Projects) *Saver {
+func New(log logger.Logger, cfg *config.Config, db Database, sessions sessions.Sessions, projects projects.Projects, metrics connMetrics.Connector) *Saver {
 	ctx := context.Background()
 	if cfg == nil {
 		log.Fatal(ctx, "connector config is empty")
@@ -58,6 +60,7 @@ func New(log logger.Logger, cfg *config.Config, db Database, sessions sessions.S
 		db:              db,
 		sessModule:      sessions,
 		projModule:      projects,
+		metrics:         metrics,
 		updatedSessions: make(map[uint64]bool, 0),
 		lastUpdate:      make(map[uint64]time.Time, 0),
 		projectIDs:      projectIDs,
@@ -444,15 +447,18 @@ func (s *Saver) Handle(msg messages.Message) {
 		// Check if project ID is allowed
 		sessInfo, err := s.sessModule.Get(msg.SessionID())
 		if err != nil {
+			s.metrics.IncreaseMessages(connMetrics.MessageNoSession)
 			s.log.Error(context.Background(), "can't get session info: %s, skipping message", err)
 			return
 		}
 		if !s.projectIDs[sessInfo.ProjectID] {
+			s.metrics.IncreaseMessages(connMetrics.MessageFiltered)
 			s.log.Debug(context.Background(), "project ID %d is not allowed, skipping message", sessInfo.ProjectID)
 			return
 		}
 		s.log.Info(context.Background(), "project ID %d is allowed", sessInfo.ProjectID)
 	}
+	s.metrics.IncreaseMessages(connMetrics.MessageHandled)
 	newEvent := handleEvent(msg)
 	if newEvent != nil {
 		if s.events == nil {
@@ -475,9 +481,14 @@ func (s *Saver) commitEvents() {
 		s.log.Info(context.Background(), "empty events batch")
 		return
 	}
+	start := time.Now()
 	if err := s.db.InsertEvents(s.events); err != nil {
+		s.metrics.IncreaseDroppedRows(float64(len(s.events)), connMetrics.TableEvents)
 		s.log.Error(context.Background(), "can't insert events: %s", err)
+	} else {
+		s.metrics.IncreaseInsertedRows(float64(len(s.events)), connMetrics.TableEvents)
 	}
+	s.metrics.RecordInsertDuration(float64(time.Since(start).Milliseconds()), connMetrics.TableEvents)
 	s.events = nil
 }
 
@@ -503,9 +514,14 @@ func (s *Saver) commitSessions() {
 		s.log.Info(context.Background(), "empty sessions batch to send")
 		return
 	}
+	start := time.Now()
 	if err := s.db.InsertSessions(sessions); err != nil {
+		s.metrics.IncreaseDroppedRows(float64(len(sessions)), connMetrics.TableSessions)
 		s.log.Error(context.Background(), "can't insert sessions: %s", err)
+	} else {
+		s.metrics.IncreaseInsertedRows(float64(len(sessions)), connMetrics.TableSessions)
 	}
+	s.metrics.RecordInsertDuration(float64(time.Since(start).Milliseconds()), connMetrics.TableSessions)
 	s.log.Info(context.Background(), "finished: %d, to keep: %d, to send: %d", l, len(toKeep), len(toSend))
 	// Clear current list of finished sessions
 	for _, sessionID := range toSend {
@@ -531,6 +547,7 @@ func (s *Saver) Commit() {
 	s.commitEvents()
 	s.checkZombieSessions()
 	s.commitSessions()
+	s.metrics.RecordPendingSessions(float64(len(s.sessions)))
 }
 
 func (s *Saver) checkZombieSessions() {
@@ -569,6 +586,7 @@ func (s *Saver) checkZombieSessions() {
 			zombieSessionsCount++
 		}
 	}
+	s.metrics.IncreaseZombieSessions(float64(zombieSessionsCount))
 	if zombieSessionsCount > 0 {
 		s.log.Info(context.Background(), "found %d zombie sessions", zombieSessionsCount)
 	}

--- a/ee/backend/pkg/metrics/assist/metrics.go
+++ b/ee/backend/pkg/metrics/assist/metrics.go
@@ -1,0 +1,121 @@
+package assist
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	DropParse        = "parse"
+	DropInsert       = "insert"
+	DropUpdate       = "update"
+	DropUnknownState = "unknown_state"
+)
+
+type Assist interface {
+	RecordOnlineSessions(count float64)
+	RecordNodes(count float64)
+	RecordStatsQueueDepth(count float64)
+	IncreaseStatsEvents(eventType, eventState string)
+	IncreaseStatsDropped(reason string)
+	List() []prometheus.Collector
+}
+
+type assistImpl struct {
+	onlineSessions  prometheus.Gauge
+	nodes           prometheus.Gauge
+	statsQueueDepth prometheus.Gauge
+	statsEvents     *prometheus.CounterVec
+	statsDropped    *prometheus.CounterVec
+}
+
+func New(serviceName string) Assist {
+	return &assistImpl{
+		onlineSessions:  newOnlineSessions(serviceName),
+		nodes:           newNodes(serviceName),
+		statsQueueDepth: newStatsQueueDepth(serviceName),
+		statsEvents:     newStatsEvents(serviceName),
+		statsDropped:    newStatsDropped(serviceName),
+	}
+}
+
+func (a *assistImpl) List() []prometheus.Collector {
+	return []prometheus.Collector{
+		a.onlineSessions,
+		a.nodes,
+		a.statsQueueDepth,
+		a.statsEvents,
+		a.statsDropped,
+	}
+}
+
+func newOnlineSessions(serviceName string) prometheus.Gauge {
+	return prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: serviceName,
+			Name:      "online_sessions",
+			Help:      "A gauge displaying the number of live assist sessions, derived cluster-wide from the Redis online-session keys (matches what the API shows).",
+		},
+	)
+}
+
+func (a *assistImpl) RecordOnlineSessions(count float64) {
+	a.onlineSessions.Set(count)
+}
+
+func newNodes(serviceName string) prometheus.Gauge {
+	return prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: serviceName,
+			Name:      "nodes",
+			Help:      "A gauge displaying the number of live assist WebSocket nodes reporting into Redis (assist:nodes:*).",
+		},
+	)
+}
+
+func (a *assistImpl) RecordNodes(count float64) {
+	a.nodes.Set(count)
+}
+
+func newStatsQueueDepth(serviceName string) prometheus.Gauge {
+	return prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: serviceName,
+			Name:      "stats_queue_depth",
+			Help:      "A gauge displaying the depth of the assist:stats Redis list at each consumer tick; sustained growth means the stats consumer is falling behind (unbounded Redis memory).",
+		},
+	)
+}
+
+func (a *assistImpl) RecordStatsQueueDepth(count float64) {
+	a.statsQueueDepth.Set(count)
+}
+
+func newStatsEvents(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "stats_events_total",
+			Help:      "A counter displaying processed assist stats events by type (assist/call/control/record) and state (start/end).",
+		},
+		[]string{"event_type", "event_state"},
+	)
+}
+
+func (a *assistImpl) IncreaseStatsEvents(eventType, eventState string) {
+	a.statsEvents.WithLabelValues(eventType, eventState).Inc()
+}
+
+func newStatsDropped(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "stats_events_dropped_total",
+			Help:      "A counter displaying assist stats events consumed from Redis but not persisted, by reason (lost assist analytics).",
+		},
+		[]string{"reason"},
+	)
+}
+
+func (a *assistImpl) IncreaseStatsDropped(reason string) {
+	a.statsDropped.WithLabelValues(reason).Inc()
+}

--- a/ee/backend/pkg/metrics/canvas/metrics.go
+++ b/ee/backend/pkg/metrics/canvas/metrics.go
@@ -6,43 +6,54 @@ import (
 	"openreplay/backend/pkg/metrics/common"
 )
 
+const (
+	FrameSaved      = "saved"
+	FrameBadMessage = "bad_message"
+	UploadOK        = "uploaded"
+	UploadMissing   = "missing"
+)
+
 type Canvas interface {
 	RecordCanvasImageSize(size float64)
-	IncreaseTotalSavedImages()
+	IncreaseFrames(outcome string)
 	RecordCanvasesPerSession(number float64)
 	RecordPreparingDuration(duration float64)
-	IncreaseTotalCreatedArchives()
+	IncreaseTriggerErrors()
+	IncreaseUploads(outcome string)
 	RecordUploadingDuration(duration float64)
 	List() []prometheus.Collector
 }
 
 type canvasImpl struct {
-	canvasesImageSize            prometheus.Histogram
-	canvasesTotalSavedImages     prometheus.Counter
-	canvasesCanvasesPerSession   prometheus.Histogram
-	canvasesPreparingDuration    prometheus.Histogram
-	canvasesTotalCreatedArchives prometheus.Counter
-	canvasesUploadingDuration    prometheus.Histogram
+	canvasesImageSize          prometheus.Histogram
+	frames                     *prometheus.CounterVec
+	canvasesCanvasesPerSession prometheus.Histogram
+	canvasesPreparingDuration  prometheus.Histogram
+	triggerErrors              prometheus.Counter
+	uploads                    *prometheus.CounterVec
+	canvasesUploadingDuration  prometheus.Histogram
 }
 
 func New(serviceName string) Canvas {
 	return &canvasImpl{
-		canvasesImageSize:            newImageSizeMetric(serviceName),
-		canvasesTotalSavedImages:     newTotalSavedImages(serviceName),
-		canvasesCanvasesPerSession:   newCanvasesPerSession(serviceName),
-		canvasesPreparingDuration:    newPreparingDuration(serviceName),
-		canvasesTotalCreatedArchives: newTotalCreatedArchives(serviceName),
-		canvasesUploadingDuration:    newUploadingDuration(serviceName),
+		canvasesImageSize:          newImageSizeMetric(serviceName),
+		frames:                     newFrames(serviceName),
+		canvasesCanvasesPerSession: newCanvasesPerSession(serviceName),
+		canvasesPreparingDuration:  newPreparingDuration(serviceName),
+		triggerErrors:              newTriggerErrors(serviceName),
+		uploads:                    newUploads(serviceName),
+		canvasesUploadingDuration:  newUploadingDuration(serviceName),
 	}
 }
 
 func (c *canvasImpl) List() []prometheus.Collector {
 	return []prometheus.Collector{
 		c.canvasesImageSize,
-		c.canvasesTotalSavedImages,
+		c.frames,
 		c.canvasesCanvasesPerSession,
 		c.canvasesPreparingDuration,
-		c.canvasesTotalCreatedArchives,
+		c.triggerErrors,
+		c.uploads,
 		c.canvasesUploadingDuration,
 	}
 }
@@ -62,18 +73,19 @@ func (c *canvasImpl) RecordCanvasImageSize(size float64) {
 	c.canvasesImageSize.Observe(size)
 }
 
-func newTotalSavedImages(serviceName string) prometheus.Counter {
-	return prometheus.NewCounter(
+func newFrames(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: serviceName,
-			Name:      "total_saved_images",
-			Help:      "A counter displaying the total number of saved images.",
+			Name:      "frames_total",
+			Help:      "A counter displaying consumed canvas frames by outcome (saved/bad_message).",
 		},
+		[]string{"outcome"},
 	)
 }
 
-func (c *canvasImpl) IncreaseTotalSavedImages() {
-	c.canvasesTotalSavedImages.Inc()
+func (c *canvasImpl) IncreaseFrames(outcome string) {
+	c.frames.WithLabelValues(outcome).Inc()
 }
 
 func newCanvasesPerSession(serviceName string) prometheus.Histogram {
@@ -106,18 +118,33 @@ func (c *canvasImpl) RecordPreparingDuration(duration float64) {
 	c.canvasesPreparingDuration.Observe(duration)
 }
 
-func newTotalCreatedArchives(serviceName string) prometheus.Counter {
+func newTriggerErrors(serviceName string) prometheus.Counter {
 	return prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: serviceName,
-			Name:      "total_created_archives",
-			Help:      "A counter displaying the total number of created canvas archives.",
+			Name:      "trigger_produce_errors_total",
+			Help:      "A counter displaying failures to produce a canvas pack trigger (the canvas is never archived).",
 		},
 	)
 }
 
-func (c *canvasImpl) IncreaseTotalCreatedArchives() {
-	c.canvasesTotalCreatedArchives.Inc()
+func (c *canvasImpl) IncreaseTriggerErrors() {
+	c.triggerErrors.Inc()
+}
+
+func newUploads(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "uploads_total",
+			Help:      "A counter displaying canvas archive uploads by outcome (uploaded/missing).",
+		},
+		[]string{"outcome"},
+	)
+}
+
+func (c *canvasImpl) IncreaseUploads(outcome string) {
+	c.uploads.WithLabelValues(outcome).Inc()
 }
 
 func newUploadingDuration(serviceName string) prometheus.Histogram {

--- a/ee/backend/pkg/metrics/connector/metrics.go
+++ b/ee/backend/pkg/metrics/connector/metrics.go
@@ -1,0 +1,154 @@
+package connector
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"openreplay/backend/pkg/metrics/common"
+)
+
+const (
+	MessageHandled   = "handled"
+	MessageFiltered  = "filtered"
+	MessageNoSession = "no_session"
+	TableEvents      = "events"
+	TableSessions    = "sessions"
+)
+
+type Connector interface {
+	IncreaseMessages(outcome string)
+	IncreaseInsertedRows(count float64, table string)
+	IncreaseDroppedRows(count float64, table string)
+	RecordInsertDuration(durMillis float64, table string)
+	IncreaseZombieSessions(count float64)
+	RecordPendingSessions(count float64)
+	List() []prometheus.Collector
+}
+
+type connectorImpl struct {
+	messages        *prometheus.CounterVec
+	insertedRows    *prometheus.CounterVec
+	droppedRows     *prometheus.CounterVec
+	insertDuration  *prometheus.HistogramVec
+	zombieSessions  prometheus.Counter
+	pendingSessions prometheus.Gauge
+}
+
+func New(serviceName string) Connector {
+	return &connectorImpl{
+		messages:        newMessages(serviceName),
+		insertedRows:    newInsertedRows(serviceName),
+		droppedRows:     newDroppedRows(serviceName),
+		insertDuration:  newInsertDuration(serviceName),
+		zombieSessions:  newZombieSessions(serviceName),
+		pendingSessions: newPendingSessions(serviceName),
+	}
+}
+
+func (c *connectorImpl) List() []prometheus.Collector {
+	return []prometheus.Collector{
+		c.messages,
+		c.insertedRows,
+		c.droppedRows,
+		c.insertDuration,
+		c.zombieSessions,
+		c.pendingSessions,
+	}
+}
+
+func newMessages(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "messages_total",
+			Help:      "A counter displaying consumed messages by outcome (handled/filtered/no_session).",
+		},
+		[]string{"outcome"},
+	)
+}
+
+func (c *connectorImpl) IncreaseMessages(outcome string) {
+	c.messages.WithLabelValues(outcome).Inc()
+}
+
+func newInsertedRows(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "inserted_rows_total",
+			Help:      "A counter displaying rows successfully written to the destination, by table.",
+		},
+		[]string{"table"},
+	)
+}
+
+func (c *connectorImpl) IncreaseInsertedRows(count float64, table string) {
+	if count == 0 {
+		return
+	}
+	c.insertedRows.WithLabelValues(table).Add(count)
+}
+
+func newDroppedRows(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "dropped_rows_total",
+			Help:      "A counter displaying rows discarded after a failed batch insert (data loss), by table.",
+		},
+		[]string{"table"},
+	)
+}
+
+func (c *connectorImpl) IncreaseDroppedRows(count float64, table string) {
+	if count == 0 {
+		return
+	}
+	c.droppedRows.WithLabelValues(table).Add(count)
+}
+
+func newInsertDuration(serviceName string) *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: serviceName,
+			Name:      "insert_duration_seconds",
+			Help:      "A histogram displaying the duration of batch inserts into the destination in seconds, by table.",
+			Buckets:   common.DefaultDurationBuckets,
+		},
+		[]string{"table"},
+	)
+}
+
+func (c *connectorImpl) RecordInsertDuration(durMillis float64, table string) {
+	c.insertDuration.WithLabelValues(table).Observe(durMillis / 1000.0)
+}
+
+func newZombieSessions(serviceName string) prometheus.Counter {
+	return prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "zombie_sessions_total",
+			Help:      "A counter displaying sessions flushed without a SessionEnd message after the inactivity timeout.",
+		},
+	)
+}
+
+func (c *connectorImpl) IncreaseZombieSessions(count float64) {
+	if count == 0 {
+		return
+	}
+	c.zombieSessions.Add(count)
+}
+
+func newPendingSessions(serviceName string) prometheus.Gauge {
+	return prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: serviceName,
+			Name:      "pending_sessions",
+			Help:      "A gauge displaying sessions currently held in memory waiting to be flushed.",
+		},
+	)
+}
+
+func (c *connectorImpl) RecordPendingSessions(count float64) {
+	c.pendingSessions.Set(count)
+}

--- a/ee/backend/pkg/metrics/database/metrics.go
+++ b/ee/backend/pkg/metrics/database/metrics.go
@@ -6,6 +6,13 @@ import (
 	"openreplay/backend/pkg/metrics/common"
 )
 
+const (
+	MessageSaved     = "saved"
+	MessageError     = "error"
+	MessageDuplicate = "duplicate"
+	MessageNoSession = "no_session"
+)
+
 type Database interface {
 	RecordBatchElements(number float64)
 	RecordBatchInsertDuration(durMillis float64)
@@ -15,6 +22,10 @@ type Database interface {
 	IncreaseTotalRequests(method, table string)
 	IncreaseRedisRequests(method, table string)
 	RecordRedisRequestDuration(durMillis float64, method, table string)
+	IncreaseSaverMessages(platform, outcome string)
+	RecordBulkDroppedRows(size float64, db, table string)
+	IncreaseBulkSendRetries(db, table string)
+	RecordCHQueueDepth(size float64)
 	List() []prometheus.Collector
 }
 
@@ -27,6 +38,10 @@ type databaseImpl struct {
 	dbTotalRequests           *prometheus.CounterVec
 	cacheRedisRequests        *prometheus.CounterVec
 	cacheRedisRequestDuration *prometheus.HistogramVec
+	saverMessages             *prometheus.CounterVec
+	bulkDroppedRows           *prometheus.CounterVec
+	bulkSendRetries           *prometheus.CounterVec
+	chQueueDepth              prometheus.Gauge
 }
 
 func New(serviceName string) Database {
@@ -39,6 +54,10 @@ func New(serviceName string) Database {
 		dbTotalRequests:           newTotalRequests(serviceName),
 		cacheRedisRequests:        newRedisRequests(serviceName),
 		cacheRedisRequestDuration: newRedisRequestDuration(serviceName),
+		saverMessages:             newSaverMessages(serviceName),
+		bulkDroppedRows:           newBulkDroppedRows(serviceName),
+		bulkSendRetries:           newBulkSendRetries(serviceName),
+		chQueueDepth:              newCHQueueDepth(serviceName),
 	}
 }
 
@@ -52,6 +71,10 @@ func (d *databaseImpl) List() []prometheus.Collector {
 		d.dbTotalRequests,
 		d.cacheRedisRequests,
 		d.cacheRedisRequestDuration,
+		d.saverMessages,
+		d.bulkDroppedRows,
+		d.bulkSendRetries,
+		d.chQueueDepth,
 	}
 }
 
@@ -177,4 +200,66 @@ func newRedisRequestDuration(serviceName string) *prometheus.HistogramVec {
 
 func (d *databaseImpl) RecordRedisRequestDuration(durMillis float64, method, table string) {
 	d.cacheRedisRequestDuration.WithLabelValues(method, table).Observe(durMillis / 1000.0)
+}
+
+func newSaverMessages(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "messages_total",
+			Help:      "A counter displaying handled analytics messages by platform and outcome (saved/error/duplicate/no_session).",
+		},
+		[]string{"platform", "outcome"},
+	)
+}
+
+func (d *databaseImpl) IncreaseSaverMessages(platform, outcome string) {
+	d.saverMessages.WithLabelValues(platform, outcome).Inc()
+}
+
+func newBulkDroppedRows(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "bulk_dropped_rows_total",
+			Help:      "A counter displaying rows permanently dropped because the batch could not be parsed by the database (data loss).",
+		},
+		[]string{"db", "table"},
+	)
+}
+
+func (d *databaseImpl) RecordBulkDroppedRows(size float64, db, table string) {
+	if size == 0 {
+		return
+	}
+	d.bulkDroppedRows.WithLabelValues(db, table).Add(size)
+}
+
+func newBulkSendRetries(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "bulk_send_retries_total",
+			Help:      "A counter displaying transient bulk send failures that were retried.",
+		},
+		[]string{"db", "table"},
+	)
+}
+
+func (d *databaseImpl) IncreaseBulkSendRetries(db, table string) {
+	d.bulkSendRetries.WithLabelValues(db, table).Inc()
+}
+
+func newCHQueueDepth(serviceName string) prometheus.Gauge {
+	return prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: serviceName,
+			Name:      "ch_worker_queue_depth",
+			Help:      "A gauge displaying the current depth of the ClickHouse send-worker queue.",
+		},
+	)
+}
+
+func (d *databaseImpl) RecordCHQueueDepth(size float64) {
+	d.chQueueDepth.Set(size)
 }

--- a/ee/backend/pkg/metrics/ender/metrics.go
+++ b/ee/backend/pkg/metrics/ender/metrics.go
@@ -2,33 +2,55 @@ package ender
 
 import "github.com/prometheus/client_golang/prometheus"
 
+const (
+	EndNew             = "new"
+	EndUpdated         = "updated"
+	EndDuplicate       = "duplicate"
+	EndShorter         = "shorter"
+	EndNotFound        = "not_found"
+	EndFailed          = "failed"
+	EndNegative        = "negative"
+	StageLoad          = "load"
+	StageUpdate        = "update"
+	StageProduce       = "produce"
+	StageProduceCanvas = "produce_canvas"
+)
+
 type Ender interface {
 	IncreaseActiveSessions()
 	DecreaseActiveSessions()
-	IncreaseClosedSessions()
 	IncreaseTotalSessions()
+	IncreaseSessionEnds(outcome string, count float64)
+	IncreaseEndErrors(stage string, count float64)
+	IncreaseRebalanceEvictions(count float64)
 	List() []prometheus.Collector
 }
 
 type enderImpl struct {
-	activeSessions prometheus.Gauge
-	closedSessions prometheus.Counter
-	totalSessions  prometheus.Counter
+	activeSessions     prometheus.Gauge
+	totalSessions      prometheus.Counter
+	sessionEnds        *prometheus.CounterVec
+	endErrors          *prometheus.CounterVec
+	rebalanceEvictions prometheus.Counter
 }
 
 func New(serviceName string) Ender {
 	return &enderImpl{
-		activeSessions: newActiveSessions(serviceName),
-		closedSessions: newClosedSessions(serviceName),
-		totalSessions:  newTotalSessions(serviceName),
+		activeSessions:     newActiveSessions(serviceName),
+		totalSessions:      newTotalSessions(serviceName),
+		sessionEnds:        newSessionEnds(serviceName),
+		endErrors:          newEndErrors(serviceName),
+		rebalanceEvictions: newRebalanceEvictions(serviceName),
 	}
 }
 
 func (e *enderImpl) List() []prometheus.Collector {
 	return []prometheus.Collector{
 		e.activeSessions,
-		e.closedSessions,
 		e.totalSessions,
+		e.sessionEnds,
+		e.endErrors,
+		e.rebalanceEvictions,
 	}
 }
 
@@ -50,30 +72,69 @@ func (e *enderImpl) DecreaseActiveSessions() {
 	e.activeSessions.Dec()
 }
 
-func newClosedSessions(serviceName string) prometheus.Counter {
-	return prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: serviceName,
-			Name:      "sessions_closed",
-			Help:      "A counter displaying the number of closed sessions (sent SessionEnd).",
-		},
-	)
-}
-
-func (e *enderImpl) IncreaseClosedSessions() {
-	e.closedSessions.Inc()
-}
-
 func newTotalSessions(serviceName string) prometheus.Counter {
 	return prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: serviceName,
 			Name:      "sessions_total",
-			Help:      "A counter displaying the number of all processed sessions.",
+			Help:      "A counter displaying the number of sessions registered by the ender (first message seen).",
 		},
 	)
 }
 
 func (e *enderImpl) IncreaseTotalSessions() {
 	e.totalSessions.Inc()
+}
+
+func newSessionEnds(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "session_ends_total",
+			Help:      "A counter displaying finalised ended-session candidates by outcome (new/updated/duplicate/shorter/not_found/failed/negative).",
+		},
+		[]string{"outcome"},
+	)
+}
+
+func (e *enderImpl) IncreaseSessionEnds(outcome string, count float64) {
+	if count == 0 {
+		return
+	}
+	e.sessionEnds.WithLabelValues(outcome).Add(count)
+}
+
+func newEndErrors(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "session_end_errors_total",
+			Help:      "A counter displaying failures while finalising ended sessions by stage (load/update/produce are retried, produce_canvas is not).",
+		},
+		[]string{"stage"},
+	)
+}
+
+func (e *enderImpl) IncreaseEndErrors(stage string, count float64) {
+	if count == 0 {
+		return
+	}
+	e.endErrors.WithLabelValues(stage).Add(count)
+}
+
+func newRebalanceEvictions(serviceName string) prometheus.Counter {
+	return prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "rebalance_evicted_sessions_total",
+			Help:      "A counter displaying tracked sessions dropped from memory because their partition was revoked on rebalance.",
+		},
+	)
+}
+
+func (e *enderImpl) IncreaseRebalanceEvictions(count float64) {
+	if count == 0 {
+		return
+	}
+	e.rebalanceEvictions.Add(count)
 }

--- a/ee/backend/pkg/metrics/images/metrics.go
+++ b/ee/backend/pkg/metrics/images/metrics.go
@@ -6,35 +6,42 @@ import (
 	"openreplay/backend/pkg/metrics/common"
 )
 
+const (
+	FrameSaved      = "saved"
+	FrameBadMessage = "bad_message"
+	UploadOK        = "uploaded"
+	UploadMissing   = "missing"
+)
+
 type Images interface {
 	RecordSavingImageDuration(duration float64)
-	IncreaseTotalSavedImages()
-	IncreaseTotalCreatedArchives()
+	IncreaseFrames(outcome string)
+	IncreaseUploads(outcome string)
 	RecordUploadingDuration(duration float64)
 	List() []prometheus.Collector
 }
 
 type imagesImpl struct {
-	savingImageDuration  prometheus.Histogram
-	totalSavedImages     prometheus.Counter
-	totalCreatedArchives prometheus.Counter
-	uploadingDuration    prometheus.Histogram
+	savingImageDuration prometheus.Histogram
+	frames              *prometheus.CounterVec
+	uploads             *prometheus.CounterVec
+	uploadingDuration   prometheus.Histogram
 }
 
 func New(serviceName string) Images {
 	return &imagesImpl{
-		savingImageDuration:  newSavingImageDuration(serviceName),
-		totalSavedImages:     newTotalSavedImages(serviceName),
-		totalCreatedArchives: newTotalCreatedArchives(serviceName),
-		uploadingDuration:    newUploadingDuration(serviceName),
+		savingImageDuration: newSavingImageDuration(serviceName),
+		frames:              newFrames(serviceName),
+		uploads:             newUploads(serviceName),
+		uploadingDuration:   newUploadingDuration(serviceName),
 	}
 }
 
 func (i *imagesImpl) List() []prometheus.Collector {
 	return []prometheus.Collector{
 		i.savingImageDuration,
-		i.totalSavedImages,
-		i.totalCreatedArchives,
+		i.frames,
+		i.uploads,
 		i.uploadingDuration,
 	}
 }
@@ -54,32 +61,34 @@ func (i *imagesImpl) RecordSavingImageDuration(duration float64) {
 	i.savingImageDuration.Observe(duration)
 }
 
-func newTotalSavedImages(serviceName string) prometheus.Counter {
-	return prometheus.NewCounter(
+func newFrames(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: serviceName,
-			Name:      "total_saved_images",
-			Help:      "A counter displaying the total number of saved images.",
+			Name:      "frames_total",
+			Help:      "A counter displaying consumed screenshot frames by outcome (saved/bad_message).",
 		},
+		[]string{"outcome"},
 	)
 }
 
-func (i *imagesImpl) IncreaseTotalSavedImages() {
-	i.totalSavedImages.Inc()
+func (i *imagesImpl) IncreaseFrames(outcome string) {
+	i.frames.WithLabelValues(outcome).Inc()
 }
 
-func newTotalCreatedArchives(serviceName string) prometheus.Counter {
-	return prometheus.NewCounter(
+func newUploads(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: serviceName,
-			Name:      "total_created_archives",
-			Help:      "A counter displaying the total number of created archives.",
+			Name:      "uploads_total",
+			Help:      "A counter displaying screenshot archive uploads by outcome (uploaded/missing).",
 		},
+		[]string{"outcome"},
 	)
 }
 
-func (i *imagesImpl) IncreaseTotalCreatedArchives() {
-	i.totalCreatedArchives.Inc()
+func (i *imagesImpl) IncreaseUploads(outcome string) {
+	i.uploads.WithLabelValues(outcome).Inc()
 }
 
 func newUploadingDuration(serviceName string) prometheus.Histogram {

--- a/ee/backend/pkg/metrics/sink/metrics.go
+++ b/ee/backend/pkg/metrics/sink/metrics.go
@@ -6,14 +6,17 @@ import (
 	"openreplay/backend/pkg/metrics/common"
 )
 
+const (
+	MessageWritten  = "written"
+	MessageFiltered = "filtered"
+	MessageTrigger  = "trigger"
+	MessageError    = "error"
+)
+
 type Sink interface {
-	RecordMessageSize(size float64)
-	IncreaseWrittenMessages()
-	IncreaseTotalMessages()
+	IncreaseMessages(outcome string)
 	RecordBatchSize(size float64)
-	IncreaseTotalBatches()
 	RecordWrittenBytes(size float64, fileType string)
-	IncreaseTotalWrittenBytes(size float64, fileType string)
 	IncreaseCachedAssets()
 	DecreaseCachedAssets()
 	IncreaseSkippedAssets()
@@ -22,17 +25,17 @@ type Sink interface {
 	RecordProcessAssetDuration(durMillis float64)
 	RecordOpenFiles(count, limit float64)
 	IncreaseFileEvictions(count float64)
+	RecordSyncDuration(durMillis float64)
+	IncreaseSyncedBytes(size float64)
+	IncreaseStaleSessionsEvicted(count float64)
+	IncreaseTriggerErrors()
 	List() []prometheus.Collector
 }
 
 type sinkImpl struct {
-	messageSize          prometheus.Histogram
-	writtenMessages      prometheus.Counter
-	totalMessages        prometheus.Counter
+	messages             *prometheus.CounterVec
 	batchSize            prometheus.Histogram
-	totalBatches         prometheus.Counter
 	writtenBytes         *prometheus.HistogramVec
-	totalWrittenBytes    *prometheus.CounterVec
 	cachedAssets         prometheus.Gauge
 	skippedAssets        prometheus.Counter
 	totalAssets          prometheus.Counter
@@ -41,17 +44,17 @@ type sinkImpl struct {
 	openFiles            prometheus.Gauge
 	openFilesLimit       prometheus.Gauge
 	fileEvictions        prometheus.Counter
+	syncDuration         prometheus.Histogram
+	syncedBytes          prometheus.Counter
+	staleEvictions       prometheus.Counter
+	triggerErrors        prometheus.Counter
 }
 
 func New(serviceName string) Sink {
 	return &sinkImpl{
-		messageSize:          newMessageSize(serviceName),
-		writtenMessages:      newWrittenMessages(serviceName),
-		totalMessages:        newTotalMessages(serviceName),
+		messages:             newMessages(serviceName),
 		batchSize:            newBatchSize(serviceName),
-		totalBatches:         newTotalBatches(serviceName),
 		writtenBytes:         newWrittenBytes(serviceName),
-		totalWrittenBytes:    newTotalWrittenBytes(serviceName),
 		cachedAssets:         newCachedAssets(serviceName),
 		skippedAssets:        newSkippedAssets(serviceName),
 		totalAssets:          newTotalAssets(serviceName),
@@ -60,18 +63,18 @@ func New(serviceName string) Sink {
 		openFiles:            newOpenFiles(serviceName),
 		openFilesLimit:       newOpenFilesLimit(serviceName),
 		fileEvictions:        newFileEvictions(serviceName),
+		syncDuration:         newSyncDuration(serviceName),
+		syncedBytes:          newSyncedBytes(serviceName),
+		staleEvictions:       newStaleEvictions(serviceName),
+		triggerErrors:        newTriggerErrors(serviceName),
 	}
 }
 
 func (s *sinkImpl) List() []prometheus.Collector {
 	return []prometheus.Collector{
-		s.messageSize,
-		s.writtenMessages,
-		s.totalMessages,
+		s.messages,
 		s.batchSize,
-		s.totalBatches,
 		s.writtenBytes,
-		s.totalWrittenBytes,
 		s.cachedAssets,
 		s.skippedAssets,
 		s.totalAssets,
@@ -80,50 +83,26 @@ func (s *sinkImpl) List() []prometheus.Collector {
 		s.openFiles,
 		s.openFilesLimit,
 		s.fileEvictions,
+		s.syncDuration,
+		s.syncedBytes,
+		s.staleEvictions,
+		s.triggerErrors,
 	}
 }
 
-func newMessageSize(serviceName string) prometheus.Histogram {
-	return prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: serviceName,
-			Name:      "message_size_bytes",
-			Help:      "A histogram displaying the size of each message in bytes.",
-			Buckets:   common.DefaultSizeBuckets,
-		},
-	)
-}
-
-func (s *sinkImpl) RecordMessageSize(size float64) {
-	s.messageSize.Observe(size)
-}
-
-func newWrittenMessages(serviceName string) prometheus.Counter {
-	return prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: serviceName,
-			Name:      "messages_written",
-			Help:      "A counter displaying the total number of all written messages.",
-		},
-	)
-}
-
-func (s *sinkImpl) IncreaseWrittenMessages() {
-	s.writtenMessages.Inc()
-}
-
-func newTotalMessages(serviceName string) prometheus.Counter {
-	return prometheus.NewCounter(
+func newMessages(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: serviceName,
 			Name:      "messages_total",
-			Help:      "A counter displaying the total number of all processed messages.",
+			Help:      "A counter displaying consumed messages by outcome (written/filtered/trigger/error).",
 		},
+		[]string{"outcome"},
 	)
 }
 
-func (s *sinkImpl) IncreaseTotalMessages() {
-	s.totalMessages.Inc()
+func (s *sinkImpl) IncreaseMessages(outcome string) {
+	s.messages.WithLabelValues(outcome).Inc()
 }
 
 func newBatchSize(serviceName string) prometheus.Histogram {
@@ -139,20 +118,6 @@ func newBatchSize(serviceName string) prometheus.Histogram {
 
 func (s *sinkImpl) RecordBatchSize(size float64) {
 	s.batchSize.Observe(size)
-}
-
-func newTotalBatches(serviceName string) prometheus.Counter {
-	return prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: serviceName,
-			Name:      "batches_total",
-			Help:      "A counter displaying the total number of all written batches.",
-		},
-	)
-}
-
-func (s *sinkImpl) IncreaseTotalBatches() {
-	s.totalBatches.Inc()
 }
 
 func newWrittenBytes(serviceName string) *prometheus.HistogramVec {
@@ -172,25 +137,6 @@ func (s *sinkImpl) RecordWrittenBytes(size float64, fileType string) {
 		return
 	}
 	s.writtenBytes.WithLabelValues(fileType).Observe(size)
-	s.IncreaseTotalWrittenBytes(size, fileType)
-}
-
-func newTotalWrittenBytes(serviceName string) *prometheus.CounterVec {
-	return prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: serviceName,
-			Name:      "written_bytes_total",
-			Help:      "A counter displaying the total number of bytes written to all session files.",
-		},
-		[]string{"file_type"},
-	)
-}
-
-func (s *sinkImpl) IncreaseTotalWrittenBytes(size float64, fileType string) {
-	if size == 0 {
-		return
-	}
-	s.totalWrittenBytes.WithLabelValues(fileType).Add(size)
 }
 
 func newCachedAssets(serviceName string) prometheus.Gauge {
@@ -309,4 +255,67 @@ func (s *sinkImpl) IncreaseFileEvictions(count float64) {
 		return
 	}
 	s.fileEvictions.Add(count)
+}
+
+func newSyncDuration(serviceName string) prometheus.Histogram {
+	return prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: serviceName,
+			Name:      "sync_duration_seconds",
+			Help:      "A histogram displaying the duration of periodic session file syncs to disk in seconds.",
+			Buckets:   common.DefaultDurationBuckets,
+		},
+	)
+}
+
+func (s *sinkImpl) RecordSyncDuration(durMillis float64) {
+	s.syncDuration.Observe(durMillis / 1000.0)
+}
+
+func newSyncedBytes(serviceName string) prometheus.Counter {
+	return prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "synced_bytes_total",
+			Help:      "A counter displaying the total number of bytes flushed to disk by periodic syncs.",
+		},
+	)
+}
+
+func (s *sinkImpl) IncreaseSyncedBytes(size float64) {
+	if size == 0 {
+		return
+	}
+	s.syncedBytes.Add(size)
+}
+
+func newStaleEvictions(serviceName string) prometheus.Counter {
+	return prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "stale_sessions_evicted_total",
+			Help:      "A counter displaying the total number of sessions evicted by TTL due to inactivity (potential data loss).",
+		},
+	)
+}
+
+func (s *sinkImpl) IncreaseStaleSessionsEvicted(count float64) {
+	if count == 0 {
+		return
+	}
+	s.staleEvictions.Add(count)
+}
+
+func newTriggerErrors(serviceName string) prometheus.Counter {
+	return prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "trigger_produce_errors_total",
+			Help:      "A counter displaying failures to produce SessionEnd to the trigger topics (storage may miss the session).",
+		},
+	)
+}
+
+func (s *sinkImpl) IncreaseTriggerErrors() {
+	s.triggerErrors.Inc()
 }

--- a/ee/backend/pkg/metrics/spot/spot.go
+++ b/ee/backend/pkg/metrics/spot/spot.go
@@ -1,0 +1,132 @@
+package spot
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"openreplay/backend/pkg/metrics/common"
+)
+
+const (
+	SpotProcessed   = "processed"
+	SpotSkipped     = "skipped"
+	SpotFailed      = "failed"
+	StageDownload   = "download"
+	StageCrop       = "crop"
+	StageCropUpload = "crop_upload"
+	StageTranscode  = "transcode"
+	StageUpload     = "upload"
+	StagePlaylist   = "playlist"
+)
+
+type Spot interface {
+	IncreaseSpots(outcome string)
+	IncreaseTaskFailures(stage string)
+	RecordStageDuration(durMillis float64, stage string)
+	RecordOriginalVideoSize(size float64)
+	RecordCroppedVideoSize(size float64)
+	List() []prometheus.Collector
+}
+
+type spotImpl struct {
+	spots             *prometheus.CounterVec
+	taskFailures      *prometheus.CounterVec
+	stageDuration     *prometheus.HistogramVec
+	originalVideoSize prometheus.Histogram
+	croppedVideoSize  prometheus.Histogram
+}
+
+func New(serviceName string) Spot {
+	return &spotImpl{
+		spots:             newSpots(serviceName),
+		taskFailures:      newTaskFailures(serviceName),
+		stageDuration:     newStageDuration(serviceName),
+		originalVideoSize: newOriginalVideoSize(serviceName),
+		croppedVideoSize:  newCroppedVideoSize(serviceName),
+	}
+}
+
+func (s *spotImpl) List() []prometheus.Collector {
+	return []prometheus.Collector{
+		s.spots,
+		s.taskFailures,
+		s.stageDuration,
+		s.originalVideoSize,
+		s.croppedVideoSize,
+	}
+}
+
+func newSpots(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "spots_total",
+			Help:      "A counter displaying spot videos handled by the transcoder by outcome (processed/skipped/failed).",
+		},
+		[]string{"outcome"},
+	)
+}
+
+func (s *spotImpl) IncreaseSpots(outcome string) {
+	s.spots.WithLabelValues(outcome).Inc()
+}
+
+func newTaskFailures(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "task_failures_total",
+			Help:      "A counter displaying failed transcoding tasks by pipeline stage (download/crop/crop_upload/transcode/upload/playlist).",
+		},
+		[]string{"stage"},
+	)
+}
+
+func (s *spotImpl) IncreaseTaskFailures(stage string) {
+	s.taskFailures.WithLabelValues(stage).Inc()
+}
+
+func newStageDuration(serviceName string) *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: serviceName,
+			Name:      "stage_duration_seconds",
+			Help:      "A histogram displaying the duration of each successful transcoding pipeline stage in seconds.",
+			Buckets:   common.DefaultDurationBuckets,
+		},
+		[]string{"stage"},
+	)
+}
+
+func (s *spotImpl) RecordStageDuration(durMillis float64, stage string) {
+	s.stageDuration.WithLabelValues(stage).Observe(durMillis / 1000.0)
+}
+
+func newOriginalVideoSize(serviceName string) prometheus.Histogram {
+	return prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: serviceName,
+			Name:      "original_video_size_bytes",
+			Help:      "A histogram displaying the size of each downloaded origin spot video in bytes.",
+			Buckets:   common.VideoSizeBuckets,
+		},
+	)
+}
+
+func (s *spotImpl) RecordOriginalVideoSize(size float64) {
+	s.originalVideoSize.Observe(size)
+}
+
+func newCroppedVideoSize(serviceName string) prometheus.Histogram {
+	return prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: serviceName,
+			Name:      "cropped_video_size_bytes",
+			Help:      "A histogram displaying the size of each cropped spot video in bytes.",
+			Buckets:   common.VideoSizeBuckets,
+		},
+	)
+}
+
+func (s *spotImpl) RecordCroppedVideoSize(size float64) {
+	s.croppedVideoSize.Observe(size)
+}

--- a/ee/backend/pkg/metrics/storage/metrics.go
+++ b/ee/backend/pkg/metrics/storage/metrics.go
@@ -6,32 +6,58 @@ import (
 	"openreplay/backend/pkg/metrics/common"
 )
 
+const (
+	UploadOK      = "uploaded"
+	UploadMissing = "missing"
+	UploadFailed  = "failed"
+)
+
 type Storage interface {
 	RecordSessionSize(fileSize float64, fileType string)
-	IncreaseStorageTotalSessions(fileType string)
 	RecordSessionUploadDuration(durMillis float64, fileType, mode string)
+	IncreaseUploads(fileType, outcome string)
+	IncreaseUploadedBytes(size float64, fileType string)
+	IncreaseFailedSessions()
+	IncreaseSessionsNotFound()
+	IncreaseSessionsWithoutStart()
+	RecordDrainDuration(durMillis float64)
 	List() []prometheus.Collector
 }
 
 type storageImpl struct {
 	sessionSize           *prometheus.HistogramVec
-	totalSessions         *prometheus.CounterVec
 	sessionUploadDuration *prometheus.HistogramVec
+	uploads               *prometheus.CounterVec
+	uploadedBytes         *prometheus.CounterVec
+	failedSessions        prometheus.Counter
+	sessionsNotFound      prometheus.Counter
+	sessionsWithoutStart  prometheus.Counter
+	drainDuration         prometheus.Histogram
 }
 
 func New(serviceName string) Storage {
 	return &storageImpl{
 		sessionSize:           newSessionSize(serviceName),
-		totalSessions:         newTotalSessions(serviceName),
 		sessionUploadDuration: newSessionUploadDuration(serviceName),
+		uploads:               newUploads(serviceName),
+		uploadedBytes:         newUploadedBytes(serviceName),
+		failedSessions:        newFailedSessions(serviceName),
+		sessionsNotFound:      newSessionsNotFound(serviceName),
+		sessionsWithoutStart:  newSessionsWithoutStart(serviceName),
+		drainDuration:         newDrainDuration(serviceName),
 	}
 }
 
 func (s *storageImpl) List() []prometheus.Collector {
 	return []prometheus.Collector{
 		s.sessionSize,
-		s.totalSessions,
 		s.sessionUploadDuration,
+		s.uploads,
+		s.uploadedBytes,
+		s.failedSessions,
+		s.sessionsNotFound,
+		s.sessionsWithoutStart,
+		s.drainDuration,
 	}
 }
 
@@ -51,21 +77,6 @@ func (s *storageImpl) RecordSessionSize(fileSize float64, fileType string) {
 	s.sessionSize.WithLabelValues(fileType).Observe(fileSize)
 }
 
-func newTotalSessions(serviceName string) *prometheus.CounterVec {
-	return prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: serviceName,
-			Name:      "sessions_total",
-			Help:      "A counter displaying the total number of session files uploaded, partitioned by file_type.",
-		},
-		[]string{"file_type"},
-	)
-}
-
-func (s *storageImpl) IncreaseStorageTotalSessions(fileType string) {
-	s.totalSessions.WithLabelValues(fileType).Inc()
-}
-
 func newSessionUploadDuration(serviceName string) *prometheus.HistogramVec {
 	return prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -80,4 +91,94 @@ func newSessionUploadDuration(serviceName string) *prometheus.HistogramVec {
 
 func (s *storageImpl) RecordSessionUploadDuration(durMillis float64, fileType, mode string) {
 	s.sessionUploadDuration.WithLabelValues(fileType, mode).Observe(durMillis / 1000.0)
+}
+
+func newUploads(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "uploads_total",
+			Help:      "A counter displaying session file uploads by outcome (uploaded/missing/failed).",
+		},
+		[]string{"file_type", "outcome"},
+	)
+}
+
+func (s *storageImpl) IncreaseUploads(fileType, outcome string) {
+	s.uploads.WithLabelValues(fileType, outcome).Inc()
+}
+
+func newUploadedBytes(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "uploaded_bytes_total",
+			Help:      "A counter displaying bytes actually sent to object storage (post compression/encryption).",
+		},
+		[]string{"file_type"},
+	)
+}
+
+func (s *storageImpl) IncreaseUploadedBytes(size float64, fileType string) {
+	if size == 0 {
+		return
+	}
+	s.uploadedBytes.WithLabelValues(fileType).Add(size)
+}
+
+func newFailedSessions(serviceName string) prometheus.Counter {
+	return prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "failed_sessions_total",
+			Help:      "A counter displaying sessions whose DOM upload failed — the replay is broken or incomplete.",
+		},
+	)
+}
+
+func (s *storageImpl) IncreaseFailedSessions() {
+	s.failedSessions.Inc()
+}
+
+func newSessionsNotFound(serviceName string) prometheus.Counter {
+	return prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "sessions_not_found_total",
+			Help:      "A counter displaying SessionEnd triggers for which no local session files were found.",
+		},
+	)
+}
+
+func (s *storageImpl) IncreaseSessionsNotFound() {
+	s.sessionsNotFound.Inc()
+}
+
+func newSessionsWithoutStart(serviceName string) prometheus.Counter {
+	return prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: serviceName,
+			Name:      "sessions_without_start_total",
+			Help:      "A counter displaying sessions uploaded without their first DOM part (degraded replay).",
+		},
+	)
+}
+
+func (s *storageImpl) IncreaseSessionsWithoutStart() {
+	s.sessionsWithoutStart.Inc()
+}
+
+func newDrainDuration(serviceName string) prometheus.Histogram {
+	return prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: serviceName,
+			Name:      "drain_duration_seconds",
+			Help:      "A histogram displaying how long the upload pool takes to drain before a consumer commit (upload backlog).",
+			Buckets:   common.DefaultDurationBuckets,
+		},
+	)
+}
+
+func (s *storageImpl) RecordDrainDuration(durMillis float64) {
+	s.drainDuration.Observe(durMillis / 1000.0)
 }

--- a/ee/backend/pkg/metrics/web/metrics.go
+++ b/ee/backend/pkg/metrics/web/metrics.go
@@ -8,24 +8,38 @@ import (
 	"openreplay/backend/pkg/metrics/common"
 )
 
+const (
+	RejectEmptyBody           = "empty_body"
+	RejectTooLarge            = "too_large"
+	RejectBadJSON             = "bad_json"
+	RejectTrackerOutdated     = "tracker_outdated"
+	RejectNoProjectKey        = "no_project_key"
+	RejectProjectNotFound     = "project_not_found"
+	RejectProjectError        = "project_error"
+	RejectPlatformUnsupported = "platform_unsupported"
+	RejectBrowserUnrecognized = "browser_unrecognized"
+	RejectSampleRateMiss      = "sample_rate_miss"
+	RejectInternalError       = "internal_error"
+)
+
 type Web interface {
 	RecordRequestSize(size float64, url string, code int)
 	RecordRequestDuration(durMillis float64, url string, code int)
-	IncreaseTotalRequests()
+	IncreaseStartRejects(platform, reason string)
 	List() []prometheus.Collector
 }
 
 type webImpl struct {
 	httpRequestSize     *prometheus.HistogramVec
 	httpRequestDuration *prometheus.HistogramVec
-	httpTotalRequests   prometheus.Counter
+	startRejects        *prometheus.CounterVec
 }
 
 func New(serviceName string) Web {
 	return &webImpl{
 		httpRequestSize:     newRequestSizeMetric(serviceName),
 		httpRequestDuration: newRequestDurationMetric(serviceName),
-		httpTotalRequests:   newTotalRequestsMetric(serviceName),
+		startRejects:        newStartRejects(serviceName),
 	}
 }
 
@@ -33,7 +47,7 @@ func (w *webImpl) List() []prometheus.Collector {
 	return []prometheus.Collector{
 		w.httpRequestSize,
 		w.httpRequestDuration,
-		w.httpTotalRequests,
+		w.startRejects,
 	}
 }
 
@@ -69,16 +83,17 @@ func (w *webImpl) RecordRequestDuration(durMillis float64, url string, code int)
 	w.httpRequestDuration.WithLabelValues(url, strconv.Itoa(code)).Observe(durMillis / 1000.0)
 }
 
-func newTotalRequestsMetric(serviceName string) prometheus.Counter {
-	return prometheus.NewCounter(
+func newStartRejects(serviceName string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: serviceName,
-			Name:      "web_requests_total",
-			Help:      "A counter displaying the number all HTTP requests.",
+			Name:      "start_rejects_total",
+			Help:      "A counter displaying rejected session-start requests by platform and reason (sessions lost at the front door).",
 		},
+		[]string{"platform", "reason"},
 	)
 }
 
-func (w *webImpl) IncreaseTotalRequests() {
-	w.httpTotalRequests.Inc()
+func (w *webImpl) IncreaseStartRejects(platform, reason string) {
+	w.startRejects.WithLabelValues(platform, reason).Inc()
 }

--- a/ee/backend/pkg/sessionmanager/manager.go
+++ b/ee/backend/pkg/sessionmanager/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"openreplay/backend/pkg/logger"
+	assistMetrics "openreplay/backend/pkg/metrics/assist"
 )
 
 const (
@@ -59,9 +60,10 @@ type sessionManagerImpl struct {
 	sorted    []*SessionData
 	batchSize int
 	scanSize  int64
+	metrics   assistMetrics.Assist
 }
 
-func New(log logger.Logger, cacheTTL time.Duration, batchSize int, scanSize int64, redis *redis.Client) (SessionManager, error) {
+func New(log logger.Logger, cacheTTL time.Duration, batchSize int, scanSize int64, redis *redis.Client, metrics assistMetrics.Assist) (SessionManager, error) {
 	switch {
 	case log == nil:
 		return nil, fmt.Errorf("logger is required")
@@ -73,6 +75,8 @@ func New(log logger.Logger, cacheTTL time.Duration, batchSize int, scanSize int6
 		return nil, fmt.Errorf("scan size is required")
 	case redis == nil:
 		return nil, fmt.Errorf("redis client is required")
+	case metrics == nil:
+		return nil, fmt.Errorf("metrics is required")
 	}
 	sm := &sessionManagerImpl{
 		ctx:       context.Background(),
@@ -86,6 +90,7 @@ func New(log logger.Logger, cacheTTL time.Duration, batchSize int, scanSize int6
 		sorted:    make([]*SessionData, 0),
 		batchSize: batchSize,
 		scanSize:  scanSize,
+		metrics:   metrics,
 	}
 	return sm, nil
 }
@@ -177,9 +182,11 @@ func (sm *sessionManagerImpl) getOnlineSessionIDs() (map[string]struct{}, error)
 		return nil, err
 	}
 	sm.log.Debug(sm.ctx, "Found %d nodes", len(nodeIDs))
+	sm.metrics.RecordNodes(float64(len(nodeIDs)))
 
 	allSessionIDs := sm.getAllNodeSessions(nodeIDs)
 	sm.log.Debug(sm.ctx, "Collected %d unique session IDs", len(allSessionIDs))
+	sm.metrics.RecordOnlineSessions(float64(len(allSessionIDs)))
 	return allSessionIDs, nil
 }
 

--- a/ee/backend/pkg/storage/encryptor.go
+++ b/ee/backend/pkg/storage/encryptor.go
@@ -20,14 +20,14 @@ func GenerateEncryptionKey() []byte {
 	return key
 }
 
-func (u *uploaderImpl) streamEncryptionToS3(name, key, srcPath string) error {
+func (u *uploaderImpl) streamEncryptionToS3(name, key, srcPath string) (int64, error) {
 	keyBytes := []byte(key)
 	if len(keyBytes) != keyLen {
-		return fmt.Errorf("invalid encryption key length: %d, expected %d", len(keyBytes), keyLen)
+		return 0, fmt.Errorf("invalid encryption key length: %d, expected %d", len(keyBytes), keyLen)
 	}
 	block, err := aes.NewCipher(keyBytes)
 	if err != nil {
-		return fmt.Errorf("failed to create AES cipher: %s", err)
+		return 0, fmt.Errorf("failed to create AES cipher: %s", err)
 	}
 
 	pr, pw := io.Pipe()
@@ -66,10 +66,11 @@ func (u *uploaderImpl) streamEncryptionToS3(name, key, srcPath string) error {
 		_, wErr = io.CopyBuffer(w, f, make([]byte, 256*1024))
 	}()
 
-	if err := u.objStorage.Upload(pr, name, "application/octet-stream", objectstorage.NoContentEncoding, objectstorage.NoCompression); err != nil {
+	cr := &countingReader{r: pr}
+	if err := u.objStorage.Upload(cr, name, "application/octet-stream", objectstorage.NoContentEncoding, objectstorage.NoCompression); err != nil {
 		pr.CloseWithError(err)
 		<-errCh
-		return err
+		return cr.n, err
 	}
-	return <-errCh
+	return cr.n, <-errCh
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reworks backend metrics to use outcome and stage labels instead of coarse counters, and adds metrics to services that previously had none (`assist`, `connector`, session handlers). Adds new operational metrics: sync duration, synced bytes, ClickHouse queue depth, bulk retries and dropped rows, drain duration, and rebalance evictions.

**Breaking metric changes**
- Removed `ws_connections_online`, `ws_rooms_online`, `IncreaseTotalBatches`, `IncreaseTotalRequests`, `IncreaseClosedSessions`, and separate per-stage spot duration metrics.
- Spot durations are now a single labeled metric, and `IncreaseTotalSavedImages` was replaced with outcome-labeled `IncreaseFrames`.

<sup>Written for commit 0258746966d659d5ac1fb363f158a1ee98415bdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

