### PR TITLE
ui: dynamic metadata items sizing, smaller width limit; (#4844)

### DIFF
--- a/frontend/app/components/shared/SessionItem/MetaItem/MetaItem.tsx
+++ b/frontend/app/components/shared/SessionItem/MetaItem/MetaItem.tsx
@@ -12,21 +12,23 @@ export default function MetaItem(props: Props) {
   return (
     <div
       className={cn(
-        'text-sm flex flex-row items-center px-2 py-0 gap-1 rounded-lg bg-white border border-gray-light overflow-hidden',
+        'text-sm inline-flex flex-row items-center px-2 py-0 gap-1 rounded-lg bg-white border border-gray-light overflow-hidden max-w-[260px]',
         className,
       )}
     >
+      {/* flex:1 1 0 + max-width:max-content => each part grows equally, freezes at its
+          natural width, and donates the leftover to the other one */}
       <TextEllipsis
         text={label}
-        className="p-0"
-        maxWidth={'100px'}
+        className="p-0 flex-1 basis-0 min-w-0"
+        maxWidth={'max-content'}
         popupProps={{ size: 'small', disabled: true }}
       />
-      <span className="bg-gray-light inline-block w-px min-h-[17px]"></span>
+      <span className="bg-gray-light inline-block w-px min-h-[17px] flex-none"></span>
       <TextEllipsis
         text={value}
-        maxWidth={'175px'}
-        className="p-0 text-neutral-500"
+        maxWidth={'max-content'}
+        className="p-0 text-neutral-500 flex-1 basis-0 min-w-0"
         popupProps={{ size: 'small', disabled: true }}
       />
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates session metadata item sizing so label and value share available space dynamically instead of using fixed max widths, and caps the item at 260px. Long text still truncates with ellipsis.

<sup>Written for commit 6ea36c3f52803cc490ec5c289d694a03d7843e1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

