### PR TITLE
 fix(api): accept 2xx status codes for MS Teams webhook responses

### DIFF
--- a/api/chalicelib/core/collaborations/collaboration_msteams.py
+++ b/api/chalicelib/core/collaborations/collaboration_msteams.py
@@ -41,7 +41,7 @@ class MSTeams(BaseCollaboration):
                     "title": "Welcome to OpenReplay"
                 },
                 timeout=3)
-            if r.status_code != 200:
+            if not (200 <= r.status_code < 300):
                 logger.warning("MSTeams integration failed")
                 logger.warning(sanitize(r.text))
                 return False
@@ -63,7 +63,7 @@ class MSTeams(BaseCollaboration):
                 endpoint=integration["endpoint"],
                 json_data=body,
                 timeout=5)
-            if r.status_code != 200:
+            if not (200 <= r.status_code < 300):
                 logger.warning(f"!! issue sending msteams raw; webhookId:{webhook_id} code:{r.status_code}")
                 logger.warning(sanitize(r.text))
                 return None
@@ -94,7 +94,7 @@ class MSTeams(BaseCollaboration):
                                    "summary": part[0]["activityTitle"],
                                    "sections": part
                                })
-            if r.status_code != 200:
+            if not (200 <= r.status_code < 300):
                 logger.warning("!!!! something went wrong")
                 logger.warning(sanitize(r.text))
 


### PR DESCRIPTION
## Problem
Adding a Microsoft Teams integration always fails with:
> We couldn't send you a test message on your Microsoft Teams channel. Please verify your webhook url.

even when the test message is actually delivered to the Teams channel.

## Root cause
Microsoft has retired classic Office 365 Connector incoming webhooks in favor
of webhooks created via the Teams **Workflows** app (Power Automate). Classic
Connector webhooks returned `200 OK` on success; Workflows webhooks return
`202 Accepted`.

`MSTeams.say_hello()`, `send_raw()`, and `send_batch()` in
`/api/chalicelib/core/collaborations/collaboration_msteams.py` all check for
an exact `status_code == 200`, so every webhook created after the connector
retirement is rejected — even though delivery actually succeeds. This also
means `send_raw`/`send_batch` would silently fail to deliver real alert
notifications, not just the initial test message.

## Fix
Widen the check to accept the full 2xx range (`200 <= status_code < 300`)
instead of an exact match on 200.

There is also a related open issue - https://github.com/openreplay/openreplay/issues/4437

## Reference
https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook

Tested against a self-hosted v1.27.0 instance with a live Workflows-based
Teams webhook (previously returned 202 and failed; succeeds with this fix).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MS Teams integration so webhooks created with the Workflows app are accepted. Microsoft retired classic Connector webhooks, and Workflows webhooks return `202 Accepted` instead of `200 OK` on success, so the integration treated successful deliveries as failures. The status check now accepts any 2xx response, which fixes the test message and ensures `send_raw` and `send_batch` actually deliver alert notifications.

<sup>Written for commit 77e6ab5e2011885a9df8b4dcb55e3ee5c5285b84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

