### PR TITLE
refactor(chalice): MCP auth

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -17,7 +17,7 @@ from chalicelib.utils import pg_client, ch_client
 from chalicelib.utils.log import sanitize
 from crons import core_crons, core_dynamic_crons
 from routers import core, core_dynamic
-from routers.subs import health, spot, product_analytics
+from routers.subs import health, spot, product_analytics, mcp
 
 loglevel = config("LOGLEVEL", default=logging.WARNING)
 print(f">Loglevel set to: {loglevel}")
@@ -155,3 +155,6 @@ app.include_router(spot.app_apikey)
 app.include_router(product_analytics.public_app, prefix="/pa")
 app.include_router(product_analytics.app, prefix="/pa")
 app.include_router(product_analytics.app_apikey, prefix="/pa")
+
+app.include_router(mcp.app)
+app.include_router(mcp.public_app)

--- a/api/chalicelib/core/mcp/authorizers.py
+++ b/api/chalicelib/core/mcp/authorizers.py
@@ -1,0 +1,107 @@
+import logging
+
+import jwt
+from decouple import config
+from fastapi import HTTPException
+
+from chalicelib.utils import pg_client
+from chalicelib.utils.TimeUTC import TimeUTC
+from schemas import schemas, MCP
+
+logger = logging.getLogger(__name__)
+
+AUDIENCE = "mcp:OpenReplay"
+MCP_LOGIN_TIMEOUT_S = config("MCP_LOGIN_TIMEOUT_S", cast=int, default=0)
+
+
+def get_supported_audience():
+    return [AUDIENCE]
+
+
+def is_mcp_token(token: str) -> bool:
+    try:
+        decoded_token = jwt.decode(token, options={"verify_signature": False, "verify_exp": False})
+        audience = decoded_token.get("aud")
+        return audience == AUDIENCE
+    except jwt.InvalidTokenError:
+        logger.error(f"Invalid token for is_spot_token: {token}")
+        raise
+
+
+def jwt_authorizer(scheme: str, token: str, leeway=0) -> dict | None:
+    if scheme.lower() != "bearer" or len(token) < 5:
+        return None
+    try:
+        payload = jwt.decode(jwt=token,
+                             key=config("JWT_MCP_SECRET"),
+                             algorithms=config("JWT_MCP_ALGORITHM"),
+                             audience=get_supported_audience(),
+                             leeway=leeway)
+    except jwt.ExpiredSignatureError:
+        logger.debug("! JWT Expired signature")
+        return None
+    except jwt.exceptions.InvalidSignatureError:
+        logger.warning("! JWT Signature verification failed")
+        return None
+    except BaseException as e:
+        logger.warning("! JWT Base Exception", exc_info=e)
+        return None
+    return payload
+
+
+def generate_jwt(user_id, tenant_id, iat, jti, client_id):
+    token = jwt.encode(
+        payload={
+            "userId": user_id,
+            "tenantId": tenant_id,
+            "exp": iat + config("JWT_MCP_EXPIRATION", cast=int),
+            "iss": config("JWT_ISSUER"),
+            "iat": iat,
+            "jti": jti,
+            "aud": AUDIENCE,
+            "clientId": client_id
+        },
+        key=config("JWT_MCP_SECRET"),
+        algorithm=config("JWT_MCP_ALGORITHM")
+    )
+    return token
+
+
+def store_token_request(data: MCP.AuthorizeSchema, cotext: schemas.CurrentContext):
+    with pg_client.PostgresClient() as cur:
+        query = cur.mogrify(
+            """
+            INSERT INTO public.mcp_authentication_tokens(user_id, client_id, state, iat)
+            VALUES (%(user_id)s, %(client_id)s, %(state)s,
+                    timezone('utc'::text, now() - INTERVAL '10s')) ON CONFLICT DO NOTHING;""",
+            {"client_id": data.client_id, "state": data.state,
+             "user_id": cotext.user_id, },
+        )
+        cur.execute(query=query)
+
+
+def get_token_by_state(client_id, state):
+    with pg_client.PostgresClient() as cur:
+        query = cur.mogrify(
+            """
+            UPDATE public.mcp_authentication_tokens
+            SET generated= TRUE
+            WHERE client_id = %(client_id)s
+              AND state = %(state)s
+              AND NOT generated 
+            RETURNING *,EXTRACT(epoch FROM iat)::BIGINT AS iat,
+                (SELECT tenant_id 
+                 FROM public.users 
+                 WHERE users.user_id = mcp_authentication_tokens.user_id 
+                    AND users.deleted_at IS NULL) AS tenant_id;""",
+            {"client_id": client_id, "state": state},
+        )
+        cur.execute(query=query)
+        row = cur.fetchone()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="State not found or token already generated")
+    if MCP_LOGIN_TIMEOUT_S > 0 and (row["iat"] + MCP_LOGIN_TIMEOUT_S) >= TimeUTC.now():
+        raise HTTPException(status_code=408, detail="Login timed out")
+
+    return generate_jwt(user_id=row["user_id"], tenant_id=row["tenant_id"], iat=row["iat"], client_id=client_id, jti=row["jti"])

