### PR TITLE
ui: add browser independent guards for various node types in player, …

### DIFF
--- a/frontend/app/player/guards.ts
+++ b/frontend/app/player/guards.ts
@@ -1,3 +1,89 @@
+/**
+ * Realm-independent DOM guards.
+ *
+ * Replay nodes are created in (or adopted into) the player <iframe>'s document,
+ * so `instanceof` against the outer window's constructors is unreliable:
+ * Firefox re-associates an adopted node's prototype with the iframe realm,
+ * while Chrome keeps the outer association — so neither realm's constructor
+ * alone is correct in both browsers.
+ * See https://bugzilla.mozilla.org/show_bug.cgi?id=1821790
+ */
+
+export type ValueElement =
+  | HTMLInputElement
+  | HTMLTextAreaElement
+  | HTMLSelectElement;
+
+const VALUE_TAGS = ['INPUT', 'TEXTAREA', 'SELECT'];
+
+function tagOf(node: Node | null | undefined): string {
+  return node && node.nodeType === Node.ELEMENT_NODE
+    ? (node as Element).tagName.toUpperCase()
+    : '';
+}
+
 export function isRootNode(node: Node): node is Document {
-  return node.nodeType === Node.DOCUMENT_NODE || node instanceof Document;
+  return node.nodeType === Node.DOCUMENT_NODE;
+}
+
+/** Any element whose `.value` we replay: <input>, <textarea>, <select>. */
+export function isValueElement(
+  node: Node | null | undefined,
+): node is ValueElement {
+  return VALUE_TAGS.indexOf(tagOf(node)) !== -1;
+}
+
+export function isInputElement(
+  node: Node | null | undefined,
+): node is HTMLInputElement {
+  return tagOf(node) === 'INPUT';
+}
+
+export function isTextAreaElement(
+  node: Node | null | undefined,
+): node is HTMLTextAreaElement {
+  return tagOf(node) === 'TEXTAREA';
+}
+
+export function isSelectElement(
+  node: Node | null | undefined,
+): node is HTMLSelectElement {
+  return tagOf(node) === 'SELECT';
+}
+
+export function isIFrameElement(
+  node: Node | null | undefined,
+): node is HTMLIFrameElement {
+  return tagOf(node) === 'IFRAME';
+}
+
+export function isDialogElement(
+  node: Node | null | undefined,
+): node is HTMLDialogElement {
+  return tagOf(node) === 'DIALOG';
+}
+
+/**
+ * HTMLElement has no single tag to test, so try both realms' constructors:
+ * whichever one the node is associated with will match.
+ */
+export function isHTMLElement(
+  node: Node | null | undefined,
+): node is HTMLElement {
+  if (!node || node.nodeType !== Node.ELEMENT_NODE) {
+    return false;
+  }
+  if (node instanceof HTMLElement) {
+    return true;
+  }
+  const view = node.ownerDocument?.defaultView as
+    | (Window & typeof globalThis)
+    | null
+    | undefined;
+  return !!view && node instanceof view.HTMLElement;
+}
+
+/** CSSRule.STYLE_RULE — numeric constants are realm-independent. */
+export function isCSSStyleRule(rule: CSSRule): rule is CSSStyleRule {
+  return rule.type === CSSRule.STYLE_RULE;
 }

--- a/frontend/app/player/web/assist/RemoteControl.ts
+++ b/frontend/app/player/web/assist/RemoteControl.ts
@@ -2,6 +2,12 @@ import AnnotationCanvas from './AnnotationCanvas';
 import type { Socket } from './types';
 import type Screen from '../Screen/Screen';
 import type { Store } from '../../common/types';
