### PR TITLE
dev

### DIFF
--- a/api/schemas/schemas.py
+++ b/api/schemas/schemas.py
@@ -1,6 +1,5 @@
-from typing import Annotated, Any, List, Literal, Optional, Union
+from typing import Annotated, List, Literal, Optional, Union
 
-from chalicelib.utils.TimeUTC import TimeUTC
 from pydantic import (
     AfterValidator,
     AnyHttpUrl,
@@ -21,7 +20,6 @@ from .transformers_validators import (
     check_alphanumeric,
     check_property_name,
     check_regex,
-    force_is_event,
     int_to_string,
     remove_duplicate_values,
     remove_whitespace,
@@ -1175,8 +1173,3 @@ class SessionModel(BaseModel):
     userState: str
     userUuid: str
     viewed: bool = Field(default=False)
-
-
-class UsabilityTestQuery(_PaginatedSchema):
-    live: bool = Field(default=False)
-    user_id: Optional[str] = Field(default=None)

--- a/backend/pkg/analytics/charts/metric_table_errors.go
+++ b/backend/pkg/analytics/charts/metric_table_errors.go
@@ -7,7 +7,6 @@ import (
 	"openreplay/backend/pkg/analytics/model"
 	"openreplay/backend/pkg/logger"
 	"strings"
-	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -260,23 +259,17 @@ func (t *TableErrorsQueryBuilder) buildQuery(p *Payload) ([]string, error) {
 		fromClause = `product_analytics.events as e`
 	}
 
-	tableKey := fmt.Sprintf("%d", time.Now().UnixMilli())
-	eventsTable := fmt.Sprintf("errors_events_%s", tableKey)
-
+	eventsTable := fmt.Sprintf("errors_events_%s", strings.ReplaceAll(uuid.NewString(), "-", ""))
 	createSQL := fmt.Sprintf(`
-CREATE TEMPORARY TABLE %s AS (
+CREATE TEMPORARY TABLE %s ENGINE = MergeTree ORDER BY (error_id,session_id,created_at) AS (
     SELECT
         error_id,
         COALESCE("$properties".'name', 'ERROR') AS name,
-        COALESCE("$properties".'message',
-                "$properties".'error', 'Unknown error') AS message,
-        distinct_id,
+        COALESCE("$properties".'message', 'Unknown error') AS message,
         session_id,
-        project_id,
         created_at
     FROM %s
     WHERE %s
-    AND created_at IS NOT NULL
 );`,
 		eventsTable,
 		fromClause,
@@ -310,8 +303,8 @@ WITH
             max(e.created_at) AS last_occurrence
         FROM %s e
         	LEFT JOIN experimental.sessions s 
-				ON e.session_id = s.session_id AND e.project_id = s.project_id AND s.project_id = %d
-        WHERE e.error_id IS NOT NULL AND e.error_id != ''
+				ON e.session_id = s.session_id AND s.project_id = %d
+        WHERE e.error_id != ''
         GROUP BY e.error_id
     ),
     error_chart AS (

--- a/backend/pkg/analytics/charts/metric_webvitals.go
+++ b/backend/pkg/analytics/charts/metric_webvitals.go
@@ -222,76 +222,83 @@ func (h WebVitalsQueryBuilder) buildQuery(p *Payload) (string, error) {
 		outerFiltersWhereStr += fmt.Sprintf(" AND events.sample_key < %d", p.SampleRate)
 	}
 
-	sessionsWhereStr := ""
-	if len(sessionsWhere) > 0 {
-		sessionsWhereStr = " AND " + strings.Join(sessionsWhere, " AND ")
+	// Join with experimental.sessions only when the card actually filters on
+	// session attributes; otherwise the events subquery alone is enough.
+	sessionsJoinStr := ""
+	if len(sessionsWhere) > 4 {
+		sessionsWhereStr := " AND " + strings.Join(sessionsWhere, " AND ")
+		sessionsJoinStr = fmt.Sprintf(`
+            INNER JOIN (SELECT DISTINCT session_id
+                    FROM experimental.sessions AS s
+                    WHERE s.project_id = %d
+						AND isNotNull(s.duration)%s
+						AND s.datetime >= toDateTime(%d/1000)
+						AND s.datetime <= toDateTime(%d/1000)) AS s ON(s.session_id=f.session_id)`,
+			p.ProjectId, sessionsWhereStr, p.MetricPayload.StartTimestamp, p.MetricPayload.EndTimestamp)
 	}
 
 	query := fmt.Sprintf(`
-SELECT minIf(events.`+"`$properties`"+`.dom_building_time::Float64, isNotNull(events.`+"`$properties`"+`.dom_building_time)) AS dom_building_time_min,
-       avgIf(events.`+"`$properties`"+`.dom_building_time::Float64, isNotNull(events.`+"`$properties`"+`.dom_building_time)) AS dom_building_time_avg,
-       maxIf(events.`+"`$properties`"+`.dom_building_time::Float64, isNotNull(events.`+"`$properties`"+`.dom_building_time)) AS dom_building_time_max,
-       quantileIf(0.5)(events.`+"`$properties`"+`.dom_building_time::Float64, isNotNull(events.`+"`$properties`"+`.dom_building_time)) AS dom_building_time_p50,
-       quantileIf(0.75)(events.`+"`$properties`"+`.dom_building_time::Float64, isNotNull(events.`+"`$properties`"+`.dom_building_time)) AS dom_building_time_p75,
-       quantileIf(0.90)(events.`+"`$properties`"+`.dom_building_time::Float64, isNotNull(events.`+"`$properties`"+`.dom_building_time)) AS dom_building_time_p90,
-       minIf(events.`+"`$properties`"+`.ttfb::Float64, isNotNull(events.`+"`$properties`"+`.ttfb))              AS ttfb_min,
-       avgIf(events.`+"`$properties`"+`.ttfb::Float64, isNotNull(events.`+"`$properties`"+`.ttfb))              AS ttfb_avg,
-       maxIf(events.`+"`$properties`"+`.ttfb::Float64, isNotNull(events.`+"`$properties`"+`.ttfb))              AS ttfb_max,
-       quantileIf(0.5)(events.`+"`$properties`"+`.ttfb::Float64, isNotNull(events.`+"`$properties`"+`.ttfb))              AS ttfb_p50,
-       quantileIf(0.75)(events.`+"`$properties`"+`.ttfb::Float64, isNotNull(events.`+"`$properties`"+`.ttfb))              AS ttfb_p75,
-       quantileIf(0.90)(events.`+"`$properties`"+`.ttfb::Float64, isNotNull(events.`+"`$properties`"+`.ttfb))              AS ttfb_p90,
-       minIf(events.`+"`$properties`"+`.speed_index::Float64, isNotNull(events.`+"`$properties`"+`.speed_index))       AS speed_index_min,
-       avgIf(events.`+"`$properties`"+`.speed_index::Float64, isNotNull(events.`+"`$properties`"+`.speed_index))       AS speed_index_avg,
-       maxIf(events.`+"`$properties`"+`.speed_index::Float64, isNotNull(events.`+"`$properties`"+`.speed_index))       AS speed_index_max,
-       quantileIf(0.5)(events.`+"`$properties`"+`.speed_index::Float64, isNotNull(events.`+"`$properties`"+`.speed_index))       AS speed_index_p50,
-       quantileIf(0.75)(events.`+"`$properties`"+`.speed_index::Float64, isNotNull(events.`+"`$properties`"+`.speed_index))       AS speed_index_p75,
-       quantileIf(0.90)(events.`+"`$properties`"+`.speed_index::Float64, isNotNull(events.`+"`$properties`"+`.speed_index))       AS speed_index_p90,
-       minIf(events.`+"`$properties`"+`.first_contentful_paint_time::Float64, isNotNull(events.`+"`$properties`"+`.first_contentful_paint_time)) AS first_contentful_paint_time_min,
-       avgIf(events.`+"`$properties`"+`.first_contentful_paint_time::Float64, isNotNull(events.`+"`$properties`"+`.first_contentful_paint_time)) AS first_contentful_paint_time_avg,
-       maxIf(events.`+"`$properties`"+`.first_contentful_paint_time::Float64, isNotNull(events.`+"`$properties`"+`.first_contentful_paint_time)) AS first_contentful_paint_time_max,
-       quantileIf(0.5)(events.`+"`$properties`"+`.first_contentful_paint_time::Float64, isNotNull(events.`+"`$properties`"+`.first_contentful_paint_time)) AS first_contentful_paint_time_p50,
-       quantileIf(0.75)(events.`+"`$properties`"+`.first_contentful_paint_time::Float64, isNotNull(events.`+"`$properties`"+`.first_contentful_paint_time)) AS first_contentful_paint_time_p75,
-       quantileIf(0.90)(events.`+"`$properties`"+`.first_contentful_paint_time::Float64, isNotNull(events.`+"`$properties`"+`.first_contentful_paint_time)) AS first_contentful_paint_time_p90,
-       minIf(events.`+"`$properties`"+`.LCP::Float64, isNotNull(events.`+"`$properties`"+`.LCP)) AS largest_contentful_paint_min,
-       avgIf(events.`+"`$properties`"+`.LCP::Float64, isNotNull(events.`+"`$properties`"+`.LCP)) AS largest_contentful_paint_avg,
-       maxIf(events.`+"`$properties`"+`.LCP::Float64, isNotNull(events.`+"`$properties`"+`.LCP)) AS largest_contentful_paint_max,
-       quantileIf(0.5)(events.`+"`$properties`"+`.lcp::Float64, isNotNull(events.`+"`$properties`"+`.lcp)) AS largest_contentful_paint_p50,
-       quantileIf(0.75)(events.`+"`$properties`"+`.lcp::Float64, isNotNull(events.`+"`$properties`"+`.lcp)) AS largest_contentful_paint_p75,
-       quantileIf(0.90)(events.`+"`$properties`"+`.lcp::Float64, isNotNull(events.`+"`$properties`"+`.lcp)) AS largest_contentful_paint_p90,
-       minIf(events.`+"`$properties`"+`.cls::Float64, isNotNull(events.`+"`$properties`"+`.cls)) AS cumulative_layout_shift_min,
-       avgIf(events.`+"`$properties`"+`.cls::Float64, isNotNull(events.`+"`$properties`"+`.cls)) AS cumulative_layout_shift_avg,
-       maxIf(events.`+"`$properties`"+`.cls::Float64, isNotNull(events.`+"`$properties`"+`.cls)) AS cumulative_layout_shift_max,
-       quantileIf(0.5)(events.`+"`$properties`"+`.cls::Float64, isNotNull(events.`+"`$properties`"+`.cls)) AS cumulative_layout_shift_p50,
-       quantileIf(0.75)(events.`+"`$properties`"+`.cls::Float64, isNotNull(events.`+"`$properties`"+`.cls)) AS cumulative_layout_shift_p75,
-       quantileIf(0.90)(events.`+"`$properties`"+`.cls::Float64, isNotNull(events.`+"`$properties`"+`.cls)) AS cumulative_layout_shift_p90
-FROM (SELECT session_id
-      FROM (SELECT main.session_id,
-                   MIN(main.created_at) AS first_event_ts,
-                   MAX(main.created_at) AS last_event_ts
-            FROM product_analytics.events AS main
-            WHERE main.project_id = %d AND main.created_at >= toDateTime(%d/1000) AND main.created_at <= toDateTime(%d/1000)%s
-            GROUP BY session_id) AS f
-            INNER JOIN (SELECT DISTINCT ON (session_id) *
-                    FROM experimental.sessions AS s
-                    WHERE s.project_id = %d AND isNotNull(s.duration)%s AND s.datetime >= toDateTime(%d/1000) AND s.datetime <= toDateTime(%d/1000)
-                    ORDER BY _timestamp DESC) AS s ON(s.session_id=f.session_id)
-      ) AS raw
-       INNER JOIN product_analytics.events USING (session_id)
+SELECT minIf(events."$properties".dom_building_time::Float64, isNotNull(events."$properties".dom_building_time)) AS dom_building_time_min,
+       avgIf(events."$properties".dom_building_time::Float64, isNotNull(events."$properties".dom_building_time)) AS dom_building_time_avg,
+       maxIf(events."$properties".dom_building_time::Float64, isNotNull(events."$properties".dom_building_time)) AS dom_building_time_max,
+       quantileIf(0.5)(events."$properties".dom_building_time::Float64, isNotNull(events."$properties".dom_building_time)) AS dom_building_time_p50,
+       quantileIf(0.75)(events."$properties".dom_building_time::Float64, isNotNull(events."$properties".dom_building_time)) AS dom_building_time_p75,
+       quantileIf(0.90)(events."$properties".dom_building_time::Float64, isNotNull(events."$properties".dom_building_time)) AS dom_building_time_p90,
+       minIf(events."$properties".ttfb::Float64, isNotNull(events."$properties".ttfb))              AS ttfb_min,
+       avgIf(events."$properties".ttfb::Float64, isNotNull(events."$properties".ttfb))              AS ttfb_avg,
+       maxIf(events."$properties".ttfb::Float64, isNotNull(events."$properties".ttfb))              AS ttfb_max,
+       quantileIf(0.5)(events."$properties".ttfb::Float64, isNotNull(events."$properties".ttfb))              AS ttfb_p50,
+       quantileIf(0.75)(events."$properties".ttfb::Float64, isNotNull(events."$properties".ttfb))              AS ttfb_p75,
+       quantileIf(0.90)(events."$properties".ttfb::Float64, isNotNull(events."$properties".ttfb))              AS ttfb_p90,
+       minIf(events."$properties".speed_index::Float64, isNotNull(events."$properties".speed_index))       AS speed_index_min,
+       avgIf(events."$properties".speed_index::Float64, isNotNull(events."$properties".speed_index))       AS speed_index_avg,
+       maxIf(events."$properties".speed_index::Float64, isNotNull(events."$properties".speed_index))       AS speed_index_max,
+       quantileIf(0.5)(events."$properties".speed_index::Float64, isNotNull(events."$properties".speed_index))       AS speed_index_p50,
+       quantileIf(0.75)(events."$properties".speed_index::Float64, isNotNull(events."$properties".speed_index))       AS speed_index_p75,
+       quantileIf(0.90)(events."$properties".speed_index::Float64, isNotNull(events."$properties".speed_index))       AS speed_index_p90,
+       minIf(events."$properties".first_contentful_paint_time::Float64, isNotNull(events."$properties".first_contentful_paint_time)) AS first_contentful_paint_time_min,
+       avgIf(events."$properties".first_contentful_paint_time::Float64, isNotNull(events."$properties".first_contentful_paint_time)) AS first_contentful_paint_time_avg,
+       maxIf(events."$properties".first_contentful_paint_time::Float64, isNotNull(events."$properties".first_contentful_paint_time)) AS first_contentful_paint_time_max,
+       quantileIf(0.5)(events."$properties".first_contentful_paint_time::Float64, isNotNull(events."$properties".first_contentful_paint_time)) AS first_contentful_paint_time_p50,
+       quantileIf(0.75)(events."$properties".first_contentful_paint_time::Float64, isNotNull(events."$properties".first_contentful_paint_time)) AS first_contentful_paint_time_p75,
+       quantileIf(0.90)(events."$properties".first_contentful_paint_time::Float64, isNotNull(events."$properties".first_contentful_paint_time)) AS first_contentful_paint_time_p90,
+       minIf(events."$properties".lcp::Float64, isNotNull(events."$properties".lcp)) AS largest_contentful_paint_min,
+       avgIf(events."$properties".lcp::Float64, isNotNull(events."$properties".lcp)) AS largest_contentful_paint_avg,
+       maxIf(events."$properties".lcp::Float64, isNotNull(events."$properties".lcp)) AS largest_contentful_paint_max,
+       quantileIf(0.5)(events."$properties".lcp::Float64, isNotNull(events."$properties".lcp)) AS largest_contentful_paint_p50,
+       quantileIf(0.75)(events."$properties".lcp::Float64, isNotNull(events."$properties".lcp)) AS largest_contentful_paint_p75,
+       quantileIf(0.90)(events."$properties".lcp::Float64, isNotNull(events."$properties".lcp)) AS largest_contentful_paint_p90,
+       minIf(events."$properties".cls::Float64, isNotNull(events."$properties".cls)) AS cumulative_layout_shift_min,
+       avgIf(events."$properties".cls::Float64, isNotNull(events."$properties".cls)) AS cumulative_layout_shift_avg,
+       maxIf(events."$properties".cls::Float64, isNotNull(events."$properties".cls)) AS cumulative_layout_shift_max,
+       quantileIf(0.5)(events."$properties".cls::Float64, isNotNull(events."$properties".cls)) AS cumulative_layout_shift_p50,
+       quantileIf(0.75)(events."$properties".cls::Float64, isNotNull(events."$properties".cls)) AS cumulative_layout_shift_p75,
+       quantileIf(0.90)(events."$properties".cls::Float64, isNotNull(events."$properties".cls)) AS cumulative_layout_shift_p90
+FROM product_analytics.events
+	 INNER JOIN (SELECT session_id
+				 FROM ( SELECT DISTINCT main.session_id
+						FROM product_analytics.events AS main
+						WHERE main.project_id = %d 
+							AND main.created_at >= toDateTime(%d/1000) 
+							AND main.created_at <= toDateTime(%d/1000)
+							%s) AS f
+						%s
+				  ) AS raw USING (session_id)
 WHERE events.project_id = %d
   AND events.created_at >= toDateTime(%d / 1000)
   AND events.created_at <= toDateTime(%d / 1000)
   AND events.`+"`$event_name`"+` = 'LOCATION'
   AND events.`+"`$auto_captured`"+`%s
   AND (
-    isNotNull(events.`+"`$properties`"+`.dom_building_time)
-        OR isNotNull(events.`+"`$properties`"+`.ttfb)
-        OR isNotNull(events.`+"`$properties`"+`.speed_index)
-        OR isNotNull(events.`+"`$properties`"+`.first_contentful_paint_time)
-        OR isNotNull(events.`+"`$properties`"+`.lcp)
-        OR isNotNull(events.`+"`$properties`"+`.cls)
+    isNotNull(events."$properties".dom_building_time)
+        OR isNotNull(events."$properties".ttfb)
+        OR isNotNull(events."$properties".speed_index)
+        OR isNotNull(events."$properties".first_contentful_paint_time)
+        OR isNotNull(events."$properties".lcp)
+        OR isNotNull(events."$properties".cls)
     )`,
 		p.ProjectId, p.MetricPayload.StartTimestamp, p.MetricPayload.EndTimestamp, innerEventsWhereStr,
-		p.ProjectId, sessionsWhereStr, p.MetricPayload.StartTimestamp, p.MetricPayload.EndTimestamp,
+		sessionsJoinStr,
 		p.ProjectId, p.MetricPayload.StartTimestamp, p.MetricPayload.EndTimestamp, outerFiltersWhereStr)
 
 	return query, nil


### PR DESCRIPTION
- **refactor(chalcie): refactored schemas**
- **refactor(gapi): optimized get table of JS errors**
- **refactor(gapi): optimized webvitals**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes the JS errors table and WebVitals chart queries, and removes dead code from the API schemas.

**Refactors**
- JS errors query: UUID-based temp table name, explicit `MergeTree` engine, dropped unused columns, and message fallback simplified to `'Unknown error'` (no longer falls back to `$properties.error`).
- WebVitals query: joins `experimental.sessions` only when session filters exist, so unfiltered cards now include events from all sessions (previously only those with a non-null duration).
- Removes `UsabilityTestQuery` and the `force_is_event` validator from `api/schemas/schemas.py`.

<sup>Written for commit 1081b5dbff2fc62ba0b5d465dd1c8caf68aeff63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