--- a/api/chalicelib/core/mcp/tracer.py
+++ b/api/chalicelib/core/mcp/tracer.py
@@ -1,0 +1,16 @@
+import logging
+
+from chalicelib.utils import pg_client
+
+logger = logging.getLogger(__name__)
+
+
+def store_client_id(client_id: str, user_id: int):
+    with pg_client.PostgresClient() as cur:
+        query = cur.mogrify(
+            """
+            INSERT INTO public.mcp_app_users(user_id, client_id)
+            VALUES (%(user_id)s, %(client_id)s) ON CONFLICT DO NOTHING;""",
+            {"client_id": client_id, "user_id": user_id, },
+        )
+        cur.execute(query=query)

--- a/api/routers/subs/mcp.py
+++ b/api/routers/subs/mcp.py
@@ -1,0 +1,30 @@
+from fastapi import Depends, Body, BackgroundTasks
+from fastapi import HTTPException
+
+import schemas
+from chalicelib.core.mcp import authorizers, tracer
+from or_dependencies import OR_context
+from routers.base import get_routers
+
+public_app, app, app_apikey = get_routers()
+
+
+@app.post('/v1/mcp/authorize', tags=["mcp"])
+def authorize_mcp_app(background_tasks: BackgroundTasks,
+                      data: schemas.MCP.AuthorizeSchema = Body(...),
+                      context: schemas.CurrentContext = Depends(OR_context)):
+    if not (context.email.endswith("asayer.io") or context.email.endswith("openreplay.com")):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    authorizers.store_token_request(data=data, cotext=context)
+    background_tasks.add_task(tracer.store_client_id,
+                              user_id=context.user_id,
+                              client_id=data.client_id)
+    return {"data": {"success": True}}
+
+
+@public_app.get("/v1/mcp/auth-status", tags=["mcp"])
+def get_mcp_jwt(client_id: str, state: str):
+    jwt = authorizers.get_token_by_state(client_id=client_id, state=state)
+    if jwt is None:
+        raise HTTPException(status_code=404, detail="Unauthorized")
+    return {"jwt": jwt}

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -2,3 +2,4 @@ from .schemas import *
 from .product_analytics import *
 from . import overrides as _overrides
 from .schemas import _PaginatedSchema as PaginatedSchema
+from . import schemas_mcp as MCP

--- a/api/schemas/schemas_mcp.py
+++ b/api/schemas/schemas_mcp.py
@@ -1,0 +1,9 @@
+from pydantic import Field
+
+from .overrides import BaseModel
+
+
+class AuthorizeSchema(BaseModel):
+    state: str = Field(...)
+    # client_id is to identify the running MCP app for a client
+    client_id: str = Field(...)

--- a/ee/api/.gitignore
+++ b/ee/api/.gitignore
@@ -207,6 +207,7 @@ Pipfile.lock
 /chalicelib/core/issues/
 /chalicelib/core/jobs.py
 /chalicelib/core/log_tools/*
+/chalicelib/core/mcp/*
 /chalicelib/core/metadata.py
 /chalicelib/core/mobile.py
 /chalicelib/core/saved_search.py

--- a/ee/api/app.py
+++ b/ee/api/app.py
@@ -27,6 +27,7 @@ from routers.subs import (
     health,
     spot,
     product_analytics,
+    mcp
 )
 
 if config("ENABLE_SSO", cast=bool, default=True):
@@ -192,6 +193,9 @@ app.include_router(spot.app_apikey)
 app.include_router(product_analytics.public_app, prefix="/pa")
 app.include_router(product_analytics.app, prefix="/pa")
 app.include_router(product_analytics.app_apikey, prefix="/pa")
+
+app.include_router(mcp.app)
+app.include_router(mcp.public_app)
 
 if config("ENABLE_SSO", cast=bool, default=True):
     app.include_router(saml.public_app)

--- a/ee/api/clean-dev.sh
+++ b/ee/api/clean-dev.sh
@@ -28,10 +28,11 @@ rm -rf ./chalicelib/core/integrations_manager.py
 rm -rf ./chalicelib/core/issues
 rm -rf ./chalicelib/core/jobs.py
 rm -rf ./chalicelib/core/log_tools
+rm -rf ./chalicelib/core/mcp
 rm -rf ./chalicelib/core/metadata.py
 rm -rf ./chalicelib/core/mobile.py
 rm -rf ./chalicelib/core/saved_search.py
-rm -rf ./chalicelib/core/sessions/*.py
+find ./chalicelib/core/sessions -maxdepth 1 -name "*.py" ! -name "sessions_pg.py" -delete
 rm -rf ./chalicelib/core/sessions/sessions_viewed
 rm -rf ./chalicelib/core/sessions/sessions_favorite/sessions_favorite.py
 rm -rf ./chalicelib/core/sessions/sessions_devtool/sessions_devtool.py

--- a/ee/api/schemas/__init__.py
+++ b/ee/api/schemas/__init__.py
@@ -4,3 +4,4 @@ from .assist_stats_schema import *
 from .product_analytics import *
 from . import overrides as _overrides
 from .schemas import _PaginatedSchema as PaginatedSchema
+from . import schemas_mcp as MCP


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds MCP authentication with a two-step flow: an authenticated authorize endpoint stores a client request, and a public auth-status endpoint returns a JWT when the request is ready.

**Bug Fixes**
- `clean-dev.sh` no longer deletes `sessions_pg.py` when clearing the sessions directory.

<sup>Written for commit 07e83fc744f640674bc8a01cf4cd2ede2ec01316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