+import {
+  isHTMLElement,
+  isInputElement,
+  isSelectElement,
+  isTextAreaElement,
+} from '../../guards';
 
 export enum RemoteControlStatus {
   Disabled = 0,
@@ -132,13 +138,10 @@ export default class RemoteControl {
     const data = this.screen.getInternalViewportCoordinates(e);
     // const el = this.screen.getElementFromPoint(e); // requires requestiong node_id from domManager
     const el = this.screen.getElementFromInternalPoint(data);
-    if (el instanceof HTMLElement) {
+    if (isHTMLElement(el)) {
       el.focus();
       el.oninput = (e) => {
-        if (
-          el instanceof HTMLTextAreaElement ||
-          el instanceof HTMLInputElement
-        ) {
+        if (isTextAreaElement(el) || isInputElement(el)) {
           this.socket && this.emitData('input', el.value);
         } else if (el.isContentEditable) {
           this.socket && this.emitData('input', el.innerText);
@@ -148,7 +151,7 @@ export default class RemoteControl {
       // be opened by the click itself. We open the native picker on the mirrored
       // element so the agent can pick an option, then forward the chosen value
       // to the tracker which applies it to the real <select>.
-      if (el instanceof HTMLSelectElement) {
+      if (isSelectElement(el)) {
         el.onchange = () => {
           this.socket && this.emitData('select', el.value);
         };

--- a/frontend/app/player/web/managers/DOM/DOMManager.ts
+++ b/frontend/app/player/web/managers/DOM/DOMManager.ts
@@ -1,4 +1,5 @@
 import logger from 'App/logger';
+import { isSelectElement, isValueElement } from 'App/player/guards';
 
 import ListWalker from '../../../common/ListWalker';
 import type Screen from '../../Screen/Screen';
@@ -430,13 +431,7 @@ export default class DOMManager extends ListWalker<Message> {
           return;
         }
         const nodeWithValue = vElem.node;
-        if (
-          !(
-            nodeWithValue instanceof HTMLInputElement ||
-            nodeWithValue instanceof HTMLTextAreaElement ||
-            nodeWithValue instanceof HTMLSelectElement
-          )
-        ) {
+        if (!isValueElement(nodeWithValue)) {
           logger.error('Trying to set value of non-Input element', msg);
           return;
         }
@@ -449,7 +444,7 @@ export default class DOMManager extends ListWalker<Message> {
           };
           return;
         }
-        if (nodeWithValue instanceof HTMLSelectElement) {
+        if (isSelectElement(nodeWithValue)) {
           this.pendingSelectValues.set(msg.id, val);
         } else {
           nodeWithValue.value = val; // Maybe make special VInputValueElement type for lazy value update
@@ -712,7 +707,7 @@ export default class DOMManager extends ListWalker<Message> {
         return;
       }
       const node = vElem.node;
-      if (!(node instanceof HTMLSelectElement)) {
+      if (!isSelectElement(node)) {
         this.pendingSelectValues.delete(id);
         return;
       }

--- a/frontend/app/player/web/managers/DOM/StylesManager.ts
+++ b/frontend/app/player/web/managers/DOM/StylesManager.ts
@@ -1,6 +1,7 @@
 import type Screen from 'App/player/web/Screen/Screen';
 import { replaceCSSPseudoclasses } from 'App/player/web/messages/rewriter/rewriteMessage';
 import logger from 'App/logger';
+import { isCSSStyleRule } from 'App/player/guards';
 
 // Doesn't work with css files (hasOwnProperty returns false)
 // TODO: recheck and remove if true
@@ -14,7 +15,7 @@ function rewriteNodeStyleSheet(
   }
   for (let i = 0; i < ss.cssRules.length; i++) {
     const r = ss.cssRules[i];
-    if (r instanceof CSSStyleRule) {
+    if (isCSSStyleRule(r)) {
       r.selectorText = replaceCSSPseudoclasses(r.selectorText);
     }
   }

--- a/frontend/app/player/web/managers/DOM/VirtualDOM.ts
+++ b/frontend/app/player/web/managers/DOM/VirtualDOM.ts
@@ -1,4 +1,4 @@
-import { isRootNode } from 'App/player/guards';
+import { isIFrameElement, isRootNode } from 'App/player/guards';
 import { insertRule, deleteRule, replaceRule } from './safeCSSRules';
 
 function isNode(sth: any): sth is Node {
@@ -364,7 +364,7 @@ export class OnloadVRoot extends PromiseQueue<VRoot> {
     return new OnloadVRoot(
       new Promise((resolve, reject) => {
         vElem.onNode((host) => {
-          if (host instanceof HTMLIFrameElement) {
+          if (isIFrameElement(host)) {
             /* IFrame case: creating Document */
             const doc = host.contentDocument;
             if (doc) {

--- a/frontend/tests/unit/DOMManager.test.ts
+++ b/frontend/tests/unit/DOMManager.test.ts
@@ -1,0 +1,184 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals';
+import logger from 'App/logger';
+import DOMManager from '../../app/player/web/managers/DOM/DOMManager';
+import { VElement } from '../../app/player/web/managers/DOM/VirtualDOM';
+import { MType } from '../../app/player/web/messages/raw.gen';
+
+jest.mock('App/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    group: jest.fn(),
+  },
+}));
+
+const loggedError = logger.error as jest.Mock;
+
+class FrameVElement extends VElement {
+  constructor(
+    tagName: string,
+    private readonly doc: Document,
+    nodeId: number,
+  ) {
+    super(tagName, false, 0, nodeId);
+  }
+
+  protected createNode(): Element {
+    return this.doc.createElement(this.tagName);
+  }
+}
+
+class FakeScreen {
+  constructor(readonly document: Document) {}
+}
+
+let frame: HTMLIFrameElement;
+let frameDoc: Document;
+let screen: FakeScreen;
+let manager: DOMManager;
+
+/** Creates an iframe-realm node, mounts it, and registers it under `nodeId`. */
+function mount(tagName: string, nodeId: number): any {
+  const vElem = new FrameVElement(tagName, frameDoc, nodeId);
+  const node = vElem.node;
+  frameDoc.body.appendChild(node);
+  // @ts-ignore private access
+  manager.vElements.set(nodeId, vElem);
+  return node;
+}
+
+function setInputValue(id: number, value: string, mask = 0): void {
+  // @ts-ignore private access
+  manager.applyMessage({ tp: MType.SetInputValue, id, value, mask });
+}
+
+beforeEach(() => {
+  frame = document.createElement('iframe');
+  document.body.appendChild(frame);
+  frameDoc = frame.contentDocument!;
+  screen = new FakeScreen(frameDoc);
+  manager = new DOMManager({
+    screen: screen as any,
+    isMobile: false,
+    setCssLoading: jest.fn(),
+    time: 0,
+    stringDict: {},
+    globalDict: { get: () => undefined, all: () => ({}) },
+  });
+});
+
+afterEach(() => {
+  frame.remove();
+  jest.restoreAllMocks();
+  loggedError.mockClear();
+});
+
+describe('SetInputValue on nodes in the replay iframe', () => {
+  it('reproduces the cross-realm state the bug depended on', () => {
+    const input = mount('input', 973);
+    expect(input instanceof HTMLInputElement).toBe(false);
+    expect(input.tagName).toBe('INPUT');
+  });
+
+  it('applies an incremental value to an input (#4858)', () => {
+    const input = mount('input', 973);
+    setInputValue(973, '1');
+    expect(input.value).toBe('1');
+
+    setInputValue(973, '2');
+    expect(input.value).toBe('2');
+  });
+
+  it('applies a value to a textarea', () => {
+    const textarea = mount('textarea', 42);
+    setInputValue(42, 'hello');
+    expect(textarea.value).toBe('hello');
+  });
+
+  it('masks the value when mask is set', () => {
+    const input = mount('input', 973);
+    setInputValue(973, 'ignored', 4);
+    expect(input.value).toBe('****');
+  });
+
+  it('defers the update to blur while the input is focused', () => {
+    const input = mount('input', 973);
+    input.focus();
+    expect(frameDoc.activeElement).toBe(input);
+
+    setInputValue(973, '2');
+    expect(input.value).toBe(''); // held back so typing is not clobbered
+
+    input.blur();
+    expect(input.value).toBe('2');
+  });
+});
+
+describe('SetInputValue on a <select>', () => {
+  /** <select> values are queued: the options may not have arrived yet. */
+  function mountSelect(nodeId: number, values: string[]): any {
+    const select = mount('select', nodeId);
+    values.forEach((value) => {
+      const option = frameDoc.createElement('option');
+      option.value = value;
+      select.appendChild(option);
+    });
+    return select;
+  }
+
+  it('queues the value and applies it on flush', () => {
+    const select = mountSelect(500, ['a', 'b']);
+    setInputValue(500, 'b');
+    // @ts-ignore private access
+    expect(manager.pendingSelectValues.get(500)).toBe('b');
+
+    // @ts-ignore private access
+    manager.flushPendingSelectValues();
+    expect(select.value).toBe('b');
+    // @ts-ignore private access
+    expect(manager.pendingSelectValues.size).toBe(0);
+  });
+
+  it('keeps the value queued until the options exist', () => {
+    const select = mount('select', 501);
+    setInputValue(501, 'b');
+
+    // @ts-ignore private access
+    manager.flushPendingSelectValues();
+    expect(select.value).toBe('');
+    // @ts-ignore private access
+    expect(manager.pendingSelectValues.get(501)).toBe('b');
+
+    const option = frameDoc.createElement('option');
+    option.value = 'b';
+    select.appendChild(option);
+    // @ts-ignore private access
+    manager.flushPendingSelectValues();
+    expect(select.value).toBe('b');
+  });
+});
+
+describe('SetInputValue rejections', () => {
+  it('logs and skips an element that has no value', () => {
+    const div = mount('div', 7);
+
+    expect(() => setInputValue(7, '2')).not.toThrow();
+    expect(div.value).toBeUndefined();
+    expect(loggedError).toHaveBeenCalled();
+  });
+
+  it('logs and skips an unknown node id', () => {
+    expect(() => setInputValue(999, '2')).not.toThrow();
+    expect(loggedError).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/unit/guards.test.ts
+++ b/frontend/tests/unit/guards.test.ts
@@ -1,13 +1,165 @@
-import { describe, it, expect } from '@jest/globals';
-import { isRootNode } from '../../app/player/guards';
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import {
+  isCSSStyleRule,
+  isDialogElement,
+  isHTMLElement,
+  isIFrameElement,
+  isInputElement,
+  isRootNode,
+  isSelectElement,
+  isTextAreaElement,
+  isValueElement,
+} from '../../app/player/guards';
+
+let frame: HTMLIFrameElement;
+let frameDoc: Document;
+
+/** Element created in the iframe realm, i.e. with an iframe-realm prototype. */
+function inFrame<K extends keyof HTMLElementTagNameMap>(
+  tagName: K,
+): HTMLElementTagNameMap[K] {
+  const el = frameDoc.createElement(tagName);
+  frameDoc.body.appendChild(el);
+  return el;
+}
+
+beforeAll(() => {
+  frame = document.createElement('iframe');
+  document.body.appendChild(frame);
+  frameDoc = frame.contentDocument!;
+});
+
+afterAll(() => {
+  frame.remove();
+});
+
+describe('cross-realm assumption', () => {
+  // Guard against the whole suite quietly losing its teeth: if jsdom ever stops
+  // separating realms, the tests below would pass with plain `instanceof` too.
+  it('iframe-realm nodes fail outer-realm instanceof', () => {
+    expect(inFrame('input') instanceof HTMLInputElement).toBe(false);
+    expect(inFrame('select') instanceof HTMLSelectElement).toBe(false);
+    expect(inFrame('div') instanceof HTMLElement).toBe(false);
+  });
+});
+
+describe('isValueElement', () => {
+  it('accepts input, textarea and select from the iframe realm', () => {
+    expect(isValueElement(inFrame('input'))).toBe(true);
+    expect(isValueElement(inFrame('textarea'))).toBe(true);
+    expect(isValueElement(inFrame('select'))).toBe(true);
+  });
+
+  it('accepts the same tags from the outer realm', () => {
+    expect(isValueElement(document.createElement('input'))).toBe(true);
+    expect(isValueElement(document.createElement('textarea'))).toBe(true);
+    expect(isValueElement(document.createElement('select'))).toBe(true);
+  });
+
+  it('rejects elements without a value, non-elements and nullish input', () => {
+    expect(isValueElement(inFrame('div'))).toBe(false);
+    expect(isValueElement(document.createTextNode('x'))).toBe(false);
+    expect(isValueElement(document)).toBe(false);
+    expect(isValueElement(null)).toBe(false);
+    expect(isValueElement(undefined)).toBe(false);
+  });
+});
+
+describe('single-tag guards', () => {
+  it('discriminate between the value elements', () => {
+    const input = inFrame('input');
+    const textarea = inFrame('textarea');
+    const select = inFrame('select');
+
+    expect([
+      isInputElement(input),
+      isTextAreaElement(input),
+      isSelectElement(input),
+    ]).toEqual([true, false, false]);
+    expect([
+      isInputElement(textarea),
+      isTextAreaElement(textarea),
+      isSelectElement(textarea),
+    ]).toEqual([false, true, false]);
+    expect([
+      isInputElement(select),
+      isTextAreaElement(select),
+      isSelectElement(select),
+    ]).toEqual([false, false, true]);
+  });
+
+  it('recognise iframe and dialog elements across realms', () => {
+    expect(isIFrameElement(inFrame('iframe'))).toBe(true);
+    expect(isIFrameElement(frame)).toBe(true);
+    expect(isIFrameElement(inFrame('div'))).toBe(false);
+
+    expect(isDialogElement(inFrame('dialog'))).toBe(true);
+    expect(isDialogElement(inFrame('div'))).toBe(false);
+  });
+
+  it('match lowercase tagNames in XML documents', () => {
+    // tagName preserves case outside HTML documents, hence the toUpperCase().
+    const xmlDoc = document.implementation.createDocument(
+      'http://www.w3.org/1999/xhtml',
+      'html',
+    );
+    const input = xmlDoc.createElement('input');
+    expect(input.tagName).toBe('input');
+    expect(isInputElement(input)).toBe(true);
+    expect(isValueElement(input)).toBe(true);
+  });
+});
+
+describe('isHTMLElement', () => {
+  it('accepts elements from either realm', () => {
+    expect(isHTMLElement(inFrame('div'))).toBe(true);
+    expect(isHTMLElement(document.createElement('div'))).toBe(true);
+  });
+
+  it('rejects non-elements and nullish input', () => {
+    expect(isHTMLElement(document.createTextNode('x'))).toBe(false);
+    expect(isHTMLElement(document)).toBe(false);
+    expect(isHTMLElement(null)).toBe(false);
+    expect(isHTMLElement(undefined)).toBe(false);
+  });
+
+  it('rejects non-HTML elements', () => {
+    const svg = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'circle',
+    );
+    expect(isHTMLElement(svg)).toBe(false);
+  });
+});
 
 describe('isRootNode', () => {
   it('returns true for document', () => {
     expect(isRootNode(document)).toBe(true);
   });
 
+  it('returns true for an iframe document', () => {
+    expect(isRootNode(frameDoc)).toBe(true);
+  });
+
   it('returns false for element', () => {
     const div = document.createElement('div');
     expect(isRootNode(div)).toBe(false);
+  });
+
+  it('returns false for a shadow root and a fragment', () => {
+    const host = document.createElement('div');
+    expect(isRootNode(host.attachShadow({ mode: 'open' }))).toBe(false);
+    expect(isRootNode(document.createDocumentFragment())).toBe(false);
+  });
+});
+
+describe('isCSSStyleRule', () => {
+  it('accepts style rules and rejects other rules across realms', () => {
+    const style = inFrame('style');
+    style.textContent = '.a { color: red } @media print { .b { color: blue } }';
+    const rules = (style.sheet as CSSStyleSheet).cssRules;
+
+    expect(isCSSStyleRule(rules[0])).toBe(true);
+    expect(isCSSStyleRule(rules[1])).toBe(false);
   });
 });


### PR DESCRIPTION
…add more unit tests for same

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-realm DOM type checks in the player so replayed nodes are recognized correctly in all browsers, replacing unreliable `instanceof` against the outer window with tag-based guards.

- Adds realm-independent guards for input, textarea, select, iframe, dialog, and style rule nodes.
- Switches RemoteControl, DOMManager, StylesManager, and VirtualDOM to use the new guards.
- Adds unit tests for the guards and for DOMManager's value handling with iframe-realm nodes.

<sup>Written for commit 7cfe10cad273a1afdc5ef3000d9ae4f195aefe33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

