### PR TITLE
Updated patch build from main 5cf43dd8ab7686e48c242108123f86a4ea3cbba0

### DIFF
--- a/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
+++ b/scripts/helmcharts/openreplay/charts/frontend/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.10
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-AppVersion: "v1.27.27"
+AppVersion: "v1.27.28"


### PR DESCRIPTION
This PR updates the Helm chart version after building the patch from $HEAD_COMMIT_ID.
Once this PR is merged, tag update job will run automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the frontend Helm chart's `AppVersion` to `v1.27.28` after building the patch from main. Merging this PR triggers the tag update job automatically.

<sup>Written for commit 4ef7199929de6ee34d5f3dc0e9e70a5ebb842f8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

