### PR TITLE
refactor(gapi): refactored webvitals code

### DIFF
--- a/backend/pkg/analytics/charts/metric_webvitals.go
+++ b/backend/pkg/analytics/charts/metric_webvitals.go
@@ -287,8 +287,8 @@ FROM product_analytics.events
 WHERE events.project_id = %d
   AND events.created_at >= toDateTime(%d / 1000)
   AND events.created_at <= toDateTime(%d / 1000)
-  AND events.`+"`$event_name`"+` = 'LOCATION'
-  AND events.`+"`$auto_captured`"+`%s
+  AND events."$event_name" = 'LOCATION'
+  AND events."$auto_captured" %s
   AND (
     isNotNull(events."$properties".dom_building_time)
         OR isNotNull(events."$properties".ttfb)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactors the web vitals query to use double-quoted event field names (`"$event_name"`, `"$auto_captured"`) instead of backtick-wrapped ones, keeping the query consistent with the rest of the codebase. No behavior change.

<sup>Written for commit 5f4943db91a64772b62f41e7c5c3a0776ba0df79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/openreplay/openreplay/pull/4875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

