### PR TITLE
fix(player): render replayed canvas under the sandboxed iframe

### DIFF
--- a/frontend/app/player/web/Screen/Screen.ts
+++ b/frontend/app/player/web/Screen/Screen.ts
@@ -74,6 +74,13 @@ export default class Screen {
   ) {
     const iframe = document.createElement('iframe');
     iframe.className = styles.iframe;
+    // These flags are fixed when the browsing
+    // context is created, so this MUST be set before the iframe is attached.
+    // No allow-scripts: a crafted recording then can never execute JS in the
+    // app origin, whatever slips past sanitize.ts. That also disables scripting
+    // for the document, which stops <canvas> from painting its bitmap — see
+    // CanvasManager#paintFrame for how replayed canvases are rendered instead.
+    iframe.setAttribute('sandbox', 'allow-same-origin');
     this.iframe = iframe;
 
     const overlay = document.createElement('div');
@@ -146,6 +153,17 @@ export default class Screen {
 
   setBorderStyle(style: { outline: string }) {
     return Object.assign(this.screen.style, style);
+  }
+
+  /**
+   * Whether scripting is enabled for the replay document — i.e. whether a
+   * <canvas> in it will paint its bitmap at all. False under a sandbox without
+   * allow-scripts. See CanvasManager#paintFrame for why canvas replay needs to
+   * know.
+   */
+  get scriptingEnabled(): boolean {
+    const sandbox = this.iframe.getAttribute('sandbox');
+    return sandbox === null || sandbox.split(/\s+/).includes('allow-scripts');
   }
 
   get window(): WindowProxy | null {

--- a/frontend/app/player/web/TabManager.ts
+++ b/frontend/app/player/web/TabManager.ts
@@ -259,6 +259,7 @@ export default class TabSessionManager {
             [tarball, mp4file, framesFile],
             this.getNode as (id: number) => VElement | undefined,
             this.sessionStart,
+            !this.screen.scriptingEnabled,
           );
           this.canvasManagers[managerId] = {
             manager,

--- a/frontend/app/player/web/managers/CanvasManager.ts
+++ b/frontend/app/player/web/managers/CanvasManager.ts
@@ -43,6 +43,11 @@ export default class CanvasManager extends ListWalker<Timestamp> {
     private readonly links: [tar?: string, mp4?: string, frames?: string],
     private readonly getNode: (id: number) => VElement | undefined,
     private readonly sessionStart: number,
+    /**
+     * The replay document has scripting disabled, so the canvas bitmap is never
+     * painted and frames have to reach the screen another way. See paintFrame.
+     */
+    private readonly useCssPaint: boolean = false,
   ) {
     super();
     // try frames first, then tar, then mp4
@@ -186,16 +191,18 @@ export default class CanvasManager extends ListWalker<Timestamp> {
         if (node && node.node) {
           const canvasCtx = (node.node as HTMLCanvasElement).getContext('2d');
           const canvasEl = node.node as HTMLVideoElement;
-          requestAnimationFrame(() => {
-            canvasCtx?.clearRect(0, 0, canvasEl.width, canvasEl.height);
-            canvasCtx?.drawImage(
-              this.snapImage,
-              0,
-              0,
-              canvasEl.width,
-              canvasEl.height,
-            );
-          });
+          if (!this.useCssPaint) {
+            requestAnimationFrame(() => {
+              canvasCtx?.clearRect(0, 0, canvasEl.width, canvasEl.height);
+              canvasCtx?.drawImage(
+                this.snapImage,
+                0,
+                0,
+                canvasEl.width,
+                canvasEl.height,
+              );
+            });
+          }
           this.debugCanvas
             ?.getContext('2d')
             ?.drawImage(this.snapImage, 0, 0, 300, 200);
@@ -242,6 +249,25 @@ export default class CanvasManager extends ListWalker<Timestamp> {
           canvasEl.width,
           canvasEl.height,
         );
+        if (this.useCssPaint) {
+          // Unlike the snapshot modes there is no per-frame image to hand to
+          // paintFrame, so re-encode what was just drawn. Throttled to ~10fps by
+          // the 100ms guard above. Quality is high because this is a second
+          // lossy pass over already-lossy video frames; at these sizes the cost
+          // over 0.8 is ~20% more bytes, which never touch the network.
+          // The bitmap cannot be tainted (the video plays a same-origin blob
+          // URL), so toBlob will not fail on security grounds.
+          (node.node as HTMLCanvasElement).toBlob(
+            (blob) => {
+              if (!blob) return;
+              const url = URL.createObjectURL(blob);
+              this.paintFrame(url);
+              this.retainFrame(url);
+            },
+            'image/webp',
+            0.95,
+          );
+        }
       } else {
         console.error(`VideoMode CanvasManager: Node ${this.nodeId} not found`);
       }
@@ -249,17 +275,71 @@ export default class CanvasManager extends ListWalker<Timestamp> {
   };
 
   previousBlob: string = '';
+
+  private warnedMissingNode = false;
+
+  /**
+   * Render the current frame as the canvas element's CSS background.
+   *
+   * The replay iframe is sandboxed without allow-scripts (see Screen.ts), so
+   * scripting is disabled for its document — and per the HTML spec a <canvas>
+   * in a script-disabled document renders its *fallback content* instead of its
+   * bitmap. drawImage() still fills the bitmap (getImageData reads it straight
+   * back), nothing throws and nothing logs, so the canvas just silently stays
+   * blank. A CSS background is painted either way and reproduces drawImage's
+   * stretch-to-content-box geometry exactly.
+   *
+   * This and the bitmap path are mutually exclusive — only one of them can ever
+   * be visible, and doing both would decode every frame twice.
+   */
+  private paintFrame = (blobUrl: string) => {
+    const canvasEl = this.getNode(parseInt(this.nodeId, 10))?.node as
+      | HTMLCanvasElement
+      | undefined;
+    if (!canvasEl) {
+      // Once per manager: frames keep arriving, and a node that is merely late
+      // would otherwise flood the console.
+      if (!this.warnedMissingNode) {
+        this.warnedMissingNode = true;
+        console.error(`CanvasManager: Node ${this.nodeId} not found`);
+      }
+      return;
+    }
+    Object.assign(canvasEl.style, {
+      backgroundImage: `url("${blobUrl}")`,
+      backgroundSize: '100% 100%',
+      backgroundRepeat: 'no-repeat',
+      // The bitmap is painted into the content box, so anchor the background
+      // there too — otherwise a padded canvas would be offset against it.
+      backgroundOrigin: 'content-box',
+      backgroundClip: 'content-box',
+    });
+  };
+
+  /** Take ownership of the displayed frame and release the one it replaced. */
+  private retainFrame(blobUrl: string) {
+    const previous = this.previousBlob;
+    this.previousBlob = blobUrl;
+    if (previous && previous !== blobUrl) {
+      URL.revokeObjectURL(previous);
+    }
+  }
+
   moveReadySnap = (t: number) => {
     const msg = this.getNew(t);
     if (msg) {
       const file = this.snapshots[msg.time];
       if (file) {
         const blobUrl = file.getBlobUrl();
-        this.snapImage.src = blobUrl;
-        if (this.previousBlob) {
-          URL.revokeObjectURL(this.previousBlob);
+        if (this.useCssPaint) {
+          this.paintFrame(blobUrl);
         }
-        this.previousBlob = blobUrl;
+        // Decoding into the <img> is only worth it if something consumes it:
+        // the canvas bitmap, or the debug strip when it is switched on.
+        if (!this.useCssPaint || this.debugCanvas) {
+          this.snapImage.src = blobUrl;
+        }
+        this.retainFrame(blobUrl);
       }
     }
   };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes replayed canvas rendering under the sandboxed iframe. Previously the canvas stayed blank because the iframe sandbox without `allow-scripts` prevents canvas bitmap painting; now frames are rendered as CSS backgrounds instead.

**Bug Fixes**
- Sets the sandbox attribute on the player iframe; only the standalone `player` package had it before.
- Adds `scriptingEnabled` to `Screen` and passes its negation to `CanvasManager`.
- When scripting is disabled, each frame is re-encoded to WebP and applied as the canvas's CSS background, throttled to ~10fps.
- The bitmap and CSS paint paths are mutually exclusive to avoid decoding frames twice.

<sup>Written for commit 2c18e7e977d7e67ae36c910051401e4a60f55d40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

